### PR TITLE
[ORCH][TB03] Characterize hard-to-lyse strains by host traits

### DIFF
--- a/lyzortx/research_notes/LAB NOTEBOOK.md
+++ b/lyzortx/research_notes/LAB NOTEBOOK.md
@@ -18,7 +18,8 @@
 
 - Interaction-matrix strains analyzed: `402`.
 - Zero-lysis strains: `12 / 402` (`2.99%`).
-- Low-susceptibility strains (`<=3` lytic phages): `36 / 402` (`8.96%`).
+- Low-susceptibility strains (`<=3` lytic phages): `36 / 401` resolved strains (`8.98%`), with `S1-84` remaining
+  ambiguous because missing assays do not rule in or rule out the threshold.
 - Zero-lysis strains:
   `B156`, `B253`, `DEC2a`, `E_albertiiCIP107988T`, `FN-B4`, `FN-B7`, `H1-002-0060-C-T`, `H1-007-0015-D-G`,
   `NILS22`, `NILS24`, `ROAR205`, `ROAR220`.
@@ -28,17 +29,17 @@
   - ST: Kruskal-Wallis `p = 1.71e-05`
 - No individual trait value met the current multiple-testing cutoff (`q <= 0.1`).
 - Strongest nominal enrichments among testable groups (`n >= 4`) were:
-  - Phylogroup `Clade V`: `3 / 7` low-susceptibility (`42.9%`), odds ratio `7.89`, `q = 0.240`
-  - Phylogroup `E. fergusonii`: `2 / 5` low-susceptibility (`40.0%`), odds ratio `6.82`, `q = 0.282`
-  - ST `58`: `5 / 17` low-susceptibility (`29.4%`), odds ratio `4.56`, `q = 0.314`
+  - Phylogroup `Clade V`: `3 / 7` low-susceptibility (`42.9%`), odds ratio `8.20`, `q = 0.218`
+  - Phylogroup `E. fergusonii`: `2 / 5` low-susceptibility (`40.0%`), odds ratio `7.10`, `q = 0.264`
+  - ST `58`: `5 / 17` low-susceptibility (`29.4%`), odds ratio `4.74`, `q = 0.296`
 - Broad-susceptibility counterexample:
-  - Phylogroup `B2`: only `6 / 126` low-susceptibility (`4.9%`), median `27` lytic phages, odds ratio `0.41`
+  - Phylogroup `B2`: only `6 / 126` low-susceptibility (`4.8%`), median `27` lytic phages, odds ratio `0.41`
 
 #### TB03 interpretation
 
 1. Hard-to-lyse behavior is not random noise in the matrix; it tracks host background strongly at the field level for
    serotype, phylogroup, and ST.
