### PR TITLE
[ORCH][TC03] Build extended host surface features

### DIFF
--- a/lyzortx/pipeline/track_c/steps/build_extended_host_surface_feature_block.py
+++ b/lyzortx/pipeline/track_c/steps/build_extended_host_surface_feature_block.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Build extended Track C host surface features from capsule, LPS, and UMAP inputs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+
+UMAP_COLUMNS: Sequence[str] = tuple(f"UMAP{index}" for index in range(8))
+FEATURE_COLUMNS: Sequence[str] = (
+    "bacteria",
+    "host_surface_klebsiella_capsule_type",
+    "host_surface_klebsiella_capsule_type_missing",
+    "host_surface_lps_core_type",
+    "host_phylogeny_umap_00",
+    "host_phylogeny_umap_01",
+    "host_phylogeny_umap_02",
+    "host_phylogeny_umap_03",
+    "host_phylogeny_umap_04",
+    "host_phylogeny_umap_05",
+    "host_phylogeny_umap_06",
+    "host_phylogeny_umap_07",
+)
+METADATA_COLUMNS: Sequence[str] = (
+    "column_name",
+    "feature_group",
+    "feature_type",
+    "source_path",
+    "source_column",
+    "transform",
+    "missing_count",
+    "missing_rate",
+    "provenance_note",
+)
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--umap-path",
+        type=Path,
+        default=Path("data/genomics/bacteria/umap_phylogeny/coli_umap_8_dims.tsv"),
+        help="Tab-delimited 8D host UMAP embedding table.",
+    )
+    parser.add_argument(
+        "--capsule-path",
+        type=Path,
+        default=Path("data/genomics/bacteria/capsules/klebsiella_capsules/kaptive_results_high_hits_cured.txt"),
+        help="Tab-delimited Klebsiella capsule typing table.",
+    )
+    parser.add_argument(
+        "--lps-primary-path",
+        type=Path,
+        default=Path("data/genomics/bacteria/outer_core_lps/LPS_type_waaL_370.txt"),
+        help="Primary tab-delimited LPS core annotation table.",
+    )
+    parser.add_argument(
+        "--lps-supplemental-path",
+        type=Path,
+        default=Path("data/genomics/bacteria/outer_core_lps/LPS_type_waaL_host.txt"),
+        help="Supplemental tab-delimited LPS core annotation table for the non-370 host subset.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_c/extended_host_surface_feature_block"),
+        help="Directory for generated Track C extended host surface artifacts.",
+    )
+    parser.add_argument(
+        "--version",
+        type=str,
+        default="v1",
+        help="Version tag embedded in output file names and the manifest.",
+    )
+    parser.add_argument(
+        "--expected-host-count",
+        type=int,
+        default=404,
+        help="Expected number of strains in the output host feature matrix.",
+    )
+    return parser.parse_args(argv)
+
+
+def read_delimited_rows(path: Path, delimiter: str) -> List[Dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter=delimiter)
+        if reader.fieldnames is None:
+            raise ValueError(f"No header found in {path}")
+        return [{k: (v.strip() if isinstance(v, str) else "") for k, v in row.items()} for row in reader]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _normalize_category(value: str) -> str:
+    normalized = value.strip()
+    if normalized in {"", "-", "Unknown"}:
+        return ""
+    return normalized
+
+
+def _index_unique(rows: Sequence[Mapping[str, str]], key: str, *, path: Path) -> Dict[str, Dict[str, str]]:
+    index: Dict[str, Dict[str, str]] = {}
+    for row in rows:
+        value = row.get(key, "")
+        if not value:
+            continue
+        if value in index:
+            raise ValueError(f"Duplicate {key} value {value!r} in {path}")
+        index[value] = dict(row)
+    return index
+
+
+def build_capsule_index(capsule_rows: Sequence[Mapping[str, str]]) -> Dict[str, Dict[str, str]]:
+    capsule_index = _index_unique(capsule_rows, "bacteria", path=Path("<in-memory capsule rows>"))
+    return {
+        bacteria: {"klebsiella_capsule_type": _normalize_category(row.get("Klebs_capsule_type", ""))}
+        for bacteria, row in capsule_index.items()
+    }
+
+
+def build_lps_core_index(
+    primary_rows: Sequence[Mapping[str, str]],
+    supplemental_rows: Sequence[Mapping[str, str]],
+) -> Dict[str, Dict[str, str]]:
+    index: Dict[str, Dict[str, str]] = {}
+    for row in primary_rows:
+        bacteria = row.get("bacteria", "").strip()
+        if not bacteria:
+            continue
+        lps_core_type = _normalize_category(row.get("LPS_type", ""))
+        if not lps_core_type:
+            continue
+        index[bacteria] = {"lps_core_type": lps_core_type, "source_table": "primary"}
+
+    for row in supplemental_rows:
+        bacteria = row.get("Strain", "").strip()
+        if not bacteria:
+            continue
+        lps_core_type = _normalize_category(row.get("LPS_type", ""))
+        if not lps_core_type:
+            continue
+        existing = index.get(bacteria)
+        if existing is not None and existing["lps_core_type"] != lps_core_type:
+            raise ValueError(
+                f"Conflicting LPS core annotations for {bacteria!r}: {existing['lps_core_type']} vs {lps_core_type}"
+            )
+        if existing is None:
+            index[bacteria] = {"lps_core_type": lps_core_type, "source_table": "supplemental"}
+    return index
+
+
+def build_feature_rows(
+    *,
+    umap_rows: Sequence[Mapping[str, str]],
+    capsule_index: Mapping[str, Mapping[str, str]],
+    lps_index: Mapping[str, Mapping[str, str]],
+) -> List[Dict[str, object]]:
+    ordered_rows = sorted(umap_rows, key=lambda row: row["bacteria"])
+    feature_rows: List[Dict[str, object]] = []
+
+    for row in ordered_rows:
+        bacteria = row["bacteria"]
+        lps_record = lps_index.get(bacteria)
+        if lps_record is None:
+            raise KeyError(f"Missing LPS core annotation for {bacteria}")
+
+        capsule_type = ""
+        if bacteria in capsule_index:
+            capsule_type = _normalize_category(capsule_index[bacteria].get("klebsiella_capsule_type", ""))
+
+        feature_row: Dict[str, object] = {
+            "bacteria": bacteria,
+            "host_surface_klebsiella_capsule_type": capsule_type,
+            "host_surface_klebsiella_capsule_type_missing": int(not capsule_type),
+            "host_surface_lps_core_type": lps_record["lps_core_type"],
+        }
+
+        for index, source_column in enumerate(UMAP_COLUMNS):
+            try:
+                feature_row[f"host_phylogeny_umap_{index:02d}"] = float(row[source_column])
+            except KeyError as exc:
+                raise KeyError(f"Missing {source_column} column in UMAP row for {bacteria}") from exc
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid {source_column} value for {bacteria}: {row.get(source_column, '')!r}"
+                ) from exc
+
+        feature_rows.append(feature_row)
+
+    return feature_rows
+
+
+def build_metadata_rows(
+    *,
+    feature_rows: Sequence[Mapping[str, object]],
+    args: argparse.Namespace,
+) -> List[Dict[str, object]]:
+    host_count = len(feature_rows)
+    metadata_rows: List[Dict[str, object]] = []
+
+    definitions = {
+        "host_surface_klebsiella_capsule_type": {
+            "feature_group": "surface_antigen",
+            "feature_type": "categorical",
+            "source_path": str(args.capsule_path),
+            "source_column": "Klebs_capsule_type",
+            "transform": "Copy Klebsiella capsule type from the Kaptive-derived call table; normalize blank/Unknown to empty.",
+            "provenance_note": "Sparse Klebsiella-type capsule calls; paired missingness indicator retained for downstream joins.",
+        },
+        "host_surface_klebsiella_capsule_type_missing": {
+            "feature_group": "surface_antigen",
+            "feature_type": "binary",
+            "source_path": str(args.capsule_path),
+            "source_column": "Klebs_capsule_type",
+            "transform": "1 when host_surface_klebsiella_capsule_type is empty, else 0.",
+            "provenance_note": "Explicit missingness flag for incomplete Klebsiella capsule coverage.",
+        },
+        "host_surface_lps_core_type": {
+            "feature_group": "surface_antigen",
+            "feature_type": "categorical",
+            "source_path": f"{args.lps_primary_path};{args.lps_supplemental_path}",
+            "source_column": "LPS_type",
+            "transform": "Prefer the primary waaL 370 table; backfill missing hosts from the supplemental host table after conflict checks.",
+            "provenance_note": "Combined curated waaL tables provide complete coverage for the 404-host UMAP panel.",
+        },
+    }
+    for index in range(8):
+        definitions[f"host_phylogeny_umap_{index:02d}"] = {
+            "feature_group": "phylogeny_embedding",
+            "feature_type": "continuous",
+            "source_path": str(args.umap_path),
+            "source_column": f"UMAP{index}",
+            "transform": f"Cast UMAP{index} to float and retain the original 8D phylogenomic embedding coordinate.",
+            "provenance_note": "The output host contract is anchored to the complete UMAP panel.",
+        }
+
+    for column_name in FEATURE_COLUMNS[1:]:
+        missing_count = sum(
+            1
+            for row in feature_rows
+            if row[column_name] in {"", None} or (column_name.endswith("_missing") and int(row[column_name]) == 1)
+        )
+        if column_name.endswith("_missing"):
+            missing_count = sum(int(row[column_name]) for row in feature_rows)
+        metadata_rows.append(
+            {
+                "column_name": column_name,
+                **definitions[column_name],
+                "missing_count": missing_count,
+                "missing_rate": round(missing_count / host_count, 6) if host_count else 0.0,
+            }
+        )
+    return metadata_rows
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+
+    umap_rows = read_delimited_rows(args.umap_path, "\t")
+    capsule_rows = read_delimited_rows(args.capsule_path, "\t")
+    lps_primary_rows = read_delimited_rows(args.lps_primary_path, "\t")
+    lps_supplemental_rows = read_delimited_rows(args.lps_supplemental_path, "\t")
+
+    if len(umap_rows) != args.expected_host_count:
+        raise ValueError(f"Expected {args.expected_host_count} rows in {args.umap_path}, found {len(umap_rows)}")
+
+    capsule_index = build_capsule_index(capsule_rows)
+    lps_index = build_lps_core_index(lps_primary_rows, lps_supplemental_rows)
+    feature_rows = build_feature_rows(
+        umap_rows=umap_rows,
+        capsule_index=capsule_index,
+        lps_index=lps_index,
+    )
+    metadata_rows = build_metadata_rows(feature_rows=feature_rows, args=args)
+
+    host_count = len(feature_rows)
+    capsule_observed_hosts = sum(1 for row in feature_rows if row["host_surface_klebsiella_capsule_type"])
+    source_breakdown = Counter(lps_index[row["bacteria"]]["source_table"] for row in feature_rows)
+    capsule_type_counts = Counter(
+        str(row["host_surface_klebsiella_capsule_type"])
+        for row in feature_rows
+        if row["host_surface_klebsiella_capsule_type"]
+    )
+
+    manifest = {
+        "version": args.version,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "host_count": host_count,
+        "feature_count": len(FEATURE_COLUMNS) - 1,
+        "output_schema": list(FEATURE_COLUMNS),
+        "coverage": {
+            "klebsiella_capsule_type": {
+                "observed_hosts": capsule_observed_hosts,
+                "missing_hosts": host_count - capsule_observed_hosts,
+                "missing_rate": round((host_count - capsule_observed_hosts) / host_count, 6) if host_count else 0.0,
+                "observed_type_counts": dict(sorted(capsule_type_counts.items())),
+            },
+            "lps_core_type": {
+                "observed_hosts": host_count,
+                "missing_hosts": 0,
+                "missing_rate": 0.0,
+                "source_breakdown": dict(sorted(source_breakdown.items())),
+            },
+            "umap_phylogeny_8d": {
+                "observed_hosts": host_count,
+                "missing_hosts": 0,
+                "missing_rate": 0.0,
+            },
+        },
+        "sources": {
+            "umap_path": str(args.umap_path),
+            "umap_sha256": _sha256(args.umap_path),
+            "capsule_path": str(args.capsule_path),
+            "capsule_sha256": _sha256(args.capsule_path),
+            "lps_primary_path": str(args.lps_primary_path),
+            "lps_primary_sha256": _sha256(args.lps_primary_path),
+            "lps_supplemental_path": str(args.lps_supplemental_path),
+            "lps_supplemental_sha256": _sha256(args.lps_supplemental_path),
+        },
+    }
+
+    ensure_directory(args.output_dir)
+    write_csv(args.output_dir / f"host_extended_surface_features_{args.version}.csv", FEATURE_COLUMNS, feature_rows)
+    write_csv(
+        args.output_dir / f"host_extended_surface_feature_metadata_{args.version}.csv",
+        METADATA_COLUMNS,
+        metadata_rows,
+    )
+    write_json(
+        args.output_dir / f"host_extended_surface_feature_manifest_{args.version}.json",
+        manifest,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lyzortx/research_notes/lab_notebooks/track_C.md
+++ b/lyzortx/research_notes/lab_notebooks/track_C.md
@@ -143,3 +143,68 @@
    variants, while `NFRA`, `OMPC`, and `YNCD` remain much more fragmented even after support-based rare clustering.
 4. The emitted block is ready for downstream joins on `bacteria`, but the manifest should remain the source of truth
    for interpretation because grouped categories are a lossy compression of the original BLAST cluster table.
+
+### 2026-03-21: TC03 extended host surface features
+
+#### What was implemented
+
+- Added a dedicated Track C builder:
+  `lyzortx/pipeline/track_c/steps/build_extended_host_surface_feature_block.py`.
+- Configured the step to write generated outputs under
+  `lyzortx/generated_outputs/track_c/extended_host_surface_feature_block/`:
+  - `host_extended_surface_features_v1.csv`
+  - `host_extended_surface_feature_metadata_v1.csv`
+  - `host_extended_surface_feature_manifest_v1.json`
+- Set the output host contract to the full `404`-strain UMAP panel instead of shrinking to the sparse capsule subset.
+  This keeps the block directly joinable on `bacteria` with the current phylogeny and OMP-cluster host feature tables.
+- Added three feature families:
+  - `host_surface_klebsiella_capsule_type` plus explicit
+    `host_surface_klebsiella_capsule_type_missing`
+  - `host_surface_lps_core_type`, merged from the primary `370`-host `waaL` table and the supplemental host table after
+    conflict checks
+  - `host_phylogeny_umap_00` through `host_phylogeny_umap_07` from the in-repo 8D phylogenomic embedding table
+- Added regression tests in `lyzortx/tests/test_extended_host_surface_feature_block.py` covering LPS-source merging,
+  conflict detection, capsule missingness handling, and end-to-end file emission.
+
+#### Output summary
+
+- Final matrix size: `404` host rows x `11` engineered features, plus the `bacteria` join key.
+- Klebsiella capsule coverage:
+  - `23 / 404` hosts typed (`5.7%` observed, `94.3%` missing)
+  - Missingness indicator coverage matches the sparse call set exactly: `381 / 404` hosts flagged missing
+  - Observed capsule type counts:
+    - `K57`: `5`
+    - `K2`: `4`
+    - `K55`: `3`
+    - `K9`: `2`
+    - `K25`: `2`
+    - `K54`: `2`
+    - `K10`, `K16`, `K39`, `K63`, `K127`: `1` each
+- LPS core coverage:
+  - `404 / 404` hosts typed (`0.0%` missing)
+  - Source split: `370` hosts from `LPS_type_waaL_370.txt`, `34` backfilled from `LPS_type_waaL_host.txt`
+  - No conflicts were observed between the two curated `waaL` sources
+  - Final LPS distribution:
+    - `R1`: `188`
+    - `R3`: `54`
+    - `K12`: `40`
+    - `R4`: `34`
+    - `No_waaL`: `32`
+    - `R2`: `22`
+- UMAP coverage:
+  - All `8` phylogenomic dimensions are present for all `404 / 404` hosts
+  - The extra `35` hosts relative to the current `369`-host interaction panel are retained intentionally so Track C host
+    feature blocks can share one wider genomic join contract ahead of downstream pair-table integration
+
+#### Interpretation
+
+1. The correct simplification here is not to intersect away sparse annotations. Using the full `404`-host UMAP panel
+   preserves joinability across Track C host blocks and pushes missingness into one explicit capsule indicator where it
+   belongs.
+2. Klebsiella capsule typing is far too sparse to treat as a standalone dense categorical feature. The missingness flag
+   is likely to carry as much modeling signal as the observed `K` labels themselves until capsule coverage improves.
+3. LPS core typing is effectively complete once the two curated `waaL` sources are merged. That makes `host_surface_lps_core_type`
+   a cleaner downstream feature than the capsule call, despite both living in the same surface-feature family.
+4. The 8D UMAP block gives the host feature stack one dense phylogenomic representation that is already aligned to the
+   wider `404`-strain genomic panel. That should make TC04 integration simpler than forcing every upstream source onto
+   the smaller interaction-only subset too early.

--- a/lyzortx/tests/test_extended_host_surface_feature_block.py
+++ b/lyzortx/tests/test_extended_host_surface_feature_block.py
@@ -1,0 +1,159 @@
+import csv
+import json
+from pathlib import Path
+
+from lyzortx.pipeline.track_c.steps.build_extended_host_surface_feature_block import (
+    build_feature_rows,
+    build_lps_core_index,
+    main,
+)
+
+
+def test_build_lps_core_index_merges_primary_and_supplemental_sources() -> None:
+    primary_rows = [
+        {"bacteria": "B1", "LPS_type": "R1"},
+        {"bacteria": "B2", "LPS_type": "R3"},
+    ]
+    supplemental_rows = [
+        {"Strain": "B3", "LPS_type": "K12"},
+    ]
+
+    merged = build_lps_core_index(primary_rows, supplemental_rows)
+
+    assert merged == {
+        "B1": {"lps_core_type": "R1", "source_table": "primary"},
+        "B2": {"lps_core_type": "R3", "source_table": "primary"},
+        "B3": {"lps_core_type": "K12", "source_table": "supplemental"},
+    }
+
+
+def test_build_lps_core_index_rejects_conflicting_annotations() -> None:
+    primary_rows = [{"bacteria": "B1", "LPS_type": "R1"}]
+    supplemental_rows = [{"Strain": "B1", "LPS_type": "R3"}]
+
+    try:
+        build_lps_core_index(primary_rows, supplemental_rows)
+    except ValueError as exc:
+        assert "Conflicting LPS core annotations for 'B1'" in str(exc)
+    else:
+        raise AssertionError("Expected conflicting LPS annotations to raise ValueError")
+
+
+def test_build_feature_rows_uses_umap_panel_and_adds_capsule_missingness() -> None:
+    umap_rows = [
+        {
+            "bacteria": "B2",
+            "UMAP0": "1.5",
+            "UMAP1": "2.5",
+            "UMAP2": "3.5",
+            "UMAP3": "4.5",
+            "UMAP4": "5.5",
+            "UMAP5": "6.5",
+            "UMAP6": "7.5",
+            "UMAP7": "8.5",
+        },
+        {
+            "bacteria": "B1",
+            "UMAP0": "0.5",
+            "UMAP1": "1.5",
+            "UMAP2": "2.5",
+            "UMAP3": "3.5",
+            "UMAP4": "4.5",
+            "UMAP5": "5.5",
+            "UMAP6": "6.5",
+            "UMAP7": "7.5",
+        },
+    ]
+    capsule_index = {"B1": {"klebsiella_capsule_type": "K2"}}
+    lps_index = {
+        "B1": {"lps_core_type": "R1", "source_table": "primary"},
+        "B2": {"lps_core_type": "K12", "source_table": "supplemental"},
+    }
+
+    feature_rows = build_feature_rows(
+        umap_rows=umap_rows,
+        capsule_index=capsule_index,
+        lps_index=lps_index,
+    )
+
+    assert [row["bacteria"] for row in feature_rows] == ["B1", "B2"]
+    assert feature_rows[0]["host_surface_klebsiella_capsule_type"] == "K2"
+    assert feature_rows[0]["host_surface_klebsiella_capsule_type_missing"] == 0
+    assert feature_rows[1]["host_surface_klebsiella_capsule_type"] == ""
+    assert feature_rows[1]["host_surface_klebsiella_capsule_type_missing"] == 1
+    assert feature_rows[1]["host_surface_lps_core_type"] == "K12"
+    assert feature_rows[0]["host_phylogeny_umap_00"] == 0.5
+    assert feature_rows[1]["host_phylogeny_umap_07"] == 8.5
+
+
+def test_main_writes_matrix_metadata_and_manifest(tmp_path: Path) -> None:
+    umap_path = tmp_path / "umap.tsv"
+    capsule_path = tmp_path / "capsule.tsv"
+    lps_primary_path = tmp_path / "lps_primary.tsv"
+    lps_supplemental_path = tmp_path / "lps_supplemental.tsv"
+    output_dir = tmp_path / "out"
+
+    umap_path.write_text(
+        (
+            "bacteria\tUMAP0\tUMAP1\tUMAP2\tUMAP3\tUMAP4\tUMAP5\tUMAP6\tUMAP7\n"
+            "B2\t1.1\t2.1\t3.1\t4.1\t5.1\t6.1\t7.1\t8.1\n"
+            "B1\t0.1\t1.1\t2.1\t3.1\t4.1\t5.1\t6.1\t7.1\n"
+        ),
+        encoding="utf-8",
+    )
+    capsule_path.write_text(
+        "bacteria\tKlebs_capsule_type\tlocus\nB1\tK54\tGood\n",
+        encoding="utf-8",
+    )
+    lps_primary_path.write_text(
+        "bacteria\tgembase\tLPS_type\nB1\tGB1\tR1\n",
+        encoding="utf-8",
+    )
+    lps_supplemental_path.write_text(
+        "Strain\tLPS_type\nB2\tK12\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--umap-path",
+            str(umap_path),
+            "--capsule-path",
+            str(capsule_path),
+            "--lps-primary-path",
+            str(lps_primary_path),
+            "--lps-supplemental-path",
+            str(lps_supplemental_path),
+            "--output-dir",
+            str(output_dir),
+            "--version",
+            "test",
+            "--expected-host-count",
+            "2",
+        ]
+    )
+
+    assert exit_code == 0
+
+    matrix_path = output_dir / "host_extended_surface_features_test.csv"
+    metadata_path = output_dir / "host_extended_surface_feature_metadata_test.csv"
+    manifest_path = output_dir / "host_extended_surface_feature_manifest_test.json"
+
+    with matrix_path.open("r", encoding="utf-8", newline="") as handle:
+        matrix_rows = list(csv.DictReader(handle))
+    with metadata_path.open("r", encoding="utf-8", newline="") as handle:
+        metadata_rows = list(csv.DictReader(handle))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert len(matrix_rows) == 2
+    assert matrix_rows[0]["bacteria"] == "B1"
+    assert matrix_rows[1]["host_surface_klebsiella_capsule_type_missing"] == "1"
+    assert matrix_rows[0]["host_phylogeny_umap_00"] == "0.1"
+    capsule_metadata = {
+        row["column_name"]: row for row in metadata_rows if row["column_name"] == "host_surface_klebsiella_capsule_type"
+    }
+    assert capsule_metadata["host_surface_klebsiella_capsule_type"]["missing_count"] == "1"
+    assert manifest["host_count"] == 2
+    assert manifest["feature_count"] == 11
+    assert manifest["coverage"]["klebsiella_capsule_type"]["observed_hosts"] == 1
+    assert manifest["coverage"]["lps_core_type"]["source_breakdown"] == {"primary": 1, "supplemental": 1}


### PR DESCRIPTION
## Summary
- add a new Track C builder for extended host surface features on the 404-host UMAP panel
- emit Klebsiella capsule type with an explicit missingness indicator, merge LPS core annotations from the two curated waaL tables, and retain all 8 phylogenomic UMAP coordinates
- add regression tests for LPS source merging, sparse capsule handling, and artifact emission, and document the implementation and coverage profile in the Track C lab notebook

## Testing
- pytest -q lyzortx/tests/

Posted by Codex gpt-5.

Closes #79
