### PR TITLE
Add review dedup rule: do not re-raise addressed concerns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@
 - Review must verify: code quality, test coverage, alignment with acceptance criteria, and adherence to AGENTS.md policies.
 - When addressing review feedback, apply the Requirement Challenge Policy: push back on comments that are wrong,
   overcomplicated, or low-value rather than blindly implementing every suggestion.
+- Before raising an issue, check existing review threads and replies on the PR. Do not re-raise concerns that have
+  already been addressed with a code fix or explicitly pushed back on with a reasoned explanation.
 
 # PR Creation for Orchestrator Tasks
 


### PR DESCRIPTION
## Changes

Add to Review guidelines in AGENTS.md: before raising an issue, check existing
review threads and replies. Do not re-raise concerns already addressed with a
code fix or pushed back on with a reasoned explanation.

Codex Web's semantic dedup sees existing comments but doesn't recognize reply-based
pushback as resolution. This instruction makes the policy explicit.