### PR TITLE
Work around codex-action sandbox failure on Ubuntu 24.04

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -80,6 +80,13 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      # Workaround for https://github.com/openai/codex/issues/12572
+      # Remove once codex-action fixes bwrap sandbox on Ubuntu 24.04
+      - name: Fix sandbox compatibility with Ubuntu 24.04 AppArmor
+        run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Implement task with Codex
         uses: openai/codex-action@v1
         with:

--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -147,6 +147,14 @@ jobs:
         if: steps.comments.outputs.has_feedback == 'true' && fromJSON(steps.round.outputs.round) < 3
         run: pip install -r requirements.txt
 
+      # Workaround for https://github.com/openai/codex/issues/12572
+      # Remove once codex-action fixes bwrap sandbox on Ubuntu 24.04
+      - name: Fix sandbox compatibility with Ubuntu 24.04 AppArmor
+        if: steps.comments.outputs.has_feedback == 'true' && fromJSON(steps.round.outputs.round) < 3
+        run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Fix with Codex
         if: steps.comments.outputs.has_feedback == 'true' && fromJSON(steps.round.outputs.round) < 3
         uses: openai/codex-action@v1


### PR DESCRIPTION
## Problem

Newer GitHub Actions runner images (20260309.50+) restrict unprivileged user namespaces via AppArmor, breaking codex-action's bubblewrap sandbox with `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`.

## Fix

Relax AppArmor restrictions before running codex-action in both `codex-implement.yml` and `codex-pr-lifecycle.yml`.

See https://github.com/openai/codex/issues/12572 — remove this workaround once upstream fixes it.