### PR TITLE
fix: don't label auto-merged PRs as ready-for-human-review

### DIFF
--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -42,10 +42,9 @@ jobs:
           PR_NUM="${{ github.event.pull_request.number }}"
           echo "number=${PR_NUM}" >> "$GITHUB_OUTPUT"
 
-      - name: Label and auto-merge
+      - name: Auto-merge
         run: |
           PR_NUM="${{ steps.pr.outputs.number }}"
-          gh pr edit "$PR_NUM" --repo "${{ github.repository }}" --add-label "ready-for-human-review"
           gh pr merge "$PR_NUM" --repo "${{ github.repository }}" --squash --auto \
             --body "Auto-merged after Claude approval and passing CI."
           echo "Auto-merge enabled for PR #${PR_NUM}. Will merge when required checks pass."


### PR DESCRIPTION
## Summary

- Remove the contradictory `gh pr edit --add-label "ready-for-human-review"` line from the `auto-merge-on-approve` job in `codex-pr-lifecycle.yml`.
- The job auto-merges PRs after Claude's approval, so labeling them as "ready-for-human-review" right before merging is contradictory.
- The step is renamed from "Label and auto-merge" to "Auto-merge".

## Test plan

- [ ] Verify the workflow YAML is valid (CI lint passes).
- [ ] Confirm that PRs approved by `claude[bot]` are auto-merged without receiving the `ready-for-human-review` label.
- [ ] Confirm the "No feedback — label as clean" step in `address-feedback` still correctly applies `ready-for-human-review` for non-auto-merged PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)