### PR TITLE
Remove duplicate push trigger from unit-tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,6 @@ name: Unit Tests
 
 on:
   pull_request:
-  push:
 
 jobs:
   unit-tests:


### PR DESCRIPTION
Branch protection requires the PR check to pass before merge, making the `push` trigger redundant. Removing it eliminates duplicate CI runs on every PR push.