### PR TITLE
Fail loudly when orchestrator can't push plan updates

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -121,12 +121,17 @@ jobs:
             --plan-path lyzortx/orchestration/plan.yml \
             --state-path lyzortx/generated_outputs/orchestration/runtime_state.json
 
+      # Deliberately fails if push is rejected (e.g. by branch protection).
+      # Plan updates must land on main for the orchestrator to stay in sync.
       - name: Commit plan updates
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add lyzortx/orchestration/plan.yml lyzortx/research_notes/PLAN.md
-          git diff --cached --quiet || (git commit -m "Update plan: mark completed task" && git push)
+          if ! git diff --cached --quiet; then
+            git commit -m "Update plan: mark completed task"
+            git push
+          fi
 
       - name: Upload orchestration state artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
The `||` operator silently swallowed push failures in the plan commit step. Now uses `if/then` so `git push` runs without error suppression — the workflow will fail visibly if branch protection blocks the push.