### PR TITLE
Fix lifecycle workflow not triggering unit tests

### DIFF
--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -138,6 +138,7 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.branch }}
           fetch-depth: 0
+          token: ${{ secrets.ORCHESTRATOR_PAT }}
 
       - name: Set up Python
         if: steps.comments.outputs.has_feedback == 'true' && fromJSON(steps.round.outputs.round) < 3


### PR DESCRIPTION
## Summary

- Pass `token: ${{ secrets.ORCHESTRATOR_PAT }}` to the `actions/checkout` step in `codex-pr-lifecycle.yml`
- `actions/checkout` defaults its `token` input to `${{ github.token }}`, ignoring the job-level `GITHUB_TOKEN` env var
- Pushes made with `github.token` are suppressed by GitHub's anti-recursion rule, so the `pull_request: synchronize` event never fires and unit tests don't run

## Test plan

- [ ] Trigger `codex-pr-lifecycle` on a PR and verify unit tests run on the resulting push

🤖 Generated with [Claude Code](https://claude.com/claude-code)