### PR TITLE
[ORCH][TD03] Build phage VIRIDIC distance embedding

### DIFF
--- a/lyzortx/pipeline/track_d/README.md
+++ b/lyzortx/pipeline/track_d/README.md
@@ -9,6 +9,8 @@ This command scans `data/genomics/phages/`, resolves the canonical 96-phage pane
    `lyzortx/generated_outputs/track_d/phage_protein_sets/protein_fastas/`
 2. `genome-kmers`: write tetranucleotide SVD features to
    `lyzortx/generated_outputs/track_d/phage_genome_kmer_features/phage_genome_kmer_features.csv`
+3. `viridic-distance`: write VIRIDIC tree-distance MDS features to
+   `lyzortx/generated_outputs/track_d/phage_distance_embedding/phage_distance_embedding_features.csv`
 
 Input precedence is deterministic:
 
@@ -20,6 +22,11 @@ The genome k-mer builder fits a deterministic TruncatedSVD embedding on normaliz
 discovered genome FASTA files in `FNA/`, then emits panel-joinable rows with `phage_gc_content`,
 `phage_genome_length_nt`, and `phage_genome_tetra_svd_00..23`. Any non-panel genomes remain documented in the source
 summary and manifest but are excluded from the joinable feature CSV.
+
+The VIRIDIC distance builder parses
+`data/genomics/phages/tree/96_viridic_distance_phylogenetic_tree_algo=upgma.nwk`, computes leaf-to-leaf patristic
+distances, and fits a deterministic metric MDS embedding with `phage_viridic_mds_00..07` coordinates. It also writes
+an explicit pairwise-distance CSV for auditability alongside the feature CSV, metadata CSV, and manifest.
 
 Tracked documentation for the output formats lives in each step's `manifest.json` plus the corresponding summary/metadata
 CSV files under the output directories.

--- a/lyzortx/pipeline/track_d/run_track_d.py
+++ b/lyzortx/pipeline/track_d/run_track_d.py
@@ -10,16 +10,20 @@ from pathlib import Path
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
-from lyzortx.pipeline.track_d.steps import build_phage_genome_kmer_features, build_phage_protein_sets
+from lyzortx.pipeline.track_d.steps import (
+    build_phage_distance_embedding,
+    build_phage_genome_kmer_features,
+    build_phage_protein_sets,
+)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--step",
-        choices=["protein-sets", "genome-kmers", "all"],
+        choices=["protein-sets", "genome-kmers", "viridic-distance", "all"],
         default="all",
-        help="Track D step to run. 'all' runs the protein-set and genome k-mer feature builders.",
+        help="Track D step to run. 'all' runs the implemented Track D feature builders.",
     )
     return parser.parse_args(argv)
 
@@ -30,6 +34,8 @@ def main(argv: list[str] | None = None) -> None:
         build_phage_protein_sets.main([])
     if args.step in {"genome-kmers", "all"}:
         build_phage_genome_kmer_features.main([])
+    if args.step in {"viridic-distance", "all"}:
+        build_phage_distance_embedding.main([])
 
 
 if __name__ == "__main__":

