### PR TITLE
Replace --full-auto with -a never to fix danger-full-access sandbox

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -87,7 +87,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.4
           sandbox: danger-full-access
-          codex-args: --full-auto
+          codex-args: -a never
           prompt-file: /tmp/codex_prompt.txt
 
       - name: Verify Codex created a PR

--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -165,7 +165,7 @@ jobs:
           model: gpt-5.4
           allow-bots: true
           sandbox: danger-full-access
-          codex-args: --full-auto
+          codex-args: -a never
           prompt-file: /tmp/codex_feedback.txt
 
       - name: Verify all comments were answered


### PR DESCRIPTION
## Problem

`--full-auto` overrides `--sandbox danger-full-access` back to `workspace-write`, making `.git` read-only. Codex can't commit, push, or create PRs.

See [failing run](https://github.com/LorenaDerezanin/coli_phage_interactions_2023/actions/runs/23184474233) — sandbox reports `workspace-write` despite `danger-full-access` being passed.

## Fix

Replace `--full-auto` with `-a never` in codex-args. This sets the approval policy without overriding the sandbox mode.