### PR TITLE
[Follow-up][IM02_ST03B_SPLIT_SUITE] Add ST0.3b split-suite artifacts and regression checks

### DIFF
--- a/lyzortx/pipeline/steel_thread_v0/README.md
+++ b/lyzortx/pipeline/steel_thread_v0/README.md
@@ -15,6 +15,7 @@ This directory contains a minimal end-to-end pipeline to validate feasibility be
   - `ST0.1b` strict confidence tiers: `lyzortx/pipeline/steel_thread_v0/steps/st01b_confidence_tiers.py`.
   - `ST0.2` canonical pair table builder: `lyzortx/pipeline/steel_thread_v0/steps/st02_build_pair_table.py`.
   - `ST0.3` split builder: `lyzortx/pipeline/steel_thread_v0/steps/st03_build_splits.py`.
+  - `ST0.3b` split-suite builder: `lyzortx/pipeline/steel_thread_v0/steps/st03b_build_split_suite.py`.
   - `ST0.4` baseline model trainer: `lyzortx/pipeline/steel_thread_v0/steps/st04_train_baselines.py`.
   - `ST0.5` calibrator and ranker: `lyzortx/pipeline/steel_thread_v0/steps/st05_calibrate_rank.py`.
   - `ST0.6` recommender: `lyzortx/pipeline/steel_thread_v0/steps/st06_recommend_top3.py`.
@@ -24,6 +25,7 @@ This directory contains a minimal end-to-end pipeline to validate feasibility be
   - Regression gate for ST0.1b: `lyzortx/pipeline/steel_thread_v0/checks/check_st01b_regression.py`.
   - Regression gate for ST0.2: `lyzortx/pipeline/steel_thread_v0/checks/check_st02_regression.py`.
   - Regression gate for ST0.3: `lyzortx/pipeline/steel_thread_v0/checks/check_st03_regression.py`.
+  - Regression gate for ST0.3b: `lyzortx/pipeline/steel_thread_v0/checks/check_st03b_regression.py`.
   - Regression gate for ST0.4: `lyzortx/pipeline/steel_thread_v0/checks/check_st04_regression.py`.
   - Regression gate for ST0.5: `lyzortx/pipeline/steel_thread_v0/checks/check_st05_regression.py`.
   - Regression gate for ST0.6: `lyzortx/pipeline/steel_thread_v0/checks/check_st06_regression.py`.
@@ -34,7 +36,8 @@ This directory contains a minimal end-to-end pipeline to validate feasibility be
 - `ST0.1`: Aggregate replicate/dilution observations into hard labels and uncertainty flags.
 - `ST0.1b`: Add stricter confidence tiers as a parallel label view for dual-slice evaluation.
 - `ST0.2`: Build canonical pair table with IDs, labels, uncertainty, and v0 features.
-- `ST0.3`: Build fixed leakage-safe splits.
+- `ST0.3`: Build fixed leakage-safe host-group splits.
+- `ST0.3b`: Build split-suite artifacts for phage-family holdout and host+phage dual-axis stress tests.
 - `ST0.4`: Train baseline models.
 - `ST0.5`: Calibrate probabilities and generate rankings.
 - `ST0.6`: Produce top-3 recommendations.
