### PR TITLE
refactor: deduplicate check/step helper functions

### DIFF
--- a/lyzortx/pipeline/steel_thread_v0/checks/_check_helpers.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/_check_helpers.py
@@ -1,0 +1,83 @@
+"""Shared helpers for regression check scripts."""
+
+from __future__ import annotations
+
+import csv
+import json
+from math import isclose
+from numbers import Real
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    """Load a JSON file and return its contents as a dict."""
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def count_csv_rows(path: Path) -> int:
+    """Count data rows in a CSV file (excluding header)."""
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(f"No header found in {path}.")
+        return sum(1 for _ in reader)
+
+
+def read_csv_rows(path: Path) -> List[Dict[str, str]]:
+    """Read a CSV file into a list of dicts with stripped string values."""
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(f"No header found in {path}.")
+        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
+
+
+def compare_dicts(
+    expected: Dict[str, Any],
+    actual: Dict[str, Any],
+    prefix: str = "",
+    numeric_tolerance: Optional[float] = None,
+) -> List[str]:
+    """Recursively compare two dicts and return a list of mismatch descriptions.
+
+    Parameters
+    ----------
+    expected, actual:
+        The reference and observed dictionaries.
+    prefix:
+        Dot-separated path prefix for error messages (used in recursion).
+    numeric_tolerance:
+        When set, numeric values are compared with ``math.isclose``
+        using this as the absolute tolerance instead of exact equality.
+    """
+    errors: List[str] = []
+    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
+    for key in all_keys:
+        path = f"{prefix}.{key}" if prefix else key
+        if key not in expected:
+            errors.append(f"Unexpected key in actual: {path}")
+            continue
+        if key not in actual:
+            errors.append(f"Missing key in actual: {path}")
+            continue
+        exp_val = expected[key]
+        act_val = actual[key]
+        if isinstance(exp_val, dict) and isinstance(act_val, dict):
+            errors.extend(compare_dicts(exp_val, act_val, prefix=path, numeric_tolerance=numeric_tolerance))
+            continue
+        if numeric_tolerance is not None and _is_real_number(exp_val) and _is_real_number(act_val):
+            if not isclose(float(exp_val), float(act_val), rel_tol=0.0, abs_tol=numeric_tolerance):
+                errors.append(
+                    f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}, tolerance={numeric_tolerance}"
+                )
+            continue
+        if exp_val != act_val:
+            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
+    return errors
+
+
+def _is_real_number(value: object) -> bool:
+    """Return True for numeric types excluding bool."""
+    return isinstance(value, Real) and not isinstance(value, bool)

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st01_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st01_regression.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import compare_dicts, load_json
 from lyzortx.pipeline.steel_thread_v0.steps import st01_label_policy
 
 
@@ -32,11 +32,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Run ST0.1 before checking regression metrics.",
     )
     return parser.parse_args(argv)
-
-
-def load_json(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
 
 
 def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
@@ -78,27 +73,6 @@ def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
             "pair_label_audit_csv_sha256": pair_csv_sha256,
         },
     }
-
-
-def compare_dicts(expected: Dict[str, Any], actual: Dict[str, Any], prefix: str = "") -> List[str]:
-    errors: List[str] = []
-    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
-    for key in all_keys:
-        path = f"{prefix}.{key}" if prefix else key
-        if key not in expected:
-            errors.append(f"Unexpected key in actual: {path}")
-            continue
-        if key not in actual:
-            errors.append(f"Missing key in actual: {path}")
-            continue
-        exp_val = expected[key]
-        act_val = actual[key]
-        if isinstance(exp_val, dict) and isinstance(act_val, dict):
-            errors.extend(compare_dicts(exp_val, act_val, prefix=path))
-            continue
-        if exp_val != act_val:
-            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
-    return errors
 
 
 def main(argv: Optional[List[str]] = None) -> None:

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st01b_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st01b_regression.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import compare_dicts, load_json
 from lyzortx.pipeline.steel_thread_v0.steps import st01_label_policy, st01b_confidence_tiers
 
 
