### PR TITLE
Use PR instead of direct push for orchestrator plan updates

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -32,6 +32,7 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   orchestrator-tick:
@@ -121,17 +122,28 @@ jobs:
             --plan-path lyzortx/orchestration/plan.yml \
             --state-path lyzortx/generated_outputs/orchestration/runtime_state.json
 
-      # Deliberately fails if push is rejected (e.g. by branch protection).
-      # Plan updates must land on main for the orchestrator to stay in sync.
-      - name: Commit plan updates
+      # Main is branch-protected; land plan updates via auto-merged PR.
+      - name: Commit plan updates via PR
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add lyzortx/orchestration/plan.yml lyzortx/research_notes/PLAN.md
-          if ! git diff --cached --quiet; then
-            git commit -m "Update plan: mark completed task"
-            git push
+          if git diff --cached --quiet; then
+            echo "No plan changes to commit."
+            exit 0
           fi
+
+          BRANCH="orchestrator/plan-update-$(date +%s)"
+          git checkout -b "$BRANCH"
+          git commit -m "Update plan: mark completed task"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "Update plan: mark completed task" \
+            --body "Automated plan update from orchestrator workflow run." \
+            --base main \
+            --head "$BRANCH" \
+            --label orchestrator-task
 
       - name: Upload orchestration state artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

- Replaces the direct `git push` to main in the orchestrator workflow with a PR-based flow
- Creates a timestamped branch (`orchestrator/plan-update-<epoch>`), commits plan changes, and opens a PR with the `orchestrator-task` label
- Adds `pull-requests: write` permission to the workflow

## Why

Main is now branch-protected, so the existing direct-push step would fail. This lets required checks (unit tests) run before the plan update lands.

## Test plan

- [ ] Trigger the orchestrator workflow and verify it creates a PR instead of pushing directly
- [ ] Verify the PR has the `orchestrator-task` label
- [ ] Confirm the PR passes required checks and can be merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)