### PR TITLE
[ORCH][TC02] Build OMP receptor variant feature block

### DIFF
--- a/lyzortx/pipeline/track_c/steps/build_omp_receptor_variant_feature_block.py
+++ b/lyzortx/pipeline/track_c/steps/build_omp_receptor_variant_feature_block.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Build a bounded OMP receptor variant feature block from BLAST cluster assignments."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+
+RECEPTOR_COLUMNS: Tuple[str, ...] = (
+    "BTUB",
+    "FADL",
+    "FHUA",
+    "LAMB",
+    "LPTD",
+    "NFRA",
+    "OMPA",
+    "OMPC",
+    "OMPF",
+    "TOLC",
+    "TSX",
+    "YNCD",
+)
+
+METADATA_COLUMNS: Tuple[str, ...] = (
+    "column_name",
+    "receptor",
+    "grouped_category",
+    "global_selection_rank",
+    "receptor_selection_rank",
+    "support_count",
+    "support_rate",
+    "indicator_variance",
+    "grouped_source_clusters",
+    "source_path",
+    "source_column",
+    "transform",
+    "provenance_note",
+)
+
+
+@dataclass(frozen=True)
+class CategoryStat:
+    """Grouped category summary for one receptor."""
+
+    receptor: str
+    category: str
+    count: int
+    prevalence: float
+    variance: float
+    grouped_source_clusters: Tuple[str, ...]
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--receptor-clusters-path",
+        type=Path,
+        default=Path("data/genomics/bacteria/outer_membrane_proteins/blast_results_cured_clusters=99_wide.tsv"),
+        help="Tab-delimited BLAST cluster assignments for 12 OMP receptors.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_c/omp_receptor_variant_feature_block"),
+        help="Directory for generated Track C OMP receptor artifacts.",
+    )
+    parser.add_argument(
+        "--version",
+        type=str,
+        default="v1",
+        help="Version tag embedded in output file names and the manifest.",
+    )
+    parser.add_argument(
+        "--min-cluster-count",
+        type=int,
+        default=5,
+        help="Clusters observed fewer than this many times are grouped into a receptor-specific rare bucket.",
+    )
+    parser.add_argument(
+        "--max-feature-count",
+        type=int,
+        default=22,
+        help="Maximum number of one-hot receptor-variant features to emit, excluding the bacteria key.",
+    )
+    parser.add_argument(
+        "--expected-host-count",
+        type=int,
+        default=404,
+        help="Expected number of bacterial strains in the receptor cluster table.",
+    )
+    return parser.parse_args(argv)
+
+
+def read_delimited_rows(path: Path, delimiter: str) -> List[Dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter=delimiter)
+        if reader.fieldnames is None:
+            raise ValueError(f"No header found in {path}")
+        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
+
+
+def _index_unique(rows: Sequence[Mapping[str, str]], key: str, *, path: Path) -> Dict[str, Dict[str, str]]:
+    out: Dict[str, Dict[str, str]] = {}
+    for row in rows:
+        value = row.get(key, "")
+        if not value:
+            continue
+        if value in out:
+            raise ValueError(f"Duplicate {key} value {value!r} in {path}")
+        out[value] = dict(row)
+    return out
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _normalize_cluster(value: str) -> str:
+    return value.strip()
+
+
+def _feature_column_name(receptor: str, category: str) -> str:
+    receptor_label = receptor.lower()
+    if category == "rare":
+        suffix = "cluster_rare"
+    elif category == "missing":
+        suffix = "cluster_missing"
+    else:
+        suffix = f"cluster_{category.lower()}"
+    return f"host_omp_receptor_{receptor_label}_{suffix}"
+
+
+def _grouped_category(value: str, *, kept_clusters: Iterable[str]) -> str:
+    normalized = _normalize_cluster(value)
+    kept = set(kept_clusters)
+    if not normalized:
+        return "missing"
+    if normalized in kept:
+        return normalized
+    return "rare"
+
+
+def summarize_receptor_categories(
+    rows: Sequence[Mapping[str, str]],
+    *,
+    receptor_columns: Sequence[str] = RECEPTOR_COLUMNS,
+    min_cluster_count: int = 5,
+) -> Dict[str, Dict[str, object]]:
+    if min_cluster_count < 1:
+        raise ValueError("min_cluster_count must be >= 1")
+
+    row_count = len(rows)
+    summaries: Dict[str, Dict[str, object]] = {}
+    for receptor in receptor_columns:
+        cluster_counts = Counter(
+            _normalize_cluster(row.get(receptor, "")) for row in rows if _normalize_cluster(row.get(receptor, ""))
+        )
+        kept_cluster_counts = {
+            cluster: count
+            for cluster, count in sorted(cluster_counts.items(), key=lambda item: (-item[1], item[0]))
+            if count >= min_cluster_count
+        }
+        rare_clusters = tuple(
+            cluster
+            for cluster, count in sorted(cluster_counts.items(), key=lambda item: (-item[1], item[0]))
+            if count < min_cluster_count
+        )
+
+        grouped_counts: Counter[str] = Counter()
+        for row in rows:
+            grouped_counts[_grouped_category(row.get(receptor, ""), kept_clusters=kept_cluster_counts)] += 1
+
+        category_stats: List[CategoryStat] = []
+        for category, count in sorted(grouped_counts.items(), key=lambda item: (-item[1], item[0])):
+            prevalence = count / row_count if row_count else 0.0
+            grouped_source_clusters = (
+                rare_clusters if category == "rare" else ((category,) if category != "missing" else ())
+            )
+            category_stats.append(
+                CategoryStat(
+                    receptor=receptor,
+                    category=category,
+                    count=count,
+                    prevalence=prevalence,
+                    variance=prevalence * (1.0 - prevalence),
+                    grouped_source_clusters=grouped_source_clusters,
+                )
+            )
+
+        summaries[receptor] = {
+            "receptor": receptor,
+            "observed_cluster_count": len(cluster_counts),
+            "missing_count": grouped_counts.get("missing", 0),
+            "kept_cluster_counts": kept_cluster_counts,
+            "rare_clusters": rare_clusters,
+            "category_stats": category_stats,
+        }
+
+    return summaries
+
+
+def select_feature_categories(
+    summaries: Mapping[str, Mapping[str, object]],
+    *,
+    receptor_columns: Sequence[str] = RECEPTOR_COLUMNS,
+    max_feature_count: int = 22,
+) -> List[CategoryStat]:
+    receptor_count = len(receptor_columns)
+    if max_feature_count < receptor_count:
+        raise ValueError(
+            f"max_feature_count must be >= the number of receptors ({receptor_count}), got {max_feature_count}"
+        )
+
+    def sort_key(stat: CategoryStat) -> Tuple[float, int, str, str]:
+        return (-stat.variance, -stat.count, stat.receptor, stat.category)
+
+    selected: Dict[Tuple[str, str], CategoryStat] = {}
+    for receptor in receptor_columns:
+        category_stats = list(summaries[receptor]["category_stats"])
+        non_missing = [stat for stat in category_stats if stat.category != "missing"]
+        candidates = non_missing if non_missing else category_stats
+        mandatory = sorted(candidates, key=sort_key)[0]
+        selected[(mandatory.receptor, mandatory.category)] = mandatory
+
+    extra_candidates: List[CategoryStat] = []
+    for receptor in receptor_columns:
+        for stat in summaries[receptor]["category_stats"]:
+            key = (stat.receptor, stat.category)
+            if key in selected:
+                continue
+            extra_candidates.append(stat)
+
+    remaining_slots = max_feature_count - len(selected)
+    for stat in sorted(extra_candidates, key=sort_key)[:remaining_slots]:
+        selected[(stat.receptor, stat.category)] = stat
+
+    selected_by_receptor: List[CategoryStat] = []
+    for receptor in receptor_columns:
+        receptor_stats = [stat for stat in selected.values() if stat.receptor == receptor]
+        receptor_stats.sort(key=sort_key)
+        selected_by_receptor.extend(receptor_stats)
+    return selected_by_receptor
+
+
+def build_feature_rows(
+    receptor_rows: Sequence[Mapping[str, str]],
+    summaries: Mapping[str, Mapping[str, object]],
+    selected_categories: Sequence[CategoryStat],
+) -> List[Dict[str, object]]:
+    field_order = ["bacteria"] + [_feature_column_name(stat.receptor, stat.category) for stat in selected_categories]
+    output_rows: List[Dict[str, object]] = []
+
+    bacteria_index = _index_unique(receptor_rows, "bacteria", path=Path("<in-memory receptor rows>"))
+    for bacteria in sorted(bacteria_index):
+        receptor_row = bacteria_index[bacteria]
+        encoded_row: Dict[str, object] = {"bacteria": bacteria}
+        for stat in selected_categories:
+            grouped_value = _grouped_category(
+                receptor_row.get(stat.receptor, ""),
+                kept_clusters=summaries[stat.receptor]["kept_cluster_counts"].keys(),
+            )
+            encoded_row[_feature_column_name(stat.receptor, stat.category)] = int(grouped_value == stat.category)
+        output_rows.append({column: encoded_row[column] for column in field_order})
+
+    return output_rows
+
+
+def build_metadata_rows(
+    selected_categories: Sequence[CategoryStat],
+    *,
+    source_path: Path,
+    min_cluster_count: int,
+) -> List[Dict[str, object]]:
+    global_rank_lookup = {
+        (stat.receptor, stat.category): rank for rank, stat in enumerate(selected_categories, start=1)
+    }
+    receptor_rank_lookup: Dict[Tuple[str, str], int] = {}
+    for receptor in RECEPTOR_COLUMNS:
+        receptor_stats = [stat for stat in selected_categories if stat.receptor == receptor]
+        for rank, stat in enumerate(receptor_stats, start=1):
+            receptor_rank_lookup[(stat.receptor, stat.category)] = rank
+
+    metadata_rows: List[Dict[str, object]] = []
+    for stat in selected_categories:
+        if stat.category == "rare":
+            transform = (
+                "1 when the receptor cluster assignment falls into the receptor-specific grouped rare bucket "
+                f"(support < {min_cluster_count}), else 0."
+            )
+            note = "Rare bucket groups low-support source clusters before feature selection."
+        elif stat.category == "missing":
+            transform = "1 when the receptor cluster assignment is missing, else 0."
+            note = "Missingness is encoded only when it survives the global feature budget."
+        else:
+            transform = f"1 when the receptor cluster assignment equals {stat.category}, else 0."
+            note = "Cluster IDs come from 99% identity BLAST clusters."
+
+        metadata_rows.append(
+            {
+                "column_name": _feature_column_name(stat.receptor, stat.category),
+                "receptor": stat.receptor,
+                "grouped_category": stat.category,
+                "global_selection_rank": global_rank_lookup[(stat.receptor, stat.category)],
+                "receptor_selection_rank": receptor_rank_lookup[(stat.receptor, stat.category)],
+                "support_count": stat.count,
+                "support_rate": round(stat.prevalence, 6),
+                "indicator_variance": round(stat.variance, 6),
+                "grouped_source_clusters": json.dumps(list(stat.grouped_source_clusters)),
+                "source_path": str(source_path),
+                "source_column": stat.receptor,
+                "transform": transform,
+                "provenance_note": note,
+            }
+        )
+    return metadata_rows
+
+
+def build_manifest(
+    *,
+    version: str,
+    receptor_rows: Sequence[Mapping[str, str]],
+    summaries: Mapping[str, Mapping[str, object]],
+    selected_categories: Sequence[CategoryStat],
+    receptor_clusters_path: Path,
+    matrix_output_path: Path,
+    metadata_output_path: Path,
+    min_cluster_count: int,
+    max_feature_count: int,
+) -> Dict[str, object]:
+    selected_by_receptor: Dict[str, List[str]] = {receptor: [] for receptor in RECEPTOR_COLUMNS}
+    for stat in selected_categories:
+        selected_by_receptor[stat.receptor].append(stat.category)
+
+    receptor_summary = {}
+    for receptor in RECEPTOR_COLUMNS:
+        summary = summaries[receptor]
+        receptor_summary[receptor] = {
+            "observed_cluster_count": summary["observed_cluster_count"],
+            "missing_count": summary["missing_count"],
+            "retained_clusters": list(summary["kept_cluster_counts"].keys()),
+            "rare_clusters": list(summary["rare_clusters"]),
+            "selected_grouped_categories": selected_by_receptor[receptor],
+            "selected_feature_columns": [
+                _feature_column_name(receptor, category) for category in selected_by_receptor[receptor]
+            ],
+        }
+
+    return {
+        "version": version,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "host_count": len(receptor_rows),
+        "receptor_count": len(RECEPTOR_COLUMNS),
+        "feature_count": len(selected_categories),
+        "encoding_policy": {
+            "source": "blast_results_cured_clusters=99_wide.tsv",
+            "rare_cluster_min_count": min_cluster_count,
+            "max_feature_count": max_feature_count,
+            "selection_rule": (
+                "Keep one non-missing grouped category per receptor, then add the highest-variance remaining grouped "
+                "categories globally until the feature budget is exhausted."
+            ),
+            "grouping_rule": (
+                "Cluster IDs with support below the rare_cluster_min_count threshold are mapped to receptor-specific "
+                "rare buckets before one-hot selection."
+            ),
+        },
+        "schema": {
+            "matrix_columns": ["bacteria"]
+            + [_feature_column_name(stat.receptor, stat.category) for stat in selected_categories],
+            "receptor_columns": list(RECEPTOR_COLUMNS),
+        },
+        "inputs": {
+            "receptor_clusters": {"path": str(receptor_clusters_path), "sha256": _sha256(receptor_clusters_path)},
+        },
+        "outputs": {
+            "matrix_csv": str(matrix_output_path),
+            "column_metadata_csv": str(metadata_output_path),
+        },
+        "receptors": receptor_summary,
+    }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    receptor_rows = read_delimited_rows(args.receptor_clusters_path, delimiter="\t")
+
+    if len(receptor_rows) != args.expected_host_count:
+        raise ValueError(
+            f"Expected {args.expected_host_count} hosts in {args.receptor_clusters_path}, found {len(receptor_rows)}"
+        )
+
+    summaries = summarize_receptor_categories(
+        receptor_rows,
+        receptor_columns=RECEPTOR_COLUMNS,
+        min_cluster_count=args.min_cluster_count,
+    )
+    selected_categories = select_feature_categories(
+        summaries,
+        receptor_columns=RECEPTOR_COLUMNS,
+        max_feature_count=args.max_feature_count,
+    )
+
+    feature_rows = build_feature_rows(receptor_rows, summaries, selected_categories)
+
+    ensure_directory(args.output_dir)
+    matrix_output_path = args.output_dir / f"host_omp_receptor_variant_features_{args.version}.csv"
+    metadata_output_path = args.output_dir / f"host_omp_receptor_variant_feature_metadata_{args.version}.csv"
+    manifest_output_path = args.output_dir / f"host_omp_receptor_variant_feature_manifest_{args.version}.json"
+
+    write_csv(
+        matrix_output_path,
+        ["bacteria"] + [_feature_column_name(stat.receptor, stat.category) for stat in selected_categories],
+        feature_rows,
+    )
+    write_csv(
+        metadata_output_path,
+        METADATA_COLUMNS,
+        build_metadata_rows(
+            selected_categories,
+            source_path=args.receptor_clusters_path,
+            min_cluster_count=args.min_cluster_count,
+        ),
+    )
+    write_json(
+        manifest_output_path,
+        build_manifest(
+            version=args.version,
+            receptor_rows=receptor_rows,
+            summaries=summaries,
+            selected_categories=selected_categories,
+            receptor_clusters_path=args.receptor_clusters_path,
+            matrix_output_path=matrix_output_path,
+            metadata_output_path=metadata_output_path,
+            min_cluster_count=args.min_cluster_count,
+            max_feature_count=args.max_feature_count,
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lyzortx/research_notes/lab_notebooks/track_C.md
+++ b/lyzortx/research_notes/lab_notebooks/track_C.md
@@ -70,3 +70,76 @@
    later pairwise compatibility work.
 5. `TonB` is still an explicit source gap. Leaving it silently absent would hide a real repository limitation, so the
    current builder surfaces that gap directly in both the matrix and the metadata manifest.
+
+### 2026-03-21: TC02 OMP receptor variant feature block
+
+#### What was implemented
+
+- Added a dedicated Track C OMP-cluster builder:
+  `lyzortx/pipeline/track_c/steps/build_omp_receptor_variant_feature_block.py`.
+- Configured the step to write generated outputs under
+  `lyzortx/generated_outputs/track_c/omp_receptor_variant_feature_block/`:
+  - `host_omp_receptor_variant_features_v1.csv`
+  - `host_omp_receptor_variant_feature_metadata_v1.csv`
+  - `host_omp_receptor_variant_feature_manifest_v1.json`
+- Ingested the full `blast_results_cured_clusters=99_wide.tsv` table directly, preserving the requested `404`-strain
+  host panel and the full set of `12` receptor proteins (`BTUB`, `FADL`, `FHUA`, `LAMB`, `LPTD`, `NFRA`, `OMPA`,
+  `OMPC`, `OMPF`, `TOLC`, `TSX`, `YNCD`).
+- Implemented a bounded categorical encoding policy:
+  - receptor clusters observed in fewer than `5` hosts are grouped into receptor-specific `rare` buckets
+  - one grouped category is always retained per receptor
+  - additional grouped categories are added by descending Bernoulli indicator variance until the feature budget is
+    exhausted
+- Added regression tests in `lyzortx/tests/test_omp_receptor_variant_feature_block.py` covering rare-cluster grouping,
+  feature-budgeted selection, row-level encoding, and end-to-end file emission.
+
+#### Output summary
+
+- Final matrix size: `404` host rows x `22` receptor features, plus the `bacteria` join key.
+- Receptor diversity in the source BLAST table:
+  - `BTUB`: `29` observed clusters, `1` missing host
+  - `FADL`: `12` observed clusters, `0` missing hosts
+  - `FHUA`: `20` observed clusters, `1` missing host
+  - `LAMB`: `11` observed clusters, `4` missing hosts
+  - `LPTD`: `11` observed clusters, `0` missing hosts
+  - `NFRA`: `62` observed clusters, `7` missing hosts
+  - `OMPA`: `11` observed clusters, `0` missing hosts
+  - `OMPC`: `52` observed clusters, `1` missing host
+  - `OMPF`: `14` observed clusters, `7` missing hosts
+  - `TOLC`: `10` observed clusters, `2` missing hosts
+  - `TSX`: `4` observed clusters, `2` missing hosts
+  - `YNCD`: `55` observed clusters, `11` missing hosts
+- Selected grouped categories by receptor:
+  - `BTUB`: `99_6`, `99_15`
+  - `FADL`: `99_1`, `99_17`
+  - `FHUA`: `99_5`
+  - `LAMB`: `99_10`, `99_9`, `99_19`
+  - `LPTD`: `99_3`, `99_8`
+  - `NFRA`: `99_14`, `99_18`, `rare`
+  - `OMPA`: `99_13`, `99_16`
+  - `OMPC`: `99_24`
+  - `OMPF`: `99_4`, `99_12`
+  - `TOLC`: `99_0`
+  - `TSX`: `99_2`, `99_11`
+  - `YNCD`: `99_7`
+- Highest-support emitted indicators:
+  - `host_omp_receptor_tolc_cluster_99_0`: `367` hosts
+  - `host_omp_receptor_fadl_cluster_99_1`: `290` hosts
+  - `host_omp_receptor_tsx_cluster_99_2`: `267` hosts
+  - `host_omp_receptor_lptd_cluster_99_3`: `235` hosts
+  - `host_omp_receptor_ompf_cluster_99_4`: `209` hosts
+- Grouped rare buckets were mostly compressed away by the global feature budget; only `NFRA`'s grouped `rare` bucket
+  survived as a final indicator (`67` hosts).
+
+#### Interpretation
+
+1. The acceptance target of `~20` receptor features is only feasible with aggressive categorical compression. The raw
+   source table contains `291` non-missing receptor-cluster states across the 12 proteins, so a naive full one-hot
+   expansion would be mostly noise and would violate the requested block size.
+2. Most of the usable signal is concentrated in a small number of common receptor variants. The selected `22` columns
+   capture the dominant structure in each receptor while still preserving one explicit grouped-rare signal for the most
+   diverse locus (`NFRA`).
+3. Receptor heterogeneity is highly uneven across loci. `TSX`, `TOLC`, and `LPTD` are dominated by one or two major
+   variants, while `NFRA`, `OMPC`, and `YNCD` remain much more fragmented even after support-based rare clustering.
+4. The emitted block is ready for downstream joins on `bacteria`, but the manifest should remain the source of truth
+   for interpretation because grouped categories are a lossy compression of the original BLAST cluster table.

--- a/lyzortx/tests/test_omp_receptor_variant_feature_block.py
+++ b/lyzortx/tests/test_omp_receptor_variant_feature_block.py
@@ -1,0 +1,134 @@
+import csv
+import json
+from pathlib import Path
+
+from lyzortx.pipeline.track_c.steps.build_omp_receptor_variant_feature_block import (
+    CategoryStat,
+    build_feature_rows,
+    main,
+    select_feature_categories,
+    summarize_receptor_categories,
+)
+
+
+def test_summarize_receptor_categories_groups_low_support_clusters_to_rare() -> None:
+    rows = [
+        {"bacteria": "B1", "BTUB": "99_1", "FADL": "99_7"},
+        {"bacteria": "B2", "BTUB": "99_1", "FADL": "99_7"},
+        {"bacteria": "B3", "BTUB": "99_2", "FADL": "99_8"},
+        {"bacteria": "B4", "BTUB": "99_3", "FADL": ""},
+    ]
+
+    summaries = summarize_receptor_categories(rows, receptor_columns=("BTUB", "FADL"), min_cluster_count=2)
+
+    assert summaries["BTUB"]["kept_cluster_counts"] == {"99_1": 2}
+    assert summaries["BTUB"]["rare_clusters"] == ("99_2", "99_3")
+    btub_stats = {stat.category: stat for stat in summaries["BTUB"]["category_stats"]}
+    assert btub_stats["rare"].count == 2
+    assert summaries["FADL"]["missing_count"] == 1
+
+
+def test_select_feature_categories_keeps_one_per_receptor_and_respects_budget() -> None:
+    summaries = {
+        "BTUB": {
+            "category_stats": [
+                CategoryStat("BTUB", "99_1", 6, 0.5, 0.25, ("99_1",)),
+                CategoryStat("BTUB", "rare", 3, 0.25, 0.1875, ("99_7", "99_8")),
+                CategoryStat("BTUB", "missing", 3, 0.25, 0.1875, ()),
+            ]
+        },
+        "FADL": {
+            "category_stats": [
+                CategoryStat("FADL", "99_9", 5, 0.416667, 0.243056, ("99_9",)),
+                CategoryStat("FADL", "rare", 4, 0.333333, 0.222222, ("99_10",)),
+                CategoryStat("FADL", "missing", 3, 0.25, 0.1875, ()),
+            ]
+        },
+    }
+
+    selected = select_feature_categories(
+        summaries,
+        receptor_columns=("BTUB", "FADL"),
+        max_feature_count=3,
+    )
+
+    assert [(stat.receptor, stat.category) for stat in selected] == [
+        ("BTUB", "99_1"),
+        ("FADL", "99_9"),
+        ("FADL", "rare"),
+    ]
+
+
+def test_build_feature_rows_emits_selected_indicator_columns() -> None:
+    rows = [
+        {"bacteria": "B2", "BTUB": "99_1", "FADL": ""},
+        {"bacteria": "B1", "BTUB": "99_7", "FADL": "99_9"},
+    ]
+    summaries = summarize_receptor_categories(rows, receptor_columns=("BTUB", "FADL"), min_cluster_count=2)
+    selected = [
+        CategoryStat("BTUB", "rare", 1, 0.5, 0.25, ("99_1", "99_7")),
+        CategoryStat("FADL", "missing", 1, 0.5, 0.25, ()),
+    ]
+
+    feature_rows = build_feature_rows(rows, summaries, selected)
+
+    assert [row["bacteria"] for row in feature_rows] == ["B1", "B2"]
+    assert feature_rows[0]["host_omp_receptor_btub_cluster_rare"] == 1
+    assert feature_rows[0]["host_omp_receptor_fadl_cluster_missing"] == 0
+    assert feature_rows[1]["host_omp_receptor_fadl_cluster_missing"] == 1
+
+
+def test_main_writes_matrix_metadata_and_manifest(tmp_path: Path) -> None:
+    receptor_path = tmp_path / "receptors.tsv"
+    output_dir = tmp_path / "out"
+
+    receptor_path.write_text(
+        (
+            "bacteria\tBTUB\tFADL\tFHUA\tLAMB\tLPTD\tNFRA\tOMPA\tOMPC\tOMPF\tTOLC\tTSX\tYNCD\n"
+            "B1\t99_1\t99_7\t99_4\t99_5\t99_6\t99_7\t99_8\t99_9\t99_10\t99_11\t99_12\t99_13\n"
+            "B2\t99_1\t99_7\t99_4\t99_5\t99_6\t99_7\t99_8\t99_9\t99_10\t99_11\t99_12\t99_13\n"
+            "B3\t99_2\t99_8\t99_4\t99_5\t99_6\t99_7\t99_8\t99_9\t99_10\t99_11\t99_14\t99_15\n"
+            "B4\t\t99_8\t99_16\t99_17\t99_18\t99_19\t99_20\t99_21\t99_22\t99_23\t\t99_24\n"
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--receptor-clusters-path",
+            str(receptor_path),
+            "--output-dir",
+            str(output_dir),
+            "--version",
+            "test",
+            "--min-cluster-count",
+            "2",
+            "--max-feature-count",
+            "12",
+            "--expected-host-count",
+            "4",
+        ]
+    )
+
+    assert exit_code == 0
+
+    matrix_path = output_dir / "host_omp_receptor_variant_features_test.csv"
+    metadata_path = output_dir / "host_omp_receptor_variant_feature_metadata_test.csv"
+    manifest_path = output_dir / "host_omp_receptor_variant_feature_manifest_test.json"
+
+    with matrix_path.open("r", encoding="utf-8", newline="") as handle:
+        matrix_rows = list(csv.DictReader(handle))
+    with metadata_path.open("r", encoding="utf-8", newline="") as handle:
+        metadata_rows = list(csv.DictReader(handle))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert len(matrix_rows) == 4
+    assert matrix_rows[0]["bacteria"] == "B1"
+    assert len(matrix_rows[0]) == 13
+    assert any(row["receptor"] == "BTUB" for row in metadata_rows)
+    rare_rows = [row for row in metadata_rows if row["grouped_category"] == "rare"]
+    assert all("support < 2" in row["transform"] for row in rare_rows)
+    assert manifest["host_count"] == 4
+    assert manifest["feature_count"] == 12
+    assert manifest["encoding_policy"]["rare_cluster_min_count"] == 2
+    assert manifest["receptors"]["BTUB"]["retained_clusters"] == ["99_1"]


### PR DESCRIPTION
## Summary
- add a dedicated Track C builder for the 404-host OMP receptor BLAST cluster table
- group low-support receptor clusters into receptor-specific rare buckets and emit a bounded 22-feature one-hot block
- add regression tests for grouping, feature selection, row encoding, and end-to-end artifact generation
- document implementation details, output shape, and interpretation in the Track C lab notebook

## Testing
- pytest -q lyzortx/tests/

Closes #76