@@ -37,11 +37,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Run ST0.1b before checking regression metrics.",
     )
     return parser.parse_args(argv)
-
-
-def load_json(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
 
 
 def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
@@ -80,27 +75,6 @@ def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
             "pair_confidence_audit_csv_sha256": pair_csv_sha256,
         },
     }
-
-
-def compare_dicts(expected: Dict[str, Any], actual: Dict[str, Any], prefix: str = "") -> List[str]:
-    errors: List[str] = []
-    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
-    for key in all_keys:
-        path = f"{prefix}.{key}" if prefix else key
-        if key not in expected:
-            errors.append(f"Unexpected key in actual: {path}")
-            continue
-        if key not in actual:
-            errors.append(f"Missing key in actual: {path}")
-            continue
-        exp_val = expected[key]
-        act_val = actual[key]
-        if isinstance(exp_val, dict) and isinstance(act_val, dict):
-            errors.extend(compare_dicts(exp_val, act_val, prefix=path))
-            continue
-        if exp_val != act_val:
-            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
-    return errors
 
 
 def main(argv: Optional[List[str]] = None) -> None:

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st02_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st02_regression.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import compare_dicts, load_json
 from lyzortx.pipeline.steel_thread_v0.steps import (
     st01_label_policy,
     st01b_confidence_tiers,
@@ -46,11 +46,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Run ST0.2 before checking regression metrics.",
     )
     return parser.parse_args(argv)
-
-
-def load_json(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
 
 
 def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
@@ -93,27 +88,6 @@ def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
             "pair_table_csv_sha256": pair_table_sha256,
         },
     }
-
-
-def compare_dicts(expected: Dict[str, Any], actual: Dict[str, Any], prefix: str = "") -> List[str]:
-    errors: List[str] = []
-    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
-    for key in all_keys:
-        path = f"{prefix}.{key}" if prefix else key
-        if key not in expected:
-            errors.append(f"Unexpected key in actual: {path}")
-            continue
-        if key not in actual:
-            errors.append(f"Missing key in actual: {path}")
-            continue
-        exp_val = expected[key]
-        act_val = actual[key]
-        if isinstance(exp_val, dict) and isinstance(act_val, dict):
-            errors.extend(compare_dicts(exp_val, act_val, prefix=path))
-            continue
-        if exp_val != act_val:
-            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
-    return errors
 
 
 def main(argv: Optional[List[str]] = None) -> None:

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st03_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st03_regression.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import compare_dicts, load_json
 from lyzortx.pipeline.steel_thread_v0.steps import (
     st01_label_policy,
     st01b_confidence_tiers,
@@ -36,11 +36,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument("--run-st02", action="store_true", help="Run ST0.2 before checking ST0.3.")
     parser.add_argument("--run-st03", action="store_true", help="Run ST0.3 before checking ST0.3.")
     return parser.parse_args(argv)
-
-
-def load_json(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
 
 
 def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
@@ -85,27 +80,6 @@ def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
             "split_assignments_csv_sha256": assignment_sha256,
         },
     }
-
-
-def compare_dicts(expected: Dict[str, Any], actual: Dict[str, Any], prefix: str = "") -> List[str]:
-    errors: List[str] = []
-    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
-    for key in all_keys:
-        path = f"{prefix}.{key}" if prefix else key
-        if key not in expected:
-            errors.append(f"Unexpected key in actual: {path}")
-            continue
-        if key not in actual:
-            errors.append(f"Missing key in actual: {path}")
-            continue
-        exp_val = expected[key]
-        act_val = actual[key]
-        if isinstance(exp_val, dict) and isinstance(act_val, dict):
-            errors.extend(compare_dicts(exp_val, act_val, prefix=path))
-            continue
-        if exp_val != act_val:
-            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
-    return errors
 
 
 def main(argv: Optional[List[str]] = None) -> None:

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st03b_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st03b_regression.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import compare_dicts, load_json
 from lyzortx.pipeline.steel_thread_v0.steps import (
     st01_label_policy,
     st01b_confidence_tiers,
@@ -38,11 +38,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument("--run-st03", action="store_true", help="Run ST0.3 before checking ST0.3b.")
     parser.add_argument("--run-st03b", action="store_true", help="Run ST0.3b before checking ST0.3b.")
     return parser.parse_args(argv)
-
-
-def load_json(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
 
 
 def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
@@ -81,27 +76,6 @@ def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
             "split_suite_assignments_csv_sha256": assignment_sha256,
         },
     }
