### PR TITLE
Use long-form --ask-for-approval flag in codex-args

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -87,7 +87,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.4
           sandbox: danger-full-access
-          codex-args: -a never
+          codex-args: --ask-for-approval never
           prompt-file: /tmp/codex_prompt.txt
 
       - name: Verify Codex created a PR

--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -165,7 +165,7 @@ jobs:
           model: gpt-5.4
           allow-bots: true
           sandbox: danger-full-access
-          codex-args: -a never
+          codex-args: --ask-for-approval never
           prompt-file: /tmp/codex_feedback.txt
 
       - name: Verify all comments were answered


### PR DESCRIPTION
Short form `-a never` is parsed by the action's node wrapper, not passed to codex CLI.

See [failing run](https://github.com/LorenaDerezanin/coli_phage_interactions_2023/actions/runs/23185387516).