### PR TITLE
feat: skip Claude review if PR already has Claude approval

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,7 +28,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Check for existing Claude approval
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          APPROVED=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+            --jq '[.[] | select(.user.login == "claude[bot]" and .state == "APPROVED")] | length')
+          echo "skip=$([[ $APPROVED -gt 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
       - name: Select model
+        if: steps.check.outputs.skip != 'true'
         id: model
         run: |
           if [ "${{ github.event.action }}" = "opened" ]; then
@@ -38,10 +48,12 @@ jobs:
           fi
 
       - uses: actions/checkout@v6
+        if: steps.check.outputs.skip != 'true'
         with:
           fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
+        if: steps.check.outputs.skip != 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true


### PR DESCRIPTION
## Summary

- Adds an early check in the `auto-review` job to detect if `claude[bot]` has already submitted an APPROVED review on the PR.
- If an approval exists, subsequent steps (model selection, checkout, claude-code-action) are skipped entirely.
- Saves Anthropic API costs on subsequent pushes to PRs that Claude has already approved.

## Test plan

- [ ] Open a new PR without any Claude approval -- verify the review runs normally.
- [ ] Push to a PR that already has a `claude[bot]` APPROVED review -- verify the job exits early after the check step.
- [ ] Verify the `interactive` job (triggered by `@claude` mentions) is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)