@@ -90,6 +93,18 @@ Run the ST0.3 regression gate (recomputes ST0.1, ST0.1b, ST0.2, and ST0.3 then c
 
 ```bash
 python -m lyzortx.pipeline.steel_thread_v0.checks.check_st03_regression --run-st01 --run-st01b --run-st02 --run-st03
+```
+
+Run ST0.3b split-suite builder:
+
+```bash
+python -m lyzortx.pipeline.steel_thread_v0.run_steel_thread_v0 --step st03b
+```
+
+Run the ST0.3b regression gate (recomputes ST0.1, ST0.1b, ST0.2, ST0.3, and ST0.3b then compares against baseline):
+
+```bash
+python -m lyzortx.pipeline.steel_thread_v0.checks.check_st03b_regression --run-st01 --run-st01b --run-st02 --run-st03 --run-st03b
 ```
 
 Run ST0.4 baseline training:
@@ -171,6 +186,10 @@ python -m lyzortx.pipeline.steel_thread_v0.run_steel_thread_v0 --step check-st03
 ```
 
 ```bash
+python -m lyzortx.pipeline.steel_thread_v0.run_steel_thread_v0 --step check-st03b
+```
+
+```bash
 python -m lyzortx.pipeline.steel_thread_v0.run_steel_thread_v0 --step check-st04
 ```
 
@@ -209,6 +228,10 @@ python -m lyzortx.pipeline.steel_thread_v0.run_steel_thread_v0 --step st06b
   - `st03_split_assignments.csv`
   - `st03_split_protocol.json`
   - `st03_split_audit.json`
+- ST0.3b files:
+  - `st03b_split_suite_assignments.csv`
+  - `st03b_split_suite_protocol.json`
+  - `st03b_split_suite_audit.json`
 - ST0.4 files:
   - `st04_pair_predictions_raw.csv`
   - `st04_model_metrics_raw.json`

--- a/lyzortx/pipeline/steel_thread_v0/baselines/st03b_expected_metrics.json
+++ b/lyzortx/pipeline/steel_thread_v0/baselines/st03b_expected_metrics.json
@@ -1,0 +1,64 @@
+{
+  "artifacts": {
+    "split_suite_assignments_csv_sha256": "04098506a9811707cdc6b9fee0f4766c377e9896bbe7e83c3d90676e7d108633"
+  },
+  "leakage_summary": {
+    "holdout_membership": {
+      "phage_family_holdout_ids_sorted": [
+        "Autographiviridae"
+      ]
+    },
+    "leakage_checks": {
+      "dual_axis_train_vs_dual_holdout_cv_group_overlap_count": 0,
+      "dual_axis_train_vs_dual_holdout_family_overlap_count": 0,
+      "host_group_holdout_cv_group_overlap_count": 0,
+      "phage_family_holdout_family_overlap_count": 0
+    }
+  },
+  "protocol_summary": {
+    "split_modes": {
+      "dual_axis_host_phage": {
+        "evaluation_membership": [
+          "dual_holdout_test",
+          "host_only_holdout",
+          "phage_only_holdout"
+        ],
+        "host_axis": "st03 host-group holdout",
+        "phage_axis": "st03b phage-family holdout"
+      },
+      "host_group_holdout": {
+        "group_key": "cv_group",
+        "source": "st03_split_assignments.csv::split_holdout"
+      },
+      "phage_family_holdout": {
+        "group_key": "phage_family",
+        "holdout_assignment": "hash-based deterministic assignment by phage_family",
+        "holdout_fraction": 0.2,
+        "split_salt": "steel_thread_v0_st03b_split_suite_v1"
+      }
+    },
+    "step_name": "st03b_build_split_suite"
+  },
+  "split_suite_summary": {
+    "phage_family_holdout_count": 1,
+    "phage_family_holdout_fraction_actual": 0.2,
+    "phage_family_total_count": 5,
+    "row_count": 35424,
+    "split_counts": {
+      "dual_axis_host_phage": {
+        "dual_holdout_test": 2470,
+        "host_only_holdout": 3770,
+        "phage_only_holdout": 11552,
+        "train_non_holdout": 17632
+      },
+      "host_group_holdout": {
+        "holdout_test": 6240,
+        "train_non_holdout": 29184
+      },
+      "phage_family_holdout": {
+        "holdout_test": 14022,
+        "train_non_holdout": 21402
+      }
+    }
+  }
+}

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st03b_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st03b_regression.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regression check for ST0.3b split-suite outputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from lyzortx.pipeline.steel_thread_v0.steps import (
+    st01_label_policy,
+    st01b_confidence_tiers,
+    st02_build_pair_table,
+    st03_build_splits,
+    st03b_build_split_suite,
+)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--expected-baseline-path",
+        type=Path,
+        default=Path("lyzortx/pipeline/steel_thread_v0/baselines/st03b_expected_metrics.json"),
+        help="Path to expected regression baseline JSON.",
+    )
+    parser.add_argument(
+        "--intermediate-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate"),
+        help="Directory containing ST0.3b generated artifacts.",
+    )
+    parser.add_argument("--run-st01", action="store_true", help="Run ST0.1 before checking ST0.3b.")
+    parser.add_argument("--run-st01b", action="store_true", help="Run ST0.1b before checking ST0.3b.")
+    parser.add_argument("--run-st02", action="store_true", help="Run ST0.2 before checking ST0.3b.")
+    parser.add_argument("--run-st03", action="store_true", help="Run ST0.3 before checking ST0.3b.")
+    parser.add_argument("--run-st03b", action="store_true", help="Run ST0.3b before checking ST0.3b.")
+    return parser.parse_args(argv)
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
+    audit_path = intermediate_dir / "st03b_split_suite_audit.json"
+    protocol_path = intermediate_dir / "st03b_split_suite_protocol.json"
+    assignments_path = intermediate_dir / "st03b_split_suite_assignments.csv"
+
+    if not audit_path.exists() or not protocol_path.exists() or not assignments_path.exists():
+        missing = [str(p) for p in (audit_path, protocol_path, assignments_path) if not p.exists()]
+        raise FileNotFoundError(
+            "ST0.3b artifacts missing. Run ST0.3b first or pass --run-st01 --run-st01b --run-st02 --run-st03 --run-st03b. Missing: "
+            + ", ".join(missing)
+        )
+
+    audit = load_json(audit_path)
+    protocol = load_json(protocol_path)
+    assignment_sha256 = hashlib.sha256(assignments_path.read_bytes()).hexdigest()
+
+    return {
+        "split_suite_summary": {
+            "row_count": audit["row_count"],
+            "split_counts": audit["split_counts"],
+            "phage_family_holdout_count": audit["phage_family_holdout_count"],
+            "phage_family_total_count": audit["phage_family_total_count"],
+            "phage_family_holdout_fraction_actual": audit["phage_family_holdout_fraction_actual"],
+        },
+        "leakage_summary": {
+            "leakage_checks": audit["leakage_checks"],
+            "holdout_membership": audit["holdout_membership"],
+        },
+        "protocol_summary": {
+            "step_name": protocol["step_name"],
+            "split_modes": protocol["split_modes"],
+        },
+        "artifacts": {
+            "split_suite_assignments_csv_sha256": assignment_sha256,
+        },
+    }
+
+
+def compare_dicts(expected: Dict[str, Any], actual: Dict[str, Any], prefix: str = "") -> List[str]:
+    errors: List[str] = []
+    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
+    for key in all_keys:
+        path = f"{prefix}.{key}" if prefix else key
+        if key not in expected:
+            errors.append(f"Unexpected key in actual: {path}")
+            continue
+        if key not in actual:
+            errors.append(f"Missing key in actual: {path}")
+            continue
+        exp_val = expected[key]
+        act_val = actual[key]
+        if isinstance(exp_val, dict) and isinstance(act_val, dict):
+            errors.extend(compare_dicts(exp_val, act_val, prefix=path))
+            continue
+        if exp_val != act_val:
+            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
+    return errors
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+
+    if args.run_st01:
+        st01_label_policy.main([])
+    if args.run_st01b:
+        st01b_confidence_tiers.main([])
+    if args.run_st02:
+        st02_build_pair_table.main([])
+    if args.run_st03:
+        st03_build_splits.main([])
+    if args.run_st03b:
+        st03b_build_split_suite.main([])
+
+    expected = load_json(args.expected_baseline_path)
+    actual = build_actual_summary(args.intermediate_dir)
+    errors = compare_dicts(expected, actual)
+
+    if errors:
+        print("ST0.3b regression check failed:")
+        for err in errors:
+            print(f"- {err}")
+        raise SystemExit(1)
+
+    print("ST0.3b regression check passed.")
+    print(f"- Baseline: {args.expected_baseline_path}")
+    print(f"- Intermediate: {args.intermediate_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/pipeline/steel_thread_v0/run_steel_thread_v0.py
+++ b/lyzortx/pipeline/steel_thread_v0/run_steel_thread_v0.py
@@ -9,6 +9,7 @@ from lyzortx.pipeline.steel_thread_v0.checks import check_st01_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st01b_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st02_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st03_regression
+from lyzortx.pipeline.steel_thread_v0.checks import check_st03b_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st04_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st05_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st06_regression
@@ -18,6 +19,7 @@ from lyzortx.pipeline.steel_thread_v0.steps import (
     st01b_confidence_tiers,
     st02_build_pair_table,
     st03_build_splits,
+    st03b_build_split_suite,
     st04_train_baselines,
     st05_calibrate_rank,
     st06_recommend_top3,
@@ -35,6 +37,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "st01b",
             "st02",
             "st03",
+            "st03b",
             "st04",
             "st05",
             "st06",
@@ -44,6 +47,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "check-st01b",
             "check-st02",
             "check-st03",
+            "check-st03b",
             "check-st04",
             "check-st05",
             "check-st06",
@@ -65,6 +69,8 @@ def main(argv: list[str] | None = None) -> None:
         st02_build_pair_table.main([])
     elif args.step == "st03":
         st03_build_splits.main([])
+    elif args.step == "st03b":
+        st03b_build_split_suite.main([])
     elif args.step == "st04":
         st04_train_baselines.main([])
     elif args.step == "st05":
@@ -83,6 +89,8 @@ def main(argv: list[str] | None = None) -> None:
         check_st02_regression.main([])
     elif args.step == "check-st03":
         check_st03_regression.main([])
+    elif args.step == "check-st03b":
+        check_st03b_regression.main([])
     elif args.step == "check-st04":
         check_st04_regression.main([])
     elif args.step == "check-st05":

--- a/lyzortx/pipeline/steel_thread_v0/steps/st03b_build_split_suite.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st03b_build_split_suite.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""ST0.3b: Build split-suite artifacts for host, phage-family, and dual-axis stress tests."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+
+ST02_REQUIRED_COLUMNS: Sequence[str] = ("pair_id", "bacteria", "phage", "cv_group", "phage_family")
+ST03_REQUIRED_COLUMNS: Sequence[str] = ("pair_id", "split_holdout")
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--st02-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st02_pair_table.csv"),
+        help="Input ST0.2 canonical pair table path.",
+    )
+    parser.add_argument(
+        "--st03-split-assignments-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_assignments.csv"),
+        help="Input ST0.3 split assignments path.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate"),
+        help="Output directory for ST0.3b artifacts.",
+    )
+    parser.add_argument(
+        "--phage-family-holdout-fraction",
+        type=float,
+        default=0.2,
+        help="Target fraction of phage families routed to holdout in split-suite modes.",
+    )
+    parser.add_argument(
+        "--split-salt",
+        type=str,
+        default="steel_thread_v0_st03b_split_suite_v1",
+        help="Deterministic salt for hash-based phage-family assignment.",
+    )
+    return parser.parse_args(argv)
+
+
+def read_csv_rows(path: Path, required_columns: Sequence[str]) -> List[Dict[str, str]]:
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(f"No header found in {path}.")
+        missing = [column for column in required_columns if column not in reader.fieldnames]
+        if missing:
+            raise ValueError(f"Missing required columns in {path}: {', '.join(sorted(missing))}")
+        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
+
+
+def select_holdout_items(items: Sequence[str], holdout_fraction: float, split_salt: str) -> Set[str]:
+    if not 0 < holdout_fraction < 1:
+        raise ValueError("phage_family_holdout_fraction must be between 0 and 1.")
+    scored: List[Tuple[float, str]] = []
+    for item in sorted(items):
+        score = int(hashlib.sha256(f"{split_salt}|{item}".encode("utf-8")).hexdigest(), 16)
+        scored.append((score / float(2**256 - 1), item))
+    scored.sort()
+    n_holdout = max(1, int(round(len(scored) * holdout_fraction)))
+    return {item for _, item in scored[:n_holdout]}
+
+
+def family_key(raw_family: str) -> str:
+    return raw_family if raw_family else "__MISSING_PHAGE_FAMILY__"
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+    ensure_directory(args.output_dir)
+
+    st02_rows = read_csv_rows(args.st02_pair_table_path, ST02_REQUIRED_COLUMNS)
+    st03_rows = read_csv_rows(args.st03_split_assignments_path, ST03_REQUIRED_COLUMNS)
+    if not st02_rows:
+        raise ValueError("ST0.2 table has no rows.")
+
+    st03_holdout_by_pair = {row["pair_id"]: row["split_holdout"] for row in st03_rows}
+    missing_pairs = sorted({row["pair_id"] for row in st02_rows} - set(st03_holdout_by_pair.keys()))
+    if missing_pairs:
+        raise ValueError(f"ST0.3 split assignments missing pair_id values, e.g. {missing_pairs[:3]}")
+
+    all_families = sorted({family_key(row["phage_family"]) for row in st02_rows})
+    holdout_families = select_holdout_items(
+        items=all_families,
+        holdout_fraction=args.phage_family_holdout_fraction,
+        split_salt=args.split_salt,
+    )
+
+    assignments: List[Dict[str, object]] = []
+    host_holdout_counter = Counter()
+    family_holdout_counter = Counter()
+    dual_axis_counter = Counter()
+
+    train_host_groups: Set[str] = set()
+    holdout_host_groups: Set[str] = set()
+    train_phage_families: Set[str] = set()
+    holdout_phage_families: Set[str] = set()
+
+    train_host_groups_dual: Set[str] = set()
+    dual_holdout_host_groups: Set[str] = set()
+    train_families_dual: Set[str] = set()
+    dual_holdout_families: Set[str] = set()
+
+    for row in st02_rows:
+        host_split = st03_holdout_by_pair[row["pair_id"]]
+        is_host_holdout = host_split == "holdout_test"
+        phage_family = family_key(row["phage_family"])
+        is_family_holdout = phage_family in holdout_families
+
+        family_split = "holdout_test" if is_family_holdout else "train_non_holdout"
+        if is_host_holdout and is_family_holdout:
+            dual_axis_split = "dual_holdout_test"
+        elif is_host_holdout:
+            dual_axis_split = "host_only_holdout"
+        elif is_family_holdout:
+            dual_axis_split = "phage_only_holdout"
+        else:
+            dual_axis_split = "train_non_holdout"
+
+        host_holdout_counter[host_split] += 1
+        family_holdout_counter[family_split] += 1
+        dual_axis_counter[dual_axis_split] += 1
+
+        if host_split == "train_non_holdout":
+            train_host_groups.add(row["cv_group"])
+        else:
+            holdout_host_groups.add(row["cv_group"])
+
+        if family_split == "train_non_holdout":
+            train_phage_families.add(phage_family)
+        else:
+            holdout_phage_families.add(phage_family)
+
+        if dual_axis_split == "train_non_holdout":
+            train_host_groups_dual.add(row["cv_group"])
+            train_families_dual.add(phage_family)
+        elif dual_axis_split == "dual_holdout_test":
+            dual_holdout_host_groups.add(row["cv_group"])
+            dual_holdout_families.add(phage_family)
+
+        assignments.append(
+            {
+                "pair_id": row["pair_id"],
+                "bacteria": row["bacteria"],
+                "phage": row["phage"],
+                "cv_group": row["cv_group"],
+                "phage_family": phage_family,
+                "split_host_holdout": host_split,
+                "split_phage_family_holdout": family_split,
+                "split_dual_axis": dual_axis_split,
+                "split_dual_axis_is_eval": 0 if dual_axis_split == "train_non_holdout" else 1,
+            }
+        )
+
+    assignments.sort(key=lambda item: (str(item["bacteria"]), str(item["phage"])))
+
+    protocol = {
+        "generated_at_utc": datetime.now(tz=timezone.utc).isoformat(),
+        "step_name": "st03b_build_split_suite",
+        "split_modes": {
+            "host_group_holdout": {
+                "group_key": "cv_group",
+                "source": "st03_split_assignments.csv::split_holdout",
+            },
+            "phage_family_holdout": {
+                "group_key": "phage_family",
+                "holdout_assignment": "hash-based deterministic assignment by phage_family",
+                "holdout_fraction": args.phage_family_holdout_fraction,
+                "split_salt": args.split_salt,
+            },
+            "dual_axis_host_phage": {
+                "host_axis": "st03 host-group holdout",
+                "phage_axis": "st03b phage-family holdout",
+                "evaluation_membership": [
+                    "dual_holdout_test",
+                    "host_only_holdout",
+                    "phage_only_holdout",
+                ],
+            },
+        },
+        "input_paths": {
+            "st02_pair_table": str(args.st02_pair_table_path),
+            "st03_split_assignments": str(args.st03_split_assignments_path),
+        },
+    }
+
+    audit = {
+        "generated_at_utc": datetime.now(tz=timezone.utc).isoformat(),
+        "row_count": len(assignments),
+        "split_counts": {
+            "host_group_holdout": dict(sorted(host_holdout_counter.items())),
+            "phage_family_holdout": dict(sorted(family_holdout_counter.items())),
+            "dual_axis_host_phage": dict(sorted(dual_axis_counter.items())),
+        },
+        "phage_family_holdout_count": len(holdout_families),
+        "phage_family_total_count": len(all_families),
+        "phage_family_holdout_fraction_actual": round(len(holdout_families) / len(all_families), 6),
+        "leakage_checks": {
+            "host_group_holdout_cv_group_overlap_count": len(train_host_groups & holdout_host_groups),
+            "phage_family_holdout_family_overlap_count": len(train_phage_families & holdout_phage_families),
+            "dual_axis_train_vs_dual_holdout_cv_group_overlap_count": len(train_host_groups_dual & dual_holdout_host_groups),
+            "dual_axis_train_vs_dual_holdout_family_overlap_count": len(train_families_dual & dual_holdout_families),
+        },
+        "holdout_membership": {
+            "phage_family_holdout_ids_sorted": sorted(holdout_families),
+        },
+    }
+
+    write_csv(args.output_dir / "st03b_split_suite_assignments.csv", fieldnames=list(assignments[0].keys()), rows=assignments)
+    write_json(args.output_dir / "st03b_split_suite_protocol.json", protocol)
+    write_json(args.output_dir / "st03b_split_suite_audit.json", audit)
+
+    print("ST0.3b completed.")
+    print(f"- Rows: {len(assignments)}")
+    print(f"- Holdout phage families: {len(holdout_families)} / {len(all_families)}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/lyzortx/research_notes/PLAN.md
+++ b/lyzortx/research_notes/PLAN.md
@@ -337,7 +337,7 @@ graph LR
 - [x] Build canonical ID normalization and mismatch report script. Implemented in
       `lyzortx/pipeline/track_a/steps/build_track_a_foundation.py` with outputs under
       `lyzortx/generated_outputs/track_a/id_map/`.
-- [ ] Implement ST0.3b split suite with explicit phage-family holdout and host+phage dual-axis stress tests.
+- [x] Implement ST0.3b split suite with explicit phage-family holdout and host+phage dual-axis stress tests.
 - [ ] Implement ST0.4b ablations (host-only, phage-only, no-identity controls) to quantify true signal sources.
 - [ ] Implement ST0.5b/ST0.6c reporting on both slices (full-label and strict-confidence) with bootstrap CIs.
 - [x] Implement label builder for binary/strength/potency targets from raw interactions. Implemented in

--- a/lyzortx/tests/test_st03b_split_suite.py
+++ b/lyzortx/tests/test_st03b_split_suite.py
@@ -1,0 +1,28 @@
+"""Unit tests for pure helper logic in ST0.3b split-suite builder."""
+
+from __future__ import annotations
+
+from lyzortx.pipeline.steel_thread_v0.steps.st03b_build_split_suite import family_key
+from lyzortx.pipeline.steel_thread_v0.steps.st03b_build_split_suite import select_holdout_items
+
+
+def test_family_key_uses_placeholder_for_missing_values() -> None:
+    assert family_key("") == "__MISSING_PHAGE_FAMILY__"
+    assert family_key("Myoviridae") == "Myoviridae"
+
+
+def test_select_holdout_items_is_deterministic_and_nonempty() -> None:
+    items = ["A", "B", "C", "D", "E"]
+    first = select_holdout_items(items, holdout_fraction=0.2, split_salt="salt-v1")
+    second = select_holdout_items(items, holdout_fraction=0.2, split_salt="salt-v1")
+
+    assert first == second
+    assert len(first) == 1
+
+
+def test_select_holdout_items_changes_with_salt() -> None:
+    items = ["A", "B", "C", "D", "E"]
+    first = select_holdout_items(items, holdout_fraction=0.4, split_salt="salt-v1")
+    second = select_holdout_items(items, holdout_fraction=0.4, split_salt="salt-v2")
+
+    assert first != second


### PR DESCRIPTION
### Motivation
- Provide an explicit phage-family holdout and host+phage dual-axis stress test suite to exercise phage-generalization failure modes beyond the existing host-group splits. 
- Produce deterministic, reproducible split-suite artifacts and leakage checks so downstream training and evaluation can validate slice-specific behavior. 

### Description
- Add `lyzortx/pipeline/steel_thread_v0/steps/st03b_build_split_suite.py` which emits `st03b_split_suite_assignments.csv`, `st03b_split_suite_protocol.json`, and `st03b_split_suite_audit.json` and deterministically selects phage-family holdouts via a hash-based salt. 
- Add regression gate `lyzortx/pipeline/steel_thread_v0/checks/check_st03b_regression.py` and baseline snapshot `lyzortx/pipeline/steel_thread_v0/baselines/st03b_expected_metrics.json` to validate outputs and artifact integrity. 
- Wire the new step into the orchestrator CLI via `--step st03b` and `--step check-st03b`, update `lyzortx/pipeline/steel_thread_v0/README.md` and `lyzortx/research_notes/PLAN.md`, and add unit tests under `lyzortx/tests/test_st03b_split_suite.py`. 
- Implement leakage checks covering host-group overlap, phage-family overlap, and dual-axis train-vs-holdout overlaps and include holdout membership in audit outputs. 

### Testing
- Ran the end-to-end ST0.3b regression gate with upstream steps via `python -m lyzortx.pipeline.steel_thread_v0.checks.check_st03b_regression --run-st01 --run-st01b --run-st02 --run-st03 --run-st03b` and it passed. 
- Executed the orchestrator check via `python -m lyzortx.pipeline.steel_thread_v0.run_steel_thread_v0 --step check-st03b` and it passed. 
- Ran unit tests with `pytest -q lyzortx/tests/test_st03b_split_suite.py lyzortx/tests/test_orchestrator_pure_functions.py` which resulted in `8 passed`. 
- Ran `pre-commit run prettier --files lyzortx/pipeline/steel_thread_v0/README.md lyzortx/research_notes/PLAN.md` and the hook passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adf6235e408324af10afa8224cca66)