### PR TITLE
Use PAT for orchestrator to trigger codex-implement on issue creation

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -23,6 +23,9 @@ jobs:
       || contains(join(github.event.issue.labels.*.name, ','), 'orchestrator-task')
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    # PAT required: github.token can't trigger other workflows (GitHub anti-recursion).
+    env:
+      GITHUB_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
 
     steps:
       - name: Resolve issue number
@@ -37,20 +40,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          token: ${{ secrets.CODEX_TRIGGER_PAT }}
           fetch-depth: 0
 
       - name: Extract task ID from issue title
         id: task
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           TITLE=$(gh issue view "${{ steps.issue.outputs.number }}" --json title --jq '.title')
           TASK_ID=$(echo "$TITLE" | grep -oP '(?<=\[ORCH\]\[)[A-Za-z0-9_.-]+(?=\])' || echo "UNKNOWN")
           echo "id=${TASK_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Build prompt
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           ISSUE_NUM="${{ steps.issue.outputs.number }}"
           {
@@ -89,8 +89,6 @@ jobs:
           prompt-file: /tmp/codex_prompt.txt
 
       - name: Push and create PR
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           ISSUE_NUM="${{ steps.issue.outputs.number }}"
           TASK_ID="${{ steps.task.outputs.id }}"

--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -26,12 +26,13 @@ jobs:
       )
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    # PAT required: github.token can't trigger other workflows (GitHub anti-recursion).
+    env:
+      GITHUB_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
 
     steps:
       - name: Resolve PR number and branch
         id: pr
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUM="${{ inputs.pr_number }}"
@@ -44,8 +45,6 @@ jobs:
 
       - name: Check for review feedback
         id: comments
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUM="${{ steps.pr.outputs.number }}"
           REVIEW_ID="${{ github.event.review.id }}"
@@ -79,8 +78,6 @@ jobs:
 
       - name: No feedback — label as clean
         if: steps.comments.outputs.has_feedback == 'false'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUM="${{ steps.pr.outputs.number }}"
           gh pr edit "$PR_NUM" --repo "${{ github.repository }}" --add-label "ready-for-human-review"
@@ -90,8 +87,6 @@ jobs:
       - name: Check review round cap
         if: steps.comments.outputs.has_feedback == 'true'
         id: round
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUM="${{ steps.pr.outputs.number }}"
           ROUND=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" \
@@ -106,8 +101,6 @@ jobs:
 
       - name: Collect review feedback
         if: steps.comments.outputs.has_feedback == 'true' && fromJSON(steps.round.outputs.round) < 3
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUM="${{ steps.pr.outputs.number }}"
           REVIEW_ID="${{ github.event.review.id }}"
@@ -165,8 +158,6 @@ jobs:
 
       - name: Push fixes
         if: steps.comments.outputs.has_feedback == 'true' && fromJSON(steps.round.outputs.round) < 3
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           BRANCH="${{ steps.pr.outputs.branch }}"
           if git diff --quiet "origin/${BRANCH}" && git diff --quiet && git diff --cached --quiet; then
@@ -182,8 +173,6 @@ jobs:
 
       - name: Request re-review
         if: steps.comments.outputs.has_feedback == 'true' && fromJSON(steps.round.outputs.round) < 3
-        env:
-          GH_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
         run: |
           PR_NUM="${{ steps.pr.outputs.number }}"
           NEXT_ROUND=$(( ${{ steps.round.outputs.round }} + 1 ))

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -39,12 +39,17 @@ jobs:
     if: ${{ github.event_name != 'issues' || contains(join(github.event.issue.labels.*.name, ','), 'orchestrator-task') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    # PAT required: github.token can't trigger other workflows (GitHub anti-recursion).
+    # Both gh CLI and Python orchestrator read GITHUB_TOKEN.
+    env:
+      GITHUB_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.CODEX_TRIGGER_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -93,9 +98,6 @@ jobs:
           PY
 
       - name: Run orchestrator command
-        env:
-          GITHUB_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -113,9 +115,6 @@ jobs:
           python -m lyzortx.orchestration.orchestrator "${args[@]}"
 
       - name: Emit current status
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           python -m lyzortx.orchestration.orchestrator \
             --command status \


### PR DESCRIPTION
## Changes

Use `CODEX_TRIGGER_PAT` consistently at the job level in all three workflows:
- `orchestrator.yml`
- `codex-implement.yml`
- `codex-pr-lifecycle.yml`

**Why:** `github.token` can't trigger other workflows due to GitHub's anti-recursion protection. This caused issues where orchestrator-created issues didn't trigger `codex-implement`, and PRs created by `codex-implement` didn't trigger CI checks.

**How:** Set `GITHUB_TOKEN` from the PAT once at job level. Both `gh` CLI and the Python orchestrator read `GITHUB_TOKEN`. Removed all per-step token overrides.

Also removes `orchestrator-task` label check from PR lifecycle so address-feedback runs on all PRs that Codex reviews.