### PR TITLE
Add PR review policy: do not approve with failing tests

### DIFF
--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -59,9 +59,11 @@ jobs:
             Review PR #${{ github.event.pull_request.number }} in this repository.
 
             Check: code quality, test coverage, alignment with acceptance criteria in the linked issue,
-            and adherence to AGENTS.md policies.
+            and adherence to AGENTS.md policies. Run tests with: pytest -q lyzortx/tests/
 
-            If the PR looks good, approve it:
+            Do NOT approve if tests fail. A branch with failing tests is not mergeable.
+
+            If the PR looks good and tests pass, approve it:
               gh pr review ${{ github.event.pull_request.number }} --approve --body "LGTM"
 
             If changes are needed, request changes with specific actionable comments:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,11 @@
 - Use one `Closes #...` line per issue when a PR intentionally resolves multiple issues.
 - Keep closure references explicit so orchestration and audit flows can advance automatically on merge.
 
+# PR Review Policy
+
+- Do not approve a PR unless all CI checks pass. A branch with failing tests is not mergeable regardless of code quality.
+- Review must verify: code quality, test coverage, alignment with acceptance criteria, and adherence to AGENTS.md policies.
+
 # PR Creation for Orchestrator Tasks
 
 - When implementing an orchestrator task, create the PR using `gh pr create` from the CLI.


### PR DESCRIPTION
## Changes

- Add PR review policy to AGENTS.md: do not approve PRs with failing CI checks
- Update codex-pr-lifecycle review prompt to run tests and reject on failure

Closes nothing — policy update.