### PR TITLE
fix: disable cancel-in-progress for Claude review concurrency

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: claude-review-pr-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # ── Auto-review on every PR open / push ──────────────────────────────


### PR DESCRIPTION
## Summary
- Sets `cancel-in-progress: false` on the Claude PR Review concurrency group
- Force-pushes (rebases) emit multiple near-simultaneous `pull_request` events that cancel each other in a loop, leaving zero completed review runs
- With `cancel-in-progress: false`, the first run completes while subsequent runs queue

## Test plan
- [ ] Rebase and force-push PR #86 — verify the Claude review run completes instead of self-cancelling

🤖 Generated with [Claude Code](https://claude.com/claude-code)