-
-
-def compare_dicts(expected: Dict[str, Any], actual: Dict[str, Any], prefix: str = "") -> List[str]:
-    errors: List[str] = []
-    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
-    for key in all_keys:
-        path = f"{prefix}.{key}" if prefix else key
-        if key not in expected:
-            errors.append(f"Unexpected key in actual: {path}")
-            continue
-        if key not in actual:
-            errors.append(f"Missing key in actual: {path}")
-            continue
-        exp_val = expected[key]
-        act_val = actual[key]
-        if isinstance(exp_val, dict) and isinstance(act_val, dict):
-            errors.extend(compare_dicts(exp_val, act_val, prefix=path))
-            continue
-        if exp_val != act_val:
-            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
-    return errors
 
 
 def main(argv: Optional[List[str]] = None) -> None:

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st04_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st04_regression.py
@@ -4,13 +4,15 @@
 from __future__ import annotations
 
 import argparse
-import csv
-import json
-from math import isclose
-from numbers import Real
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import (
+    compare_dicts,
+    load_json,
+    read_csv_rows,
+)
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import safe_round
 from lyzortx.pipeline.steel_thread_v0.steps import (
     st01_label_policy,
     st01b_confidence_tiers,
@@ -44,27 +46,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def load_json(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def safe_round(value: float, ndigits: int = 6) -> float:
-    return round(float(value), ndigits)
-
-
-def is_real_number(value: object) -> bool:
-    return isinstance(value, Real) and not isinstance(value, bool)
-
-
-def read_prediction_rows(path: Path) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
-
-
 def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
     metrics_path = intermediate_dir / "st04_model_metrics_raw.json"
     artifacts_path = intermediate_dir / "st04_model_artifacts.json"
@@ -80,7 +61,7 @@ def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
 
     metrics = load_json(metrics_path)
     artifacts = load_json(artifacts_path)
-    prediction_rows = read_prediction_rows(predictions_path)
+    prediction_rows = read_csv_rows(predictions_path)
     if not prediction_rows:
         raise ValueError(f"Prediction CSV is empty: {predictions_path}")
 
@@ -119,33 +100,6 @@ def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
     }
 
 
-def compare_dicts(expected: Dict[str, Any], actual: Dict[str, Any], prefix: str = "") -> List[str]:
-    errors: List[str] = []
-    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
-    for key in all_keys:
-        path = f"{prefix}.{key}" if prefix else key
-        if key not in expected:
-            errors.append(f"Unexpected key in actual: {path}")
-            continue
-        if key not in actual:
-            errors.append(f"Missing key in actual: {path}")
-            continue
-        exp_val = expected[key]
-        act_val = actual[key]
-        if isinstance(exp_val, dict) and isinstance(act_val, dict):
-            errors.extend(compare_dicts(exp_val, act_val, prefix=path))
-            continue
-        if is_real_number(exp_val) and is_real_number(act_val):
-            if not isclose(float(exp_val), float(act_val), rel_tol=0.0, abs_tol=NUMERIC_TOLERANCE):
-                errors.append(
-                    f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}, tolerance={NUMERIC_TOLERANCE}"
-                )
-            continue
-        if exp_val != act_val:
-            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
-    return errors
-
-
 def main(argv: Optional[List[str]] = None) -> None:
     args = parse_args(argv)
 
@@ -162,7 +116,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     expected = load_json(args.expected_baseline_path)
     actual = build_actual_summary(args.intermediate_dir)