-2. The clearest nominal concentration is in `Clade V` (`42.9%` low susceptibility versus a `9.0%` panel-wide
+2. The clearest nominal concentration is in `Clade V` (`42.9%` low susceptibility versus an `8.98%` resolved-panel
    baseline), but none of the tested trait values yet survive multiple-testing correction.
 3. `ST58` is still the strongest recurring ST signal in the currently testable set, but the ST landscape is fragmented
    across many small sequence types, so the category-level evidence remains weak after correction.

--- a/lyzortx/research_notes/ad_hoc_analysis_code/hard_to_lyse_host_traits.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/hard_to_lyse_host_traits.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import math
 import sys
 from pathlib import Path
 from typing import Iterable, Sequence
@@ -65,7 +64,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def clean_trait_value(value: object) -> str:
-    if value is None or (isinstance(value, float) and math.isnan(value)):
+    if value is None or pd.isna(value):
         return "Missing"
     text = str(value).strip()
     return text if text else "Missing"
@@ -98,6 +97,16 @@ def count_lytic_phages(interaction_matrix: pd.DataFrame) -> pd.Series:
     return binary_matrix.sum(axis=1, min_count=binary_matrix.shape[1]).astype("Int64").rename("n_lytic_phages")
 
 
+def count_known_lytic_phages(interaction_matrix: pd.DataFrame) -> pd.Series:
+    return interaction_matrix.gt(0).where(interaction_matrix.notna(), False).sum(axis=1).astype(int).rename(
+        "known_lytic_phages"
+    )
+
+
+def count_missing_assays(interaction_matrix: pd.DataFrame) -> pd.Series:
+    return interaction_matrix.isna().sum(axis=1).astype(int).rename("missing_assay_count")
+
+
 def true_count(values: pd.Series) -> int:
     return int(values.eq(True).sum())
 
@@ -106,9 +115,9 @@ def false_count(values: pd.Series) -> int:
     return int(values.eq(False).sum())
 
 
-def observed_rate(values: pd.Series) -> float:
+def observed_rate(values: pd.Series) -> float | None:
     observed_total = int(values.notna().sum())
-    return true_count(values) / observed_total if observed_total else 0.0
+    return true_count(values) / observed_total if observed_total else None
 
 
 def optional_float(value: object) -> float | None:
@@ -139,8 +148,11 @@ def build_per_strain_summary(
     low_threshold: int,
 ) -> pd.DataFrame:
     n_lytic_phages = count_lytic_phages(interaction_matrix)
+    known_lytic_phages = count_known_lytic_phages(interaction_matrix)
+    missing_assay_count = count_missing_assays(interaction_matrix)
 
-    strain_summary = n_lytic_phages.reset_index().rename(columns={"index": "bacteria"})
+    strain_summary = pd.concat([n_lytic_phages, known_lytic_phages, missing_assay_count], axis=1)
+    strain_summary = strain_summary.reset_index().rename(columns={"index": "bacteria"})
     host_columns = [
         "bacteria",
         "ABC_serotype",
@@ -157,11 +169,29 @@ def build_per_strain_summary(
     strain_summary["host_abc_serotype"] = strain_summary["ABC_serotype"].map(clean_trait_value)
     strain_summary["host_phylogroup"] = strain_summary["Clermont_Phylo"].map(clean_trait_value)
     strain_summary["host_st"] = strain_summary["ST_Warwick"].map(clean_trait_value)
-    strain_summary["is_zero_lysis"] = strain_summary["n_lytic_phages"].eq(0)
-    strain_summary["is_low_susceptibility"] = strain_summary["n_lytic_phages"].le(low_threshold)
-    strain_summary["susceptibility_bucket"] = [
-        classify_susceptibility_bucket(None if pd.isna(count) else int(count), low_threshold)
-        for count in strain_summary["n_lytic_phages"]
+    has_missing_assays = strain_summary["missing_assay_count"].gt(0)
+    strain_summary["is_zero_lysis"] = pd.Series(pd.NA, index=strain_summary.index, dtype="boolean")
+    strain_summary["is_low_susceptibility"] = pd.Series(pd.NA, index=strain_summary.index, dtype="boolean")
+    strain_summary["is_zero_lysis"] = strain_summary["is_zero_lysis"].mask(strain_summary["known_lytic_phages"].gt(0), False)
+    strain_summary["is_low_susceptibility"] = strain_summary["is_low_susceptibility"].mask(
+        strain_summary["known_lytic_phages"].gt(low_threshold), False
+    )
+    no_missing_assays = ~has_missing_assays
+    strain_summary["is_zero_lysis"] = strain_summary["is_zero_lysis"].mask(
+        no_missing_assays, strain_summary["known_lytic_phages"].eq(0)
+    )
+    strain_summary["is_low_susceptibility"] = strain_summary["is_low_susceptibility"].mask(
+        no_missing_assays, strain_summary["known_lytic_phages"].le(low_threshold)
+    )
+
+    strain_summary["susceptibility_bucket"] = UNKNOWN_SUSCEPTIBILITY_BUCKET
+    strain_summary["susceptibility_bucket"] = strain_summary["susceptibility_bucket"].mask(
+        strain_summary["known_lytic_phages"].gt(low_threshold), "broad"
+    )
+    exact_count_mask = no_missing_assays
+    strain_summary.loc[exact_count_mask, "susceptibility_bucket"] = [
+        classify_susceptibility_bucket(int(count), low_threshold)
+        for count in strain_summary.loc[exact_count_mask, "known_lytic_phages"]
     ]
     return strain_summary.sort_values(["n_lytic_phages", "bacteria"]).reset_index(drop=True)
 
@@ -237,7 +267,7 @@ def summarize_trait_field(
         key=lambda row: (
             row["summary_level"] != "trait_value",
             row["fisher_q_value"] if row["fisher_q_value"] is not None else 1.0,
-            -float(row["low_susceptibility_rate"]),
+            -(float(row["low_susceptibility_rate"]) if row["low_susceptibility_rate"] is not None else -1.0),
             row["trait_value"],
         )
     )

--- a/lyzortx/tests/test_hard_to_lyse_host_traits.py
+++ b/lyzortx/tests/test_hard_to_lyse_host_traits.py
@@ -5,6 +5,7 @@ from scipy.stats import kruskal
 from lyzortx.research_notes.ad_hoc_analysis_code.hard_to_lyse_host_traits import (
     benjamini_hochberg,
     build_per_strain_summary,
+    clean_trait_value,
     classify_susceptibility_bucket,
     derive_serotype,
     summarize_trait_field,
@@ -15,6 +16,10 @@ def test_derive_serotype_prefers_o_h_pair_and_handles_missing() -> None:
     assert derive_serotype("O8", "H9") == "O8:H9"
     assert derive_serotype("O8", "") == "O8"
     assert derive_serotype("", "") == "Missing"
+
+
+def test_clean_trait_value_treats_pd_na_as_missing() -> None:
+    assert clean_trait_value(pd.NA) == "Missing"
 
 
 def test_classify_susceptibility_bucket_distinguishes_zero_low_and_broad() -> None:
@@ -85,10 +90,43 @@ def test_build_per_strain_summary_preserves_missing_assays_in_lysis_counts() -> 
     b2 = out.loc[out["bacteria"] == "B2"].iloc[0]
 
     assert pd.isna(b1["n_lytic_phages"])
-    assert pd.isna(b1["is_zero_lysis"])
+    assert b1["is_zero_lysis"] == False
     assert pd.isna(b1["is_low_susceptibility"])
     assert b1["susceptibility_bucket"] == "unknown_missing_assays"
     assert b2["n_lytic_phages"] == 1
+
+
+def test_build_per_strain_summary_marks_definitely_broad_rows_despite_missing_assays() -> None:
+    interaction_matrix = pd.DataFrame(
+        {
+            "P1": [1, 0],
+            "P2": [1, 0],
+            "P3": [1, 0],
+            "P4": [1, 1],
+            "P5": [pd.NA, 0],
+        },
+        index=["B1", "B2"],
+    )
+    interaction_matrix.index.name = "bacteria"
+    host_metadata = pd.DataFrame(
+        {
+            "bacteria": ["B1", "B2"],
+            "ABC_serotype": ["K1", "K2"],
+            "Clermont_Phylo": ["B2", "A"],
+            "ST_Warwick": ["95", "10"],
+            "O-type": ["O8", "O89"],
+            "H-type": ["H9", "H9"],
+        }
+    )
+
+    out = build_per_strain_summary(interaction_matrix, host_metadata, low_threshold=3)
+
+    b1 = out.loc[out["bacteria"] == "B1"].iloc[0]
+
+    assert pd.isna(b1["n_lytic_phages"])
+    assert b1["is_zero_lysis"] == False
+    assert b1["is_low_susceptibility"] == False
+    assert b1["susceptibility_bucket"] == "broad"
 
 
 def test_summarize_trait_field_reports_field_and_value_rows() -> None:
@@ -146,6 +184,33 @@ def test_summarize_trait_field_excludes_unknown_low_status_from_rates() -> None:
     assert a_row["low_susceptibility_count"] == 1
     assert a_row["low_susceptibility_rate"] == 0.5
     assert a_row["tested_for_enrichment"] is True
+
+
+def test_summarize_trait_field_returns_missing_rate_when_no_statuses_are_observed() -> None:
+    strain_summary = pd.DataFrame(
+        {
+            "bacteria": ["B1", "B2", "B3"],
+            "n_lytic_phages": [pd.NA, pd.NA, 5],
+            "is_zero_lysis": [pd.NA, pd.NA, False],
+            "is_low_susceptibility": [pd.NA, pd.NA, False],
+            "host_serotype": ["O1:H1", "O1:H1", "O2:H2"],
+        }
+    )
+
+    rows = summarize_trait_field(
+        strain_summary=strain_summary,
+        field_name="host_serotype",
+        field_label="serotype",
+        low_threshold=3,
+        min_group_size=2,
+    )
+
+    unknown_row = next(row for row in rows if row["summary_level"] == "trait_value" and row["trait_value"] == "O1:H1")
+
+    assert unknown_row["low_susceptibility_count"] == 0
+    assert unknown_row["low_susceptibility_rate"] is None
+    assert unknown_row["mean_lytic_phages"] is None
+    assert unknown_row["tested_for_enrichment"] is False
 
 
 def test_summarize_trait_field_includes_singletons_in_kruskal_test() -> None:


### PR DESCRIPTION
## Summary

- add a reproducible TB03 analysis script for characterizing hard-to-lyse strains by host serotype, phylogroup, and ST
- add focused unit tests for the new analysis helpers and verify the full `lyzortx/tests/` suite passes
- record the corrected TB03 findings in the lab notebook while keeping generated outputs local under
  `lyzortx/generated_outputs/hard_to_lyse_host_traits/`

## Details

- define the hard-to-lyse slice as strains with zero or at most 3 lytic phages in `data/interactions/interaction_matrix.csv`
- preserve missing interaction-matrix assays as unknown susceptibility instead of coercing them to non-lytic counts
- classify strains as definitively non-low-susceptibility when known lytic phages already exceed the threshold, even if the exact count is unknown due to missing assays
- return `None` instead of `0.0` for low-susceptibility rate when a group has no observed statuses
- derive the primary serotype feature from `O-type:H-type` rather than sparse `ABC_serotype` values, while still keeping
  `ABC_serotype` in the per-strain output for reference
- configure the script to emit local generated outputs:
  - `hard_to_lyse_strain_summary.csv`
  - `host_trait_low_susceptibility_summary.csv`
  - `tb03_summary.json`
- summarize the verified findings in `lyzortx/research_notes/LAB NOTEBOOK.md`, including the zero-lysis strain list,
  corrected field-level Kruskal-Wallis p-values, and the strongest nominal host-background signals

## Verification

- `python lyzortx/research_notes/ad_hoc_analysis_code/hard_to_lyse_host_traits.py`
- `pytest -q lyzortx/tests/`
- `pre-commit run pymarkdown --files 'lyzortx/research_notes/LAB NOTEBOOK.md'`

Posted by Codex gpt-5.4

Closes #19