### PR TITLE
chore: add Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue list *)",
+      "Bash(gh issue view *)",
+      "Bash(git log *)",
+      "Bash(grep *)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:developers.openai.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebSearch"
+    ]
+  },
+  "respectGitignore": false
+}


### PR DESCRIPTION
## Summary
- add `.claude/settings.json` with allowed GitHub and web actions
- set `respectGitignore` to `false`

## Testing
- not run (config-only change)

Created by Codex GPT-5.