--- a/lyzortx/pipeline/track_d/steps/build_phage_distance_embedding.py
+++ b/lyzortx/pipeline/track_d/steps/build_phage_distance_embedding.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""TD03: Build phage distance embedding features from the VIRIDIC phylogenetic tree."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+from sklearn.manifold import MDS
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.track_d.steps.build_phage_protein_sets import read_panel_phages
+
+PAIRWISE_DISTANCE_COLUMNS: Tuple[str, ...] = ("phage_1", "phage_2", "viridic_tree_distance")
+METADATA_COLUMNS: Tuple[str, ...] = (
+    "column_name",
+    "feature_group",
+    "feature_type",
+    "source_path",
+    "source_column",
+    "transform",
+    "provenance_note",
+)
+
+
+@dataclass
+class NewickNode:
+    """One parsed node from a Newick tree."""
+
+    name: Optional[str]
+    length_to_parent: Optional[float]
+    children: List["NewickNode"] = field(default_factory=list)
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--phage-metadata-path",
+        type=Path,
+        default=Path("data/genomics/phages/guelin_collection.csv"),
+        help="Semicolon-delimited phage panel metadata containing the canonical phage names.",
+    )
+    parser.add_argument(
+        "--tree-path",
+        type=Path,
+        default=Path("data/genomics/phages/tree/96_viridic_distance_phylogenetic_tree_algo=upgma.nwk"),
+        help="Newick tree produced from VIRIDIC distances.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_d/phage_distance_embedding"),
+        help="Directory for generated Track D VIRIDIC distance embedding artifacts.",
+    )
+    parser.add_argument(
+        "--embedding-dim",
+        type=int,
+        default=8,
+        help="Requested metric MDS embedding dimension. Output is padded to this width if needed.",
+    )
+    parser.add_argument(
+        "--expected-panel-count",
+        type=int,
+        default=96,
+        help="Expected number of phages in the panel metadata.",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=0,
+        help="Random seed for metric MDS.",
+    )
+    return parser.parse_args(argv)
+
+
+def parse_newick_tree(text: str) -> NewickNode:
+    """Parse a Newick tree into a recursive node structure."""
+
+    stripped = text.strip()
+    if not stripped.endswith(";"):
+        raise ValueError("Newick tree must end with ';'")
+
+    index = 0
+
+    def skip_ws() -> None:
+        nonlocal index
+        while index < len(stripped) and stripped[index].isspace():
+            index += 1
+
+    def parse_name() -> Optional[str]:
+        nonlocal index
+        skip_ws()
+        start = index
+        while index < len(stripped) and stripped[index] not in ",():;":
+            index += 1
+        name = stripped[start:index].strip()
+        return name or None
+
+    def parse_length() -> Optional[float]:
+        nonlocal index
+        skip_ws()
+        if index >= len(stripped) or stripped[index] != ":":
+            return None
+        index += 1
+        skip_ws()
+        start = index
+        while index < len(stripped) and stripped[index] not in ",();":
+            index += 1
+        value = stripped[start:index].strip()
+        if not value:
+            raise ValueError("Encountered empty branch length in Newick tree")
+        return float(value)
+
+    def parse_subtree() -> NewickNode:
+        nonlocal index
+        skip_ws()
+        if index >= len(stripped):
+            raise ValueError("Unexpected end of Newick tree")
+
+        if stripped[index] == "(":
+            index += 1
+            children = [parse_subtree()]
+            skip_ws()
+            while index < len(stripped) and stripped[index] == ",":
+                index += 1
+                children.append(parse_subtree())
+                skip_ws()
+            if index >= len(stripped) or stripped[index] != ")":
+                raise ValueError("Expected ')' in Newick tree")
+            index += 1
+            name = parse_name()
+            length = parse_length()
+            return NewickNode(name=name, length_to_parent=length, children=children)
+
+        name = parse_name()
+        if name is None:
+            raise ValueError("Leaf nodes in the Newick tree must have names")
+        length = parse_length()
+        return NewickNode(name=name, length_to_parent=length, children=[])
+
+    root = parse_subtree()
+    skip_ws()
+    if index >= len(stripped) or stripped[index] != ";":
+        raise ValueError("Expected ';' at the end of the Newick tree")
+    skip_ws()
+    if index != len(stripped) - 1:
+        raise ValueError("Unexpected trailing content after the Newick tree")
+    return root
+
+
+def compute_pairwise_leaf_distances(root: NewickNode) -> Dict[str, Dict[str, float]]:
+    """Compute all leaf-to-leaf patristic distances from a rooted tree."""
+
+    adjacency: Dict[int, List[Tuple[int, float]]] = {}
+    leaf_names: Dict[str, int] = {}
+    next_node_id = 0
+
+    def attach(node: NewickNode, parent_id: Optional[int]) -> int:
+        nonlocal next_node_id
+        node_id = next_node_id
+        next_node_id += 1
+        adjacency.setdefault(node_id, [])
+
+        if parent_id is not None:
+            if node.length_to_parent is None:
+                raise ValueError("All non-root nodes must have a branch length")
+            adjacency[node_id].append((parent_id, node.length_to_parent))
+            adjacency[parent_id].append((node_id, node.length_to_parent))
+
+        if node.children:
+            for child in node.children:
+                attach(child, node_id)
+        else:
+            if node.name is None:
+                raise ValueError("Leaf nodes must have names")
+            if node.name in leaf_names:
+                raise ValueError(f"Duplicate leaf name in Newick tree: {node.name}")
+            leaf_names[node.name] = node_id
+
+        return node_id
+
+    attach(root, parent_id=None)
+
+    distances: Dict[str, Dict[str, float]] = {}
+    for leaf_name, leaf_node_id in sorted(leaf_names.items()):
+        pending: List[Tuple[int, int, float]] = [(leaf_node_id, -1, 0.0)]
+        leaf_distances: Dict[str, float] = {}
+        while pending:
+            node_id, parent_id, total_distance = pending.pop()
+            for candidate_name, candidate_node_id in leaf_names.items():
+                if candidate_node_id == node_id:
+                    leaf_distances[candidate_name] = total_distance
+                    break
+            for neighbor_id, edge_length in adjacency[node_id]:
+                if neighbor_id == parent_id:
+                    continue
+                pending.append((neighbor_id, node_id, total_distance + edge_length))
+        distances[leaf_name] = dict(sorted(leaf_distances.items()))
+
+    return dict(sorted(distances.items()))
+
+
+def distance_dict_to_matrix(
+    pairwise_distances: Mapping[str, Mapping[str, float]],
+    *,
+    phage_order: Sequence[str],
+) -> np.ndarray:
+    missing = sorted(set(phage_order) - set(pairwise_distances))
+    if missing:
+        raise ValueError("Missing phages from pairwise distance map: " + ", ".join(missing))
+
+    matrix = np.zeros((len(phage_order), len(phage_order)), dtype=np.float64)
+    for row_index, phage_1 in enumerate(phage_order):
+        row = pairwise_distances[phage_1]
+        for column_index, phage_2 in enumerate(phage_order):
+            matrix[row_index, column_index] = float(row[phage_2])
+    return matrix
+
+
+def compute_mds_embedding(
+    distance_matrix: np.ndarray,
+    *,
+    embedding_dim: int,
+    random_state: int,
+) -> Tuple[np.ndarray, Dict[str, object]]:
+    if embedding_dim < 1:
+        raise ValueError("embedding_dim must be >= 1")
+    if (
+        distance_matrix.ndim != 2
+        or distance_matrix.shape[0] == 0
+        or distance_matrix.shape[0] != distance_matrix.shape[1]
+    ):
+        raise ValueError("distance_matrix must be a non-empty square matrix")
+
+    effective_dim = min(embedding_dim, max(1, distance_matrix.shape[0] - 1))
+    mds = MDS(
+        n_components=effective_dim,
+        metric_mds=True,
+        metric="precomputed",
+        n_init=1,
+        init="classical_mds",
+        max_iter=300,
+        eps=1e-9,
+        normalized_stress="auto",
+        random_state=random_state,
+    )
+    reduced = mds.fit_transform(distance_matrix)
+
+    if effective_dim < embedding_dim:
+        padded = np.zeros((distance_matrix.shape[0], embedding_dim), dtype=np.float64)
+        padded[:, :effective_dim] = reduced
+        reduced = padded
+
+    metadata = {
+        "requested_embedding_dim": embedding_dim,
+        "effective_embedding_dim": effective_dim,
+        "stress": float(mds.stress_),
+    }
+    return reduced, metadata
+
+
+def _feature_columns(embedding_dim: int) -> Tuple[str, ...]:
+    return tuple(f"phage_viridic_mds_{index:02d}" for index in range(embedding_dim))
+
+
+def build_pairwise_distance_rows(
+    *,
+    phage_order: Sequence[str],
+    distance_matrix: np.ndarray,
+) -> List[Dict[str, object]]:
+    rows: List[Dict[str, object]] = []
+    for row_index, phage_1 in enumerate(phage_order):
+        for column_index in range(row_index, len(phage_order)):
+            rows.append(
+                {
+                    "phage_1": phage_1,
+                    "phage_2": phage_order[column_index],
+                    "viridic_tree_distance": round(float(distance_matrix[row_index, column_index]), 6),
+                }
+            )
+    return rows
+
+
+def build_feature_rows(
+    *,
+    phage_order: Sequence[str],
+    embedding: np.ndarray,
+    embedding_dim: int,
+) -> List[Dict[str, object]]:
+    rows: List[Dict[str, object]] = []
+    for row_index, phage in enumerate(phage_order):
+        row: Dict[str, object] = {"phage": phage}
+        for column_index, value in enumerate(embedding[row_index, :embedding_dim]):
+            row[f"phage_viridic_mds_{column_index:02d}"] = round(float(value), 6)
+        rows.append(row)
+    return rows
+
+
+def build_metadata_rows(*, tree_path: Path, embedding_dim: int) -> List[Dict[str, object]]:
+    rows: List[Dict[str, object]] = []
+    for column_name in _feature_columns(embedding_dim):
+        rows.append(
+            {
+                "column_name": column_name,
+                "feature_group": "viridic_tree_embedding",
+                "feature_type": "continuous",
+                "source_path": str(tree_path),
+                "source_column": "patristic distance matrix from leaf-to-leaf branch lengths",
+                "transform": "Compute pairwise tree distances from the Newick tree and project them with metric MDS.",
+                "provenance_note": "Rows are emitted only for canonical panel phages and preserve panel join keys.",
+            }
+        )
+    return rows
+
+
+def build_phage_distance_embedding_feature_block(
+    *,
+    panel_phages: Sequence[str],
+    tree_path: Path,
+    output_dir: Path,
+    metadata_path: Path,
+    embedding_dim: int,
+    random_state: int = 0,
+) -> Dict[str, object]:
+    tree = parse_newick_tree(tree_path.read_text(encoding="utf-8"))
+    pairwise_distances = compute_pairwise_leaf_distances(tree)
+
+    missing = sorted(set(panel_phages) - set(pairwise_distances))
+    extra = sorted(set(pairwise_distances) - set(panel_phages))
+    if missing:
+        raise ValueError("Panel phages missing from VIRIDIC tree: " + ", ".join(missing))
+    if extra:
+        raise ValueError("VIRIDIC tree contains non-panel leaves: " + ", ".join(extra))
+
+    phage_order = sorted(panel_phages)
+    distance_matrix = distance_dict_to_matrix(pairwise_distances, phage_order=phage_order)
+    embedding, mds_metadata = compute_mds_embedding(
+        distance_matrix,
+        embedding_dim=embedding_dim,
+        random_state=random_state,
+    )
+
+    feature_rows = build_feature_rows(
+        phage_order=phage_order,
+        embedding=embedding,
+        embedding_dim=embedding_dim,
+    )
+    pairwise_rows = build_pairwise_distance_rows(
+        phage_order=phage_order,
+        distance_matrix=distance_matrix,
+    )
+    metadata_rows = build_metadata_rows(tree_path=tree_path, embedding_dim=embedding_dim)
+
+    ensure_directory(output_dir)
+    feature_columns = _feature_columns(embedding_dim)
+    feature_fieldnames = ("phage", *feature_columns)
+    features_path = output_dir / "phage_distance_embedding_features.csv"
+    pairwise_path = output_dir / "phage_viridic_tree_pairwise_distances.csv"
+    metadata_csv_path = output_dir / "phage_distance_embedding_feature_metadata.csv"
+    write_csv(features_path, feature_fieldnames, feature_rows)
+    write_csv(pairwise_path, PAIRWISE_DISTANCE_COLUMNS, pairwise_rows)
+    write_csv(metadata_csv_path, METADATA_COLUMNS, metadata_rows)
+
+    manifest = {
+        "step_name": "build_phage_distance_embedding",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "inputs": {
+            "phage_metadata_path": str(metadata_path),
+            "tree_path": str(tree_path),
+            "embedding_dim_requested": embedding_dim,
+            "random_state": random_state,
+        },
+        "counts": {
+            "panel_phage_count": len(panel_phages),
+            "tree_leaf_count": len(pairwise_distances),
+            "output_row_count": len(feature_rows),
+            "pairwise_distance_row_count": len(pairwise_rows),
+            "embedding_dim_effective": int(mds_metadata["effective_embedding_dim"]),
+        },
+        "output_format": {
+            "feature_csv": str(features_path),
+            "pairwise_distance_csv": str(pairwise_path),
+            "feature_metadata_csv": str(metadata_csv_path),
+            "feature_columns": list(feature_fieldnames),
+        },
+        "reproducibility": {
+            "one_command": "python lyzortx/pipeline/track_d/run_track_d.py --step viridic-distance",
+            "mds_stress": round(float(mds_metadata["stress"]), 6),
+            "distance_definition": (
+                "Pairwise distances are the summed branch lengths between phage leaves in the VIRIDIC UPGMA tree."
+            ),
+            "panel_output_policy": "Require exact leaf-name agreement with the canonical panel before writing outputs.",
+        },
+    }
+    write_json(output_dir / "manifest.json", manifest)
+    return manifest
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_args(argv)
+    panel_phages = read_panel_phages(args.phage_metadata_path, expected_panel_count=args.expected_panel_count)
+    manifest = build_phage_distance_embedding_feature_block(
+        panel_phages=panel_phages,
+        tree_path=args.tree_path,
+        output_dir=args.output_dir,
+        metadata_path=args.phage_metadata_path,
+        embedding_dim=args.embedding_dim,
+        random_state=args.random_state,
+    )
+    print("Built phage VIRIDIC distance embedding features.")
+    print(f"- Panel rows written: {manifest['counts']['output_row_count']}")
+    print(f"- Tree leaves used: {manifest['counts']['tree_leaf_count']}")
+    print(f"- Pairwise distance rows written: {manifest['counts']['pairwise_distance_row_count']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_D.md
+++ b/lyzortx/research_notes/lab_notebooks/track_D.md
@@ -64,3 +64,37 @@ while restricting the final feature CSV to canonical panel phages keeps the down
 
 Combine this block with the pending RBP annotations (`TD01`) and VIRIDIC distance embedding (`TD03`), then measure
 whether the added phage-side signal improves holdout performance beyond the current identity-heavy baselines.
+
+### 2026-03-22: TD03 phage VIRIDIC distance embedding feature block
+
+#### What was implemented
+
+Added `lyzortx/pipeline/track_d/steps/build_phage_distance_embedding.py` and wired it into
+`lyzortx/pipeline/track_d/run_track_d.py` as the `viridic-distance` step. The builder parses
+`data/genomics/phages/tree/96_viridic_distance_phylogenetic_tree_algo=upgma.nwk`, computes patristic leaf-to-leaf
+distances directly from branch lengths, fits a deterministic metric MDS embedding, and emits a panel-joinable feature
+CSV with 8 VIRIDIC distance coordinates.
+
+#### Output summary
+
+Outputs are written under `lyzortx/generated_outputs/track_d/phage_distance_embedding/`:
+
+- `phage_distance_embedding_features.csv`: 96 canonical panel phages with 8 numeric MDS features plus the `phage` key
+- `phage_viridic_tree_pairwise_distances.csv`: explicit pairwise tree distances for audit and downstream checks
+- `phage_distance_embedding_feature_metadata.csv`: column-level transform and provenance metadata
+- `manifest.json`: regeneration command, effective embedding dimensionality, MDS stress, and output inventory
+
+On the current repo data, the VIRIDIC tree leaf names match the canonical 96-phage panel exactly, so the builder can
+enforce a strict no-alias join contract. The pairwise-distance extraction is therefore lossless with respect to the
+tree leaves, and the final feature block remains directly mergeable on `phage`.
+
+#### Interpretation
+
+This closes the tree-derived geometry gap for Track D with a compact phage feature block that captures relatedness
+beyond exact identity or simple family labels. Using the VIRIDIC UPGMA tree as the distance source should help
+downstream models generalize across related phages while keeping the feature contract purely numeric and join-safe.
+
+#### Next steps
+
+Merge this embedding with the genome-composition and pending RBP feature blocks, then test whether the combined phage
+representation improves phage-family holdouts and reduces the current popular-phage bias in pairwise models.

--- a/lyzortx/tests/test_track_d_viridic_distance_embedding.py
+++ b/lyzortx/tests/test_track_d_viridic_distance_embedding.py
@@ -1,0 +1,125 @@
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+
+from lyzortx.pipeline.track_d import run_track_d
+from lyzortx.pipeline.track_d.steps.build_phage_distance_embedding import (
+    build_phage_distance_embedding_feature_block,
+    compute_mds_embedding,
+    compute_pairwise_leaf_distances,
+    distance_dict_to_matrix,
+    parse_newick_tree,
+)
+from lyzortx.pipeline.track_d.steps.build_phage_protein_sets import read_panel_phages
+
+
+def _write_panel_metadata(path: Path, phages: list[str]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["phage"], delimiter=";")
+        writer.writeheader()
+        for phage in phages:
+            writer.writerow({"phage": phage})
+
+
+def test_compute_pairwise_leaf_distances_from_newick_tree() -> None:
+    tree = parse_newick_tree("((P1:0.1,P2:0.2)inner:0.3,P3:0.4);")
+
+    distances = compute_pairwise_leaf_distances(tree)
+
+    assert distances["P1"]["P1"] == 0.0
+    assert np.isclose(distances["P1"]["P2"], 0.3)
+    assert np.isclose(distances["P1"]["P3"], 0.8)
+    assert np.isclose(distances["P2"]["P3"], 0.9)
+
+
+def test_compute_mds_embedding_pads_when_requested_dimension_exceeds_rank() -> None:
+    distance_matrix = np.array(
+        [
+            [0.0, 0.3, 0.8],
+            [0.3, 0.0, 0.9],
+            [0.8, 0.9, 0.0],
+        ]
+    )
+
+    embedding, metadata = compute_mds_embedding(distance_matrix, embedding_dim=5, random_state=0)
+
+    assert embedding.shape == (3, 5)
+    assert metadata["effective_embedding_dim"] == 2
+    assert np.allclose(embedding[:, 2:], 0.0)
+
+
+def test_build_phage_distance_embedding_feature_block_writes_joinable_csvs(tmp_path: Path) -> None:
+    metadata_path = tmp_path / "panel.csv"
+    tree_path = tmp_path / "tree.nwk"
+    output_dir = tmp_path / "out"
+
+    _write_panel_metadata(metadata_path, ["P1", "P2", "P3"])
+    tree_path.write_text("((P1:0.1,P2:0.2)inner:0.3,P3:0.4);", encoding="utf-8")
+
+    panel_phages = read_panel_phages(metadata_path, expected_panel_count=3)
+    manifest = build_phage_distance_embedding_feature_block(
+        panel_phages=panel_phages,
+        tree_path=tree_path,
+        output_dir=output_dir,
+        metadata_path=metadata_path,
+        embedding_dim=5,
+    )
+
+    features_path = output_dir / "phage_distance_embedding_features.csv"
+    pairwise_path = output_dir / "phage_viridic_tree_pairwise_distances.csv"
+    metadata_csv_path = output_dir / "phage_distance_embedding_feature_metadata.csv"
+    manifest_path = output_dir / "manifest.json"
+
+    rows = list(csv.DictReader(features_path.open(encoding="utf-8")))
+    pairwise_rows = list(csv.DictReader(pairwise_path.open(encoding="utf-8")))
+    metadata_rows = list(csv.DictReader(metadata_csv_path.open(encoding="utf-8")))
+    manifest_json = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert [row["phage"] for row in rows] == ["P1", "P2", "P3"]
+    assert len(rows[0]) == 1 + 5
+    assert len(pairwise_rows) == 6
+    assert pairwise_rows[0] == {"phage_1": "P1", "phage_2": "P1", "viridic_tree_distance": "0.0"}
+    assert len(metadata_rows) == 5
+    assert manifest["counts"]["tree_leaf_count"] == 3
+    assert manifest["counts"]["embedding_dim_effective"] == 2
+    assert manifest_json["counts"]["pairwise_distance_row_count"] == 6
+
+
+def test_distance_dict_to_matrix_respects_requested_order() -> None:
+    distances = {
+        "P1": {"P1": 0.0, "P2": 0.1},
+        "P2": {"P1": 0.1, "P2": 0.0},
+    }
+
+    matrix = distance_dict_to_matrix(distances, phage_order=["P2", "P1"])
+
+    assert np.allclose(matrix, np.array([[0.0, 0.1], [0.1, 0.0]]))
+
+
+def test_run_track_d_dispatches_viridic_distance_step(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        run_track_d.build_phage_protein_sets,
+        "main",
+        lambda argv: calls.append("protein-sets"),
+    )
+    monkeypatch.setattr(
+        run_track_d.build_phage_genome_kmer_features,
+        "main",
+        lambda argv: calls.append("genome-kmers"),
+    )
+    monkeypatch.setattr(
+        run_track_d.build_phage_distance_embedding,
+        "main",
+        lambda argv: calls.append("viridic-distance"),
+    )
+
+    run_track_d.main(["--step", "viridic-distance"])
+    assert calls == ["viridic-distance"]
+
+    calls.clear()
+    run_track_d.main(["--step", "all"])
+    assert calls == ["protein-sets", "genome-kmers", "viridic-distance"]


### PR DESCRIPTION
## Summary

- add a new Track D `viridic-distance` builder that parses the VIRIDIC UPGMA Newick tree, extracts pairwise
  leaf-to-leaf patristic distances, and fits a deterministic 8D metric MDS embedding
- write a joinable phage feature CSV, an explicit pairwise-distance CSV, metadata, and a manifest under
  `lyzortx/generated_outputs/track_d/phage_distance_embedding/`
- wire the new step into `lyzortx/pipeline/track_d/run_track_d.py`, document it in the Track D README, and record
  findings in the Track D lab notebook
- add focused tests for tree parsing, distance extraction, MDS padding behavior, output writing, and runner dispatch

## Validation

- `python lyzortx/pipeline/track_d/run_track_d.py --step viridic-distance`
- `pytest -q lyzortx/tests/`

Posted by Codex gpt-5

Closes #92
