### PR TITLE
fix: reduce Codex CI token waste from env fumbling and git config

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -74,6 +74,11 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Configure git identity for Codex agent
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       # Workaround for https://github.com/openai/codex/issues/12572
       # Remove once codex-action fixes bwrap sandbox on Ubuntu 24.04
       - name: Fix sandbox compatibility with Ubuntu 24.04 AppArmor

--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -140,6 +140,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.ORCHESTRATOR_PAT }}
 
+      - name: Configure git identity for Codex agent
+        if: steps.comments.outputs.has_feedback == 'true' && fromJSON(steps.round.outputs.round) < 3
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Set up Python
         if: steps.comments.outputs.has_feedback == 'true' && fromJSON(steps.round.outputs.round) < 3
         uses: actions/setup-python@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,12 @@
 
 # Environment Policy
 
-- Use the `phage_env` micromamba environment for project commands by default.
-- Before running project tooling, activate it with `micromamba activate phage_env`.
-- Do not use system Python for repository tasks unless the user explicitly asks.
+- **Local development:** Use the `phage_env` micromamba environment. Activate it with `micromamba activate phage_env`.
+- **CI / Codex sandbox:** Use plain `python` and `pip` directly — micromamba is not installed in CI. Dependencies are
+  pre-installed via `pip install -r requirements.txt` before the agent runs.
+- **How to detect CI:** Check for the `CI` environment variable (`[ -n "$CI" ]`). If set, skip micromamba activation.
+- **Git identity in CI:** Git `user.name` and `user.email` are pre-configured before the agent runs. Do not attempt to
+  set them yourself.
 
 # Dependency Selection Policy
 


### PR DESCRIPTION
## Summary
- **AGENTS.md**: Environment Policy now distinguishes local dev (micromamba) from CI/Codex (plain python/pip), tells agents to check `$CI`, and documents that git identity is pre-configured
- **codex-implement.yml**: Added git config step before Codex runs
- **codex-pr-lifecycle.yml**: Same git config step, gated on the existing feedback condition

## Motivation
Analysis of the last 20 CI runs showed **120 environment discovery fumbles** (agent trying conda/micromamba that doesn't exist) and **28 git config failures** per batch. These waste ~10-15% of tokens per run.

## Test plan
- [x] Unit tests CI passes (AGENTS.md change is documentation-only, workflow changes are additive steps)
- [ ] Next Codex implement/lifecycle run shows zero env fumbles and zero git config failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)