### PR TITLE
feat: add manual dispatch and skip drafts for Claude PR reviews

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -2,7 +2,7 @@ name: Claude PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -37,7 +37,9 @@ jobs:
   # Opus for first review (opened) or manual dispatch, Sonnet for re-reviews (synchronize).
   auto-review:
     name: Claude Auto Review
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger with `pr_number` and `model` inputs for on-demand reviews
- Skips auto-review on draft PRs; triggers review when a draft is marked ready (`ready_for_review`)
- Consolidates auto and manual review into a single job via shared `PR_NUMBER` env var (no prompt duplication)

Usage:
```bash
gh workflow run claude-pr-review.yml -f pr_number=86 -f model=claude-opus-4-6
```

## Test plan
- [ ] Trigger manually via `gh workflow run` on an open PR and verify the review posts
- [ ] Push to a draft PR and verify the auto-review is skipped
- [ ] Mark draft as ready and verify review triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)