### PR TITLE
Fix sandbox: use action input to avoid duplicate --sandbox flag

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -86,7 +86,8 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.4
-          codex-args: --full-auto --sandbox danger-full-access
+          sandbox: danger-full-access
+          codex-args: --full-auto
           prompt-file: /tmp/codex_prompt.txt
 
       - name: Verify Codex created a PR

--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -164,7 +164,8 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.4
           allow-bots: true
-          codex-args: --full-auto --sandbox danger-full-access
+          sandbox: danger-full-access
+          codex-args: --full-auto
           prompt-file: /tmp/codex_feedback.txt
 
       - name: Verify all comments were answered


### PR DESCRIPTION
## Problem

`codex-args: --full-auto --sandbox danger-full-access` causes "the argument '--sandbox' cannot be used multiple times" because the action already passes `--sandbox` from its own input.

See [failing run](https://github.com/LorenaDerezanin/coli_phage_interactions_2023/actions/runs/23183469743).

## Fix

Use the action's `sandbox: danger-full-access` input. Keep `--full-auto` in codex-args for approval policy.