### PR TITLE
Rename CODEX_TRIGGER_PAT to ORCHESTRATOR_PAT, fail on no changes

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     # PAT required: github.token can't trigger other workflows (GitHub anti-recursion).
     env:
-      GITHUB_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
+      GITHUB_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
 
     steps:
       - name: Resolve issue number
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.CODEX_TRIGGER_PAT }}
+          token: ${{ secrets.ORCHESTRATOR_PAT }}
           fetch-depth: 0
 
       - name: Extract task ID from issue title
@@ -103,8 +103,8 @@ jobs:
 
           # Check for changes: either uncommitted files or new commits beyond origin/main
           if git diff --quiet origin/main && git diff --quiet && git diff --cached --quiet; then
-            echo "No changes detected. Skipping PR creation."
-            exit 0
+            echo "::error::Codex produced no changes. Implementation failed."
+            exit 1
           fi
 
           git config user.name "github-actions[bot]"

--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 30
     # PAT required: github.token can't trigger other workflows (GitHub anti-recursion).
     env:
-      GITHUB_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
+      GITHUB_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
 
     steps:
       - name: Resolve PR number and branch
@@ -169,7 +169,7 @@ jobs:
         run: |
           BRANCH="${{ steps.pr.outputs.branch }}"
           if git diff --quiet "origin/${BRANCH}" && git diff --quiet && git diff --cached --quiet; then
-            echo "No changes after fix attempt."
+            echo "No changes after fix attempt — Codex may have pushed back on the feedback."
             exit 0
           fi
 

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -42,14 +42,14 @@ jobs:
     # PAT required: github.token can't trigger other workflows (GitHub anti-recursion).
     # Both gh CLI and Python orchestrator read GITHUB_TOKEN.
     env:
-      GITHUB_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
+      GITHUB_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}
       GITHUB_REPOSITORY: ${{ github.repository }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.CODEX_TRIGGER_PAT }}
+          token: ${{ secrets.ORCHESTRATOR_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Changes

- Rename `CODEX_TRIGGER_PAT` → `ORCHESTRATOR_PAT` in all three workflows
- `codex-implement`: fail when Codex produces no changes (implementation failed)
- `codex-pr-lifecycle`: allow no changes (Codex may push back on feedback)

**Action required:** After merging, rename the repo secret from `CODEX_TRIGGER_PAT` to `ORCHESTRATOR_PAT` in Settings → Secrets.