-    errors = compare_dicts(expected, actual)
+    errors = compare_dicts(expected, actual, numeric_tolerance=NUMERIC_TOLERANCE)
     if errors:
         print("ST0.4 regression check failed:")
         for err in errors:

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st05_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st05_regression.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import argparse
-import csv
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import (
+    compare_dicts,
+    load_json,
+    read_csv_rows,
+)
 from lyzortx.pipeline.steel_thread_v0.steps import (
     st01_label_policy,
     st01b_confidence_tiers,
@@ -40,19 +43,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument("--run-st04", action="store_true", help="Run ST0.4 before checking ST0.5.")
     parser.add_argument("--run-st05", action="store_true", help="Run ST0.5 before checking ST0.5.")
     return parser.parse_args(argv)
-
-
-def load_json(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def read_csv_rows(path: Path) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
 
 
 def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
@@ -97,27 +87,6 @@ def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
             "logreg_platt_coef": artifacts["models"]["logreg_host_phage"]["platt_coef"],
         },
     }
-
-
-def compare_dicts(expected: Dict[str, Any], actual: Dict[str, Any], prefix: str = "") -> List[str]:
-    errors: List[str] = []
-    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
-    for key in all_keys:
-        path = f"{prefix}.{key}" if prefix else key
-        if key not in expected:
-            errors.append(f"Unexpected key in actual: {path}")
-            continue
-        if key not in actual:
-            errors.append(f"Missing key in actual: {path}")
-            continue
-        exp_val = expected[key]
-        act_val = actual[key]
-        if isinstance(exp_val, dict) and isinstance(act_val, dict):
-            errors.extend(compare_dicts(exp_val, act_val, prefix=path))
-            continue
-        if exp_val != act_val:
-            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
-    return errors
 
 
 def main(argv: Optional[List[str]] = None) -> None:

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st06_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st06_regression.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import argparse
-import csv
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import (
+    compare_dicts,
+    load_json,
+    read_csv_rows,
+)
 from lyzortx.pipeline.steel_thread_v0.steps import (
     st01_label_policy,
     st01b_confidence_tiers,
@@ -44,19 +47,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def load_json(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def read_csv_rows(path: Path) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
-
-
 def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
     recs_path = intermediate_dir / "st06_top3_recommendations.csv"
     summary_path = intermediate_dir / "st06_recommendation_summary.json"
@@ -85,27 +75,6 @@ def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
             "diversity_mode": summary["parameters"]["diversity_mode"],
         },
     }
-
-
-def compare_dicts(expected: Dict[str, Any], actual: Dict[str, Any], prefix: str = "") -> List[str]:
-    errors: List[str] = []
-    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
-    for key in all_keys:
-        path = f"{prefix}.{key}" if prefix else key
-        if key not in expected:
-            errors.append(f"Unexpected key in actual: {path}")
-            continue
-        if key not in actual:
-            errors.append(f"Missing key in actual: {path}")
-            continue
-        exp_val = expected[key]
-        act_val = actual[key]
-        if isinstance(exp_val, dict) and isinstance(act_val, dict):
-            errors.extend(compare_dicts(exp_val, act_val, prefix=path))
-            continue
-        if exp_val != act_val:
-            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
-    return errors
 
 
 def main(argv: Optional[List[str]] = None) -> None:

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st07_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st07_regression.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import argparse
-import csv
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import (
+    compare_dicts,
+    count_csv_rows,
+    load_json,
+)
 from lyzortx.pipeline.steel_thread_v0.steps import (
     st01_label_policy,
     st01b_confidence_tiers,
@@ -46,19 +49,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def load_json(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def count_csv_rows(path: Path) -> int:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        return sum(1 for _ in reader)
-
-
 def build_actual_summary(output_dir: Path) -> Dict[str, Any]:
     metrics_path = output_dir / "metrics_summary.csv"
     top3_path = output_dir / "top3_recommendations.csv"
@@ -83,27 +73,6 @@ def build_actual_summary(output_dir: Path) -> Dict[str, Any]:
         },
         "manifest_counts": manifest["counts"],
     }
