### PR TITLE
Use danger-full-access sandbox for Codex git + network access

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.4
-          codex-args: --full-auto -c 'sandbox_workspace_write.network_access=true'
+          codex-args: --full-auto --sandbox danger-full-access
           prompt-file: /tmp/codex_prompt.txt
 
       - name: Verify Codex created a PR

--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -164,7 +164,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.4
           allow-bots: true
-          codex-args: --full-auto -c 'sandbox_workspace_write.network_access=true'
+          codex-args: --full-auto --sandbox danger-full-access
           prompt-file: /tmp/codex_feedback.txt
 
       - name: Verify all comments were answered


### PR DESCRIPTION
## Problem

`workspace-write` with `network_access=true` makes `.git` read-only, preventing Codex from committing, pushing branches, or creating PRs via `gh`. See [failing run](https://github.com/LorenaDerezanin/coli_phage_interactions_2023/actions/runs/23168167481/job/67313411274).

## Fix

Switch to `danger-full-access` sandbox which removes all restrictions. Acceptable because the workflow runs in an ephemeral CI container with no persistent state.