-
-
-def compare_dicts(expected: Dict[str, Any], actual: Dict[str, Any], prefix: str = "") -> List[str]:
-    errors: List[str] = []
-    all_keys = sorted(set(expected.keys()) | set(actual.keys()))
-    for key in all_keys:
-        path = f"{prefix}.{key}" if prefix else key
-        if key not in expected:
-            errors.append(f"Unexpected key in actual: {path}")
-            continue
-        if key not in actual:
-            errors.append(f"Missing key in actual: {path}")
-            continue
-        exp_val = expected[key]
-        act_val = actual[key]
-        if isinstance(exp_val, dict) and isinstance(act_val, dict):
-            errors.extend(compare_dicts(exp_val, act_val, prefix=path))
-            continue
-        if exp_val != act_val:
-            errors.append(f"Mismatch at {path}: expected={exp_val!r}, actual={act_val!r}")
-    return errors
 
 
 def main(argv: Optional[List[str]] = None) -> None:

--- a/lyzortx/pipeline/steel_thread_v0/steps/_io_helpers.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/_io_helpers.py
@@ -1,0 +1,53 @@
+"""Shared I/O helpers for steel-thread step scripts."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    """Load a JSON file and return its contents as a dict."""
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def read_csv_rows(path: Path, required_columns: Optional[Sequence[str]] = None) -> List[Dict[str, str]]:
+    """Read a CSV file into a list of dicts with stripped string values.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+    required_columns:
+        When provided, raise ``ValueError`` if any listed column is
+        missing from the CSV header.
+    """
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(f"No header found in {path}.")
+        if required_columns is not None:
+            missing = [column for column in required_columns if column not in reader.fieldnames]
+            if missing:
+                raise ValueError(f"Missing required columns in {path}: {', '.join(sorted(missing))}")
+        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
+
+
+def parse_float(value: str) -> Optional[float]:
+    """Parse a string to float, returning None for empty or unparseable values."""
+    if value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def safe_round(value: Optional[float], ndigits: int = 6) -> Optional[float]:
+    """Round a float to *ndigits* decimal places, passing through None."""
+    if value is None:
+        return None
+    return round(float(value), ndigits)

--- a/lyzortx/pipeline/steel_thread_v0/steps/st03b_build_split_suite.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st03b_build_split_suite.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import csv
 import hashlib
 from collections import Counter
 from datetime import datetime, timezone
@@ -12,6 +11,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows
 
 ST02_REQUIRED_COLUMNS: Sequence[str] = ("pair_id", "bacteria", "phage", "cv_group", "phage_family")
 ST03_REQUIRED_COLUMNS: Sequence[str] = ("pair_id", "split_holdout")
@@ -50,17 +50,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Deterministic salt for hash-based phage-family assignment.",
     )
     return parser.parse_args(argv)
-
-
-def read_csv_rows(path: Path, required_columns: Sequence[str]) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        missing = [column for column in required_columns if column not in reader.fieldnames]
-        if missing:
-            raise ValueError(f"Missing required columns in {path}: {', '.join(sorted(missing))}")
-        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
 
 
 def select_holdout_items(items: Sequence[str], holdout_fraction: float, split_salt: str) -> Set[str]:

--- a/lyzortx/pipeline/steel_thread_v0/steps/st04_train_baselines.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st04_train_baselines.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import csv
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,6 +15,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import average_precision_score, brier_score_loss, log_loss, roc_auc_score
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import parse_float, read_csv_rows, safe_round
 
 CATEGORICAL_FEATURE_COLUMNS = [
     "host_pathotype",
@@ -109,26 +109,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def read_csv_rows(path: Path) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        out: List[Dict[str, str]] = []
-        for row in reader:
-            out.append({k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()})
-        return out
-
-
-def parse_float(value: str) -> Optional[float]:
-    if value == "":
-        return None
-    try:
-        return float(value)
-    except ValueError:
-        return None
-
-
 def build_feature_dict(row: Dict[str, str]) -> Dict[str, object]:
     features: Dict[str, object] = {}
     for col in CATEGORICAL_FEATURE_COLUMNS:
@@ -140,12 +120,6 @@ def build_feature_dict(row: Dict[str, str]) -> Dict[str, object]:
         if parsed is not None:
             features[col] = parsed
     return features
-
-
-def safe_round(value: Optional[float]) -> Optional[float]:
-    if value is None:
-        return None
-    return round(float(value), 6)
 
 
 def compute_binary_metrics(y_true: List[int], y_prob: List[float]) -> Dict[str, Optional[float]]:

--- a/lyzortx/pipeline/steel_thread_v0/steps/st04b_ablation_suite.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st04b_ablation_suite.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import csv
 import hashlib
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -17,6 +16,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import average_precision_score, brier_score_loss, log_loss, roc_auc_score
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import parse_float, read_csv_rows, safe_round
 
 REQUIRED_ST02_COLUMNS = ("pair_id", "bacteria", "phage", "label_hard_any_lysis")
 REQUIRED_ST03B_COLUMNS = ("pair_id", "split_dual_axis")
@@ -48,32 +48,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument("--logreg-c", type=float, default=1.0)
     parser.add_argument("--logreg-max-iter", type=int, default=2000)
     return parser.parse_args(argv)
-
-
-def read_csv_rows(path: Path, required_columns: Sequence[str]) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        missing = [column for column in required_columns if column not in reader.fieldnames]
-        if missing:
-            raise ValueError(f"Missing required columns in {path}: {', '.join(sorted(missing))}")
-        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
-
-
-def parse_float(value: str) -> Optional[float]:
-    if value == "":
-        return None
-    try:
-        return float(value)
-    except ValueError:
-        return None
-
-
-def safe_round(value: Optional[float]) -> Optional[float]:
-    if value is None:
-        return None
-    return round(float(value), 6)
 
 
 def infer_feature_columns(columns: Iterable[str]) -> Dict[str, List[str]]:

--- a/lyzortx/pipeline/steel_thread_v0/steps/st05_calibrate_rank.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st05_calibrate_rank.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import csv
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,6 +15,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import brier_score_loss, log_loss
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
 
 MODEL_COLUMNS = {
     "dummy_prior": "pred_dummy_raw",
@@ -67,21 +67,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Random state for Platt-scaling logistic regression.",
     )
     return parser.parse_args(argv)
-
-
-def read_csv_rows(path: Path) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        out: List[Dict[str, str]] = []
-        for row in reader:
-            out.append({k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()})
-        return out
-
-
-def safe_round(value: float) -> float:
-    return round(float(value), 6)
 
 
 def ece_score(y_true: Sequence[int], y_prob: Sequence[float], n_bins: int) -> float:

--- a/lyzortx/pipeline/steel_thread_v0/steps/st06_recommend_top3.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st06_recommend_top3.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import csv
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +12,7 @@ from typing import Dict, List, Optional
 import numpy as np
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
@@ -60,18 +60,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Random seed for bootstrap CI sampling.",
     )
     return parser.parse_args(argv)
-
-
-def read_csv_rows(path: Path) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
-
-
-def safe_round(value: float) -> float:
-    return round(float(value), 6)
 
 
 def _slice_available_rows(rows: List[Dict[str, str]], slice_name: str) -> List[Dict[str, str]]:

--- a/lyzortx/pipeline/steel_thread_v0/steps/st06b_compare_ranking_policies.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st06b_compare_ranking_policies.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 import argparse
-import csv
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
 
 SCORE_COLUMNS: Tuple[Tuple[str, str], ...] = (
     ("logreg_raw", "pred_logreg_raw"),
@@ -46,18 +46,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Maximum recommendations from one phage family in family-capped policies.",
     )
     return parser.parse_args(argv)
-
-
-def read_csv_rows(path: Path) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
-
-
-def safe_round(value: float) -> float:
-    return round(float(value), 6)
 
 
 def select_topk_with_policy(

--- a/lyzortx/pipeline/steel_thread_v0/steps/st07_build_report.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st07_build_report.py
@@ -4,13 +4,12 @@
 from __future__ import annotations
 
 import argparse
-import csv
 import hashlib
-import json
 from pathlib import Path
 from typing import Dict, List, Optional
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import load_json, read_csv_rows
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
@@ -52,19 +51,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Output directory for final ST0.7 report artifacts.",
     )
     return parser.parse_args(argv)
-
-
-def read_csv_rows(path: Path) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
-
-
-def load_json(path: Path) -> Dict[str, object]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
 
 
 def sha256(path: Path) -> str:

--- a/lyzortx/pipeline/steel_thread_v0/steps/st08_tier_a_ingest_ablation.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st08_tier_a_ingest_ablation.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import csv
 import hashlib
 from collections import Counter
 from dataclasses import dataclass
@@ -13,6 +12,7 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows
 
 REQUIRED_INTERNAL_COLUMNS = ("pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier")
 REQUIRED_VHRDB_COLUMNS = (
@@ -89,17 +89,6 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate"),
     )
     return parser.parse_args(argv)
-
-
-def read_csv_rows(path: Path, required_columns: Sequence[str]) -> List[Dict[str, str]]:
-    with path.open("r", newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise ValueError(f"No header found in {path}.")
-        missing = [column for column in required_columns if column not in reader.fieldnames]
-        if missing:
-            raise ValueError(f"Missing required columns in {path}: {', '.join(sorted(missing))}")
-        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
 
 
 def key_for_pair(row: Dict[str, str]) -> Tuple[str, str]:

--- a/lyzortx/tests/test_shared_helpers.py
+++ b/lyzortx/tests/test_shared_helpers.py
@@ -1,0 +1,171 @@
+"""Tests for shared helper modules used across check and step scripts."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import (
+    compare_dicts,
+    count_csv_rows,
+    load_json,
+    read_csv_rows as check_read_csv_rows,
+)
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import (
+    load_json as step_load_json,
+    parse_float,
+    read_csv_rows as step_read_csv_rows,
+    safe_round,
+)
+
+
+# ---------------------------------------------------------------------------
+# compare_dicts
+# ---------------------------------------------------------------------------
+
+
+class TestCompareDicts:
+    def test_identical_dicts(self) -> None:
+        assert compare_dicts({"a": 1, "b": "x"}, {"a": 1, "b": "x"}) == []
+
+    def test_mismatch_value(self) -> None:
+        errors = compare_dicts({"a": 1}, {"a": 2})
+        assert len(errors) == 1
+        assert "Mismatch at a" in errors[0]
+
+    def test_missing_key_in_actual(self) -> None:
+        errors = compare_dicts({"a": 1, "b": 2}, {"a": 1})
+        assert len(errors) == 1
+        assert "Missing key in actual: b" in errors[0]
+
+    def test_unexpected_key_in_actual(self) -> None:
+        errors = compare_dicts({"a": 1}, {"a": 1, "b": 2})
+        assert len(errors) == 1
+        assert "Unexpected key in actual: b" in errors[0]
+
+    def test_nested_comparison(self) -> None:
+        expected = {"outer": {"inner": 10}}
+        actual = {"outer": {"inner": 20}}
+        errors = compare_dicts(expected, actual)
+        assert len(errors) == 1
+        assert "outer.inner" in errors[0]
+
+    def test_numeric_tolerance_pass(self) -> None:
+        errors = compare_dicts({"val": 1.0}, {"val": 1.000001}, numeric_tolerance=1e-5)
+        assert errors == []
+
+    def test_numeric_tolerance_fail(self) -> None:
+        errors = compare_dicts({"val": 1.0}, {"val": 1.1}, numeric_tolerance=1e-5)
+        assert len(errors) == 1
+        assert "tolerance" in errors[0]
+
+    def test_no_tolerance_exact_match_required(self) -> None:
+        errors = compare_dicts({"val": 1.0}, {"val": 1.000001})
+        assert len(errors) == 1
+
+    def test_bool_not_treated_as_numeric(self) -> None:
+        # bool is excluded from numeric tolerance path; True == 1 in Python
+        # so this passes as equal via the non-numeric branch
+        errors = compare_dicts({"flag": True}, {"flag": 1}, numeric_tolerance=1e-5)
+        assert errors == []
+        # But True != "true" (different types)
+        errors = compare_dicts({"flag": True}, {"flag": "true"}, numeric_tolerance=1e-5)
+        assert len(errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# load_json (both modules)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadJson:
+    def test_check_load_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.json"
+        p.write_text(json.dumps({"key": "value"}))
+        assert load_json(p) == {"key": "value"}
+
+    def test_step_load_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.json"
+        p.write_text(json.dumps({"num": 42}))
+        assert step_load_json(p) == {"num": 42}
+
+
+# ---------------------------------------------------------------------------
+# CSV helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_CSV = textwrap.dedent("""\
+    name,age,score
+    Alice, 30 , 9.5
+    Bob,25,8.0
+""")
+
+
+class TestReadCsvRows:
+    def test_check_read_csv_rows(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.csv"
+        p.write_text(SAMPLE_CSV)
+        rows = check_read_csv_rows(p)
+        assert len(rows) == 2
+        assert rows[0]["age"] == "30"  # stripped
+
+    def test_step_read_csv_rows_no_required(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.csv"
+        p.write_text(SAMPLE_CSV)
+        rows = step_read_csv_rows(p)
+        assert len(rows) == 2
+
+    def test_step_read_csv_rows_with_required_columns(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.csv"
+        p.write_text(SAMPLE_CSV)
+        rows = step_read_csv_rows(p, required_columns=["name", "age"])
+        assert len(rows) == 2
+
+    def test_step_read_csv_rows_missing_required(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.csv"
+        p.write_text(SAMPLE_CSV)
+        with pytest.raises(ValueError, match="Missing required columns"):
+            step_read_csv_rows(p, required_columns=["name", "nonexistent"])
+
+    def test_no_header_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty.csv"
+        p.write_text("")
+        with pytest.raises(ValueError, match="No header"):
+            check_read_csv_rows(p)
+
+
+class TestCountCsvRows:
+    def test_count(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.csv"
+        p.write_text(SAMPLE_CSV)
+        assert count_csv_rows(p) == 2
+
+
+# ---------------------------------------------------------------------------
+# parse_float / safe_round
+# ---------------------------------------------------------------------------
+
+
+class TestParseFloat:
+    def test_valid(self) -> None:
+        assert parse_float("3.14") == pytest.approx(3.14)
+
+    def test_empty(self) -> None:
+        assert parse_float("") is None
+
+    def test_invalid(self) -> None:
+        assert parse_float("abc") is None
+
+
+class TestSafeRound:
+    def test_round_value(self) -> None:
+        assert safe_round(3.14159265) == pytest.approx(3.141593)
+
+    def test_none_passthrough(self) -> None:
+        assert safe_round(None) is None
+
+    def test_custom_ndigits(self) -> None:
+        assert safe_round(3.14159, ndigits=2) == pytest.approx(3.14)


### PR DESCRIPTION
## Summary

- Extract `compare_dicts`, `load_json`, `read_csv_rows`, `count_csv_rows` into `checks/_check_helpers.py`
- Extract `read_csv_rows`, `safe_round`, `parse_float`, `load_json` into `steps/_io_helpers.py`
- Update all 9 check files and 8 step files to import from shared modules instead of defining locally
- Add unit tests for all shared helpers in `test_shared_helpers.py`
- Net result: ~450 lines removed, zero behavioral changes

## Test plan

- [x] All 133 existing tests pass (`pytest lyzortx/tests/ -x -q`)
- [x] All 20 modified/new modules import without error
- [x] 23 new unit tests for the shared helpers pass
- [x] CI passes on this PR

Generated with [Claude Code](https://claude.com/claude-code)