### PR TITLE
[ORCH][TE01] Build RBP-receptor compatibility features

### DIFF
--- a/lyzortx/pipeline/track_e/README.md
+++ b/lyzortx/pipeline/track_e/README.md
@@ -1,0 +1,18 @@
+# Track E Pairwise Compatibility Features
+
+`python lyzortx/pipeline/track_e/run_track_e.py`
+
+This command runs the implemented Track E pairwise feature builder:
+
+1. `rbp-receptor-compatibility`: write leakage-safe RBP-receptor compatibility features to
+   `lyzortx/generated_outputs/track_e/rbp_receptor_compatibility_feature_block/rbp_receptor_compatibility_features_v1.csv`
+
+The TE01 builder reads the canonical ST0.2 pair table, ST0.3 split assignments, the host OMP receptor-cluster table,
+and a checked-in curated genus/subfamily lookup. Lookup matching prefers `phage_genus` and falls back to
+`phage_subfamily` when the genus has no explicit entry. Training-positive aggregates are leakage-safe:
+
+1. Holdout rows only look at `train_non_holdout` positives.
+2. Non-holdout rows use out-of-fold positives from all other CV folds.
+
+The final feature CSV is joinable on `pair_id`, `bacteria`, and `phage`, and the output directory also includes a
+column-level metadata CSV, a per-phage lookup summary CSV, and a manifest with input/output hashes.

--- a/lyzortx/pipeline/track_e/curated_inputs/genus_receptor_lookup.csv
+++ b/lyzortx/pipeline/track_e/curated_inputs/genus_receptor_lookup.csv
@@ -1,0 +1,10 @@
+match_level,taxon,target_receptors,target_family,evidence_note
+genus,Lambdavirus,LAMB,protein,"Lambda-like coliphages classically use LamB; keep exact-genus override because subfamily is missing in the source metadata."
+genus,Vectrevirus,CAPSULE,surface_glycan,"Curate as capsule-targeting from the K1/K5-like vectrevirus literature and tail-spike/depolymerase usage."
+subfamily,Tevenvirinae,OMPC|LPS_CORE,mixed,"T-even-like myophages commonly require OmpC with LPS/coreceptor context, so keep both targets."
+subfamily,Enquatrovirinae,NFRA,protein,"N4-like coliphages use the NfrA/NfrB adsorption system; map to the in-repo NFRA host locus."
+subfamily,Ounavirinae,O_ANTIGEN|LPS_CORE,surface_glycan,"FelixO1-like phages are primarily LPS/O-antigen adsorbers."
+subfamily,Braunvirinae,O_ANTIGEN|LPS_CORE,surface_glycan,"Braunvirinae entries in the current panel are treated as LPS/O-antigen targeting."
+subfamily,Studiervirinae,O_ANTIGEN|LPS_CORE,surface_glycan,"T7-like podophages are treated as surface-glycan targeting by default in this narrowed lookup."
+subfamily,Molineuxvirinae,O_ANTIGEN|LPS_CORE,surface_glycan,"Molineuxvirinae entries are treated as surface-glycan targeting in this narrowed lookup."
+subfamily,Stephanstirmvirinae,O_ANTIGEN|LPS_CORE,surface_glycan,"Stephanstirmvirinae entries are treated as surface-glycan targeting in this narrowed lookup."

--- a/lyzortx/pipeline/track_e/run_track_e.py
+++ b/lyzortx/pipeline/track_e/run_track_e.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Entry point for Track E pairwise compatibility feature builders."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from lyzortx.pipeline.track_e.steps import build_rbp_receptor_compatibility_feature_block
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--step",
+        choices=["rbp-receptor-compatibility", "all"],
+        default="all",
+        help="Track E step to run. 'all' runs the implemented Track E feature builders.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    if args.step in {"rbp-receptor-compatibility", "all"}:
+        build_rbp_receptor_compatibility_feature_block.main([])
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/pipeline/track_e/steps/build_rbp_receptor_compatibility_feature_block.py
+++ b/lyzortx/pipeline/track_e/steps/build_rbp_receptor_compatibility_feature_block.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+"""TE01: Build leakage-safe RBP-receptor compatibility features from a curated taxon lookup."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+
+OUTPUT_FEATURE_COLUMNS: Tuple[str, ...] = (
+    "lookup_available",
+    "target_receptor_present",
+    "protein_target_present",
+    "surface_target_present",
+    "receptor_cluster_matches",
+    "receptor_variant_seen_in_training_positives",
+    "receptor_variant_training_positive_count",
+)
+
+PROTEIN_TARGET_COLUMNS: Dict[str, str] = {
+    "BTUB": "BTUB",
+    "FADL": "FADL",
+    "FHUA": "FHUA",
+    "LAMB": "LAMB",
+    "LPTD": "LPTD",
+    "NFRA": "NFRA",
+    "OMPA": "OMPA",
+    "OMPC": "OMPC",
+    "OMPF": "OMPF",
+    "TOLC": "TOLC",
+    "TSX": "TSX",
+    "YNCD": "YNCD",
+}
+SURFACE_TARGETS: Tuple[str, ...] = ("LPS_CORE", "O_ANTIGEN", "CAPSULE")
+SUPPORTED_TARGETS: Tuple[str, ...] = (*tuple(PROTEIN_TARGET_COLUMNS.keys()), *SURFACE_TARGETS)
+CAPSULE_PROXY_COLUMNS: Tuple[str, ...] = (
+    "host_capsule_abc",
+    "host_capsule_groupiv_e",
+    "host_capsule_groupiv_e_stricte",
+    "host_capsule_groupiv_s",
+    "host_capsule_wzy_stricte",
+)
+FEATURE_METADATA: Dict[str, Dict[str, str]] = {
+    "lookup_available": {
+        "type": "binary",
+        "transform": "1 when the phage genus or subfamily resolves to a curated lookup entry, else 0.",
+    },
+    "target_receptor_present": {
+        "type": "binary",
+        "transform": "1 when the host has at least one mapped target receptor or surface structure for the phage taxon.",
+    },
+    "protein_target_present": {
+        "type": "binary",
+        "transform": "1 when the host has a non-missing OMP/receptor cluster for at least one mapped protein target.",
+    },
+    "surface_target_present": {
+        "type": "binary",
+        "transform": "1 when the host has an annotated mapped surface-glycan target (LPS core, O-antigen, or capsule).",
+    },
+    "receptor_cluster_matches": {
+        "type": "binary",
+        "transform": (
+            "1 when a mapped protein-receptor cluster for this pair was already seen among leakage-safe training "
+            "positives for the same curated taxon."
+        ),
+    },
+    "receptor_variant_seen_in_training_positives": {
+        "type": "binary",
+        "transform": (
+            "1 when any mapped receptor/surface variant for this pair was already seen among leakage-safe training "
+            "positives for the exact phage."
+        ),
+    },
+    "receptor_variant_training_positive_count": {
+        "type": "integer",
+        "transform": (
+            "Sum of leakage-safe positive-training counts for the exact phage across the pair's mapped receptor/surface "
+            "variants."
+        ),
+    },
+}
+
+
+@dataclass(frozen=True)
+class LookupEntry:
+    match_level: str
+    taxon: str
+    target_receptors: Tuple[str, ...]
+    target_family: str
+    evidence_note: str
+
+
+@dataclass(frozen=True)
+class TargetState:
+    present: int
+    variant: str
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--st02-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st02_pair_table.csv"),
+        help="Input ST0.2 pair table.",
+    )
+    parser.add_argument(
+        "--st03-split-assignments-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_assignments.csv"),
+        help="Input ST0.3 split assignments used for leakage-safe training views.",
+    )
+    parser.add_argument(
+        "--receptor-clusters-path",
+        type=Path,
+        default=Path("data/genomics/bacteria/outer_membrane_proteins/blast_results_cured_clusters=99_wide.tsv"),
+        help="Tab-delimited host receptor cluster assignments.",
+    )
+    parser.add_argument(
+        "--lookup-path",
+        type=Path,
+        default=Path("lyzortx/pipeline/track_e/curated_inputs/genus_receptor_lookup.csv"),
+        help="Curated genus/subfamily to receptor-target lookup CSV.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_e/rbp_receptor_compatibility_feature_block"),
+        help="Directory for generated TE01 outputs.",
+    )
+    parser.add_argument(
+        "--version",
+        type=str,
+        default="v1",
+        help="Version tag embedded in output file names and the manifest.",
+    )
+    return parser.parse_args(argv)
+
+
+def read_delimited_rows(path: Path, delimiter: str = ",") -> List[Dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter=delimiter)
+        if reader.fieldnames is None:
+            raise ValueError(f"No header found in {path}")
+        return [
+            {key: (value.strip() if isinstance(value, str) else "") for key, value in row.items()} for row in reader
+        ]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _is_truthy_flag(value: str) -> bool:
+    normalized = value.strip()
+    if normalized in {"", "0", "0.0"}:
+        return False
+    try:
+        return float(normalized) > 0
+    except ValueError:
+        return normalized.lower() not in {"false", "no", "na", "n/a"}
+
+
+def _require_columns(rows: Sequence[Mapping[str, str]], path: Path, columns: Iterable[str]) -> None:
+    if not rows:
+        raise ValueError(f"No rows found in {path}")
+    missing = [column for column in columns if column not in rows[0]]
+    if missing:
+        raise ValueError(f"Missing required columns in {path}: {', '.join(sorted(missing))}")
+
+
+def resolve_training_flag_column(rows: Sequence[Mapping[str, str]], path: Path) -> str:
+    candidates = ("include_in_training", "label_hard_include_in_training")
+    if not rows:
+        raise ValueError(f"No rows found in {path}")
+    for candidate in candidates:
+        if candidate in rows[0]:
+            return candidate
+    raise ValueError(f"Missing training-flag column in {path}; expected one of: {', '.join(candidates)}")
+
+
+def load_lookup(path: Path) -> Tuple[Dict[str, LookupEntry], Dict[str, LookupEntry]]:
+    rows = read_delimited_rows(path)
+    _require_columns(rows, path, ("match_level", "taxon", "target_receptors", "target_family", "evidence_note"))
+
+    by_genus: Dict[str, LookupEntry] = {}
+    by_subfamily: Dict[str, LookupEntry] = {}
+    for row in rows:
+        match_level = row["match_level"]
+        taxon = row["taxon"]
+        targets = tuple(token.strip().upper() for token in row["target_receptors"].split("|") if token.strip())
+        if not taxon:
+            raise ValueError(f"Empty taxon value in {path}")
+        if match_level not in {"genus", "subfamily"}:
+            raise ValueError(f"Unsupported match_level {match_level!r} in {path}")
+        if not targets:
+            raise ValueError(f"Lookup entry for {taxon!r} has no target receptors in {path}")
+        unknown_targets = sorted(set(targets) - set(SUPPORTED_TARGETS))
+        if unknown_targets:
+            raise ValueError(f"Unsupported target receptor(s) in {path}: {', '.join(unknown_targets)}")
+
+        entry = LookupEntry(
+            match_level=match_level,
+            taxon=taxon,
+            target_receptors=targets,
+            target_family=row["target_family"],
+            evidence_note=row["evidence_note"],
+        )
+        target_index = by_genus if match_level == "genus" else by_subfamily
+        if taxon in target_index:
+            raise ValueError(f"Duplicate {match_level} lookup entry for {taxon!r} in {path}")
+        target_index[taxon] = entry
+
+    return by_genus, by_subfamily
+
+
+def resolve_lookup_entry(
+    *,
+    phage_genus: str,
+    phage_subfamily: str,
+    lookup_by_genus: Mapping[str, LookupEntry],
+    lookup_by_subfamily: Mapping[str, LookupEntry],
+) -> Optional[LookupEntry]:
+    if phage_genus and phage_genus in lookup_by_genus:
+        return lookup_by_genus[phage_genus]
+    if phage_subfamily and phage_subfamily in lookup_by_subfamily:
+        return lookup_by_subfamily[phage_subfamily]
+    return None
+
+
+def build_receptor_index(rows: Sequence[Mapping[str, str]]) -> Dict[str, Dict[str, str]]:
+    _require_columns(rows, Path("<receptor_rows>"), ("bacteria", *PROTEIN_TARGET_COLUMNS.values()))
+    index: Dict[str, Dict[str, str]] = {}
+    for row in rows:
+        bacteria = row.get("bacteria", "")
+        if not bacteria:
+            continue
+        if bacteria in index:
+            raise ValueError(f"Duplicate bacteria value {bacteria!r} in receptor cluster rows")
+        index[bacteria] = dict(row)
+    return index
+
+
+def build_host_target_states(
+    st02_rows: Sequence[Mapping[str, str]],
+    receptor_index: Mapping[str, Mapping[str, str]],
+) -> Dict[str, Dict[str, TargetState]]:
+    state_by_bacteria: Dict[str, Dict[str, TargetState]] = {}
+    for row in st02_rows:
+        bacteria = row.get("bacteria", "")
+        if not bacteria or bacteria in state_by_bacteria:
+            continue
+
+        receptor_row = receptor_index.get(bacteria, {})
+        states: Dict[str, TargetState] = {}
+        for target, source_column in PROTEIN_TARGET_COLUMNS.items():
+            variant = str(receptor_row.get(source_column, "")).strip()
+            states[target] = TargetState(present=1 if variant else 0, variant=variant)
+
+        lps_variant = row.get("host_lps_type", "")
+        states["LPS_CORE"] = TargetState(present=1 if lps_variant else 0, variant=lps_variant)
+
+        o_antigen_variant = row.get("host_o_type", "")
+        states["O_ANTIGEN"] = TargetState(present=1 if o_antigen_variant else 0, variant=o_antigen_variant)
+
+        capsule_variant = row.get("host_abc_serotype", "")
+        capsule_proxy_present = any(_is_truthy_flag(row.get(column, "")) for column in CAPSULE_PROXY_COLUMNS)
+        if capsule_variant:
+            states["CAPSULE"] = TargetState(present=1, variant=capsule_variant)
+        elif capsule_proxy_present:
+            states["CAPSULE"] = TargetState(present=1, variant="__CAPSULE_PROXY_PRESENT__")
+        else:
+            states["CAPSULE"] = TargetState(present=0, variant="")
+
+        state_by_bacteria[bacteria] = states
+
+    return state_by_bacteria
+
+
+def merge_pair_rows(
+    st02_rows: Sequence[Mapping[str, str]],
+    split_rows: Sequence[Mapping[str, str]],
+    host_target_states: Mapping[str, Mapping[str, TargetState]],
+    lookup_by_genus: Mapping[str, LookupEntry],
+    lookup_by_subfamily: Mapping[str, LookupEntry],
+    training_flag_column: str,
+) -> List[Dict[str, object]]:
+    split_by_pair_id = {row["pair_id"]: row for row in split_rows}
+
+    merged_rows: List[Dict[str, object]] = []
+    for row in st02_rows:
+        pair_id = row.get("pair_id", "")
+        if not pair_id:
+            raise ValueError("ST0.2 pair row is missing pair_id")
+        split_row = split_by_pair_id.get(pair_id)
+        if split_row is None:
+            raise ValueError(f"Missing ST0.3 split assignment for pair_id {pair_id!r}")
+
+        bacteria = row.get("bacteria", "")
+        host_states = host_target_states.get(bacteria)
+        if host_states is None:
+            raise ValueError(f"Missing host target states for bacteria {bacteria!r}")
+
+        lookup_entry = resolve_lookup_entry(
+            phage_genus=row.get("phage_genus", ""),
+            phage_subfamily=row.get("phage_subfamily", ""),
+            lookup_by_genus=lookup_by_genus,
+            lookup_by_subfamily=lookup_by_subfamily,
+        )
+
+        split_holdout = split_row.get("split_holdout", "")
+        split_fold_raw = split_row.get("split_cv5_fold", "")
+        split_fold = int(split_fold_raw) if split_fold_raw else -1
+
+        merged_rows.append(
+            {
+                "pair_id": pair_id,
+                "bacteria": bacteria,
+                "phage": row.get("phage", ""),
+                "phage_genus": row.get("phage_genus", ""),
+                "phage_subfamily": row.get("phage_subfamily", ""),
+                "label_hard_any_lysis": row.get("label_hard_any_lysis", ""),
+                "include_in_training": row.get(training_flag_column, ""),
+                "split_holdout": split_holdout,
+                "split_cv5_fold": split_fold,
+                "lookup_entry": lookup_entry,
+                "host_target_states": host_states,
+            }
+        )
+
+    merged_rows.sort(key=lambda item: (str(item["bacteria"]), str(item["phage"])))
+    return merged_rows
+
+
+def _is_training_positive(row: Mapping[str, object]) -> bool:
+    return (
+        str(row.get("include_in_training", "")) == "1"
+        and str(row.get("label_hard_any_lysis", "")) == "1"
+        and str(row.get("split_holdout", "")) == "train_non_holdout"
+    )
+
+
+def _scenario_key(row: Mapping[str, object]) -> str:
+    if str(row.get("split_holdout", "")) == "holdout_test":
+        return "holdout"
+    return f"cv_fold_{int(row['split_cv5_fold'])}"
+
+
+def build_training_variant_indices(
+    merged_rows: Sequence[Mapping[str, object]],
+) -> Dict[str, Dict[str, Dict[Tuple[str, ...], Counter[str]]]]:
+    fold_ids = sorted(
+        {
+            int(row["split_cv5_fold"])
+            for row in merged_rows
+            if str(row.get("split_holdout", "")) == "train_non_holdout" and int(row["split_cv5_fold"]) >= 0
+        }
+    )
+    training_rows_by_scenario: Dict[str, List[Mapping[str, object]]] = {
+        "holdout": [row for row in merged_rows if _is_training_positive(row)]
+    }
+    for fold_id in fold_ids:
+        training_rows_by_scenario[f"cv_fold_{fold_id}"] = [
+            row for row in merged_rows if _is_training_positive(row) and int(row["split_cv5_fold"]) != fold_id
+        ]
+
+    scenario_indices: Dict[str, Dict[str, Dict[Tuple[str, ...], Counter[str]]]] = {}
+    for scenario, training_rows in training_rows_by_scenario.items():
+        phage_variant_counts: Dict[Tuple[str, str], Counter[str]] = defaultdict(Counter)
+        taxon_variant_counts: Dict[Tuple[str, str, str], Counter[str]] = defaultdict(Counter)
+
+        for row in training_rows:
+            lookup_entry = row.get("lookup_entry")
+            if not isinstance(lookup_entry, LookupEntry):
+                continue
+            host_states = row["host_target_states"]
+            for target in lookup_entry.target_receptors:
+                target_state = host_states[target]
+                if not target_state.variant:
+                    continue
+                phage_variant_counts[(str(row["phage"]), target)][target_state.variant] += 1
+                taxon_variant_counts[(lookup_entry.match_level, lookup_entry.taxon, target)][target_state.variant] += 1
+
+        scenario_indices[scenario] = {
+            "phage_variant_counts": phage_variant_counts,
+            "taxon_variant_counts": taxon_variant_counts,
+        }
+
+    return scenario_indices
+
+
+def build_feature_rows(
+    merged_rows: Sequence[Mapping[str, object]],
+    scenario_indices: Mapping[str, Mapping[str, Mapping[Tuple[str, ...], Counter[str]]]],
+) -> List[Dict[str, object]]:
+    feature_rows: List[Dict[str, object]] = []
+    for row in merged_rows:
+        lookup_entry = row.get("lookup_entry")
+        output_row: Dict[str, object] = {
+            "pair_id": row["pair_id"],
+            "bacteria": row["bacteria"],
+            "phage": row["phage"],
+        }
+
+        if not isinstance(lookup_entry, LookupEntry):
+            for column in OUTPUT_FEATURE_COLUMNS:
+                output_row[column] = 0
+            feature_rows.append(output_row)
+            continue
+
+        host_states = row["host_target_states"]
+        scenario = _scenario_key(row)
+        scenario_data = scenario_indices[scenario]
+        taxon_counts = scenario_data["taxon_variant_counts"]
+        phage_counts = scenario_data["phage_variant_counts"]
+
+        target_states = [host_states[target] for target in lookup_entry.target_receptors]
+        protein_targets = [target for target in lookup_entry.target_receptors if target in PROTEIN_TARGET_COLUMNS]
+        surface_targets = [target for target in lookup_entry.target_receptors if target in SURFACE_TARGETS]
+
+        protein_target_present = int(any(host_states[target].present for target in protein_targets))
+        surface_target_present = int(any(host_states[target].present for target in surface_targets))
+
+        protein_cluster_match_count = 0
+        exact_phage_positive_count = 0
+        exact_variant_seen = 0
+        for target in lookup_entry.target_receptors:
+            target_state = host_states[target]
+            if not target_state.variant:
+                continue
+            if (
+                target in PROTEIN_TARGET_COLUMNS
+                and target_state.variant in taxon_counts[(lookup_entry.match_level, lookup_entry.taxon, target)]
+            ):
+                protein_cluster_match_count += 1
+            positive_support = phage_counts[(str(row["phage"]), target)][target_state.variant]
+            if positive_support > 0:
+                exact_variant_seen = 1
+                exact_phage_positive_count += positive_support
+
+        output_row.update(
+            {
+                "lookup_available": 1,
+                "target_receptor_present": int(any(state.present for state in target_states)),
+                "protein_target_present": protein_target_present,
+                "surface_target_present": surface_target_present,
+                "receptor_cluster_matches": int(protein_cluster_match_count > 0),
+                "receptor_variant_seen_in_training_positives": exact_variant_seen,
+                "receptor_variant_training_positive_count": exact_phage_positive_count,
+            }
+        )
+        feature_rows.append(output_row)
+
+    feature_rows.sort(key=lambda item: (str(item["bacteria"]), str(item["phage"])))
+    return feature_rows
+
+
+def build_feature_metadata(lookup_path: Path) -> List[Dict[str, object]]:
+    return [
+        {
+            "column_name": column,
+            "type": FEATURE_METADATA[column]["type"],
+            "source_path": str(lookup_path),
+            "transform": FEATURE_METADATA[column]["transform"],
+        }
+        for column in OUTPUT_FEATURE_COLUMNS
+    ]
+
+
+def build_lookup_summary_rows(
+    merged_rows: Sequence[Mapping[str, object]],
+) -> List[Dict[str, object]]:
+    phage_taxonomy: Dict[str, Dict[str, object]] = {}
+    for row in merged_rows:
+        phage = str(row["phage"])
+        lookup_entry = row.get("lookup_entry")
+        if phage in phage_taxonomy:
+            continue
+        if isinstance(lookup_entry, LookupEntry):
+            phage_taxonomy[phage] = {
+                "phage": phage,
+                "match_level": lookup_entry.match_level,
+                "taxon": lookup_entry.taxon,
+                "target_receptors": "|".join(lookup_entry.target_receptors),
+                "target_family": lookup_entry.target_family,
+                "evidence_note": lookup_entry.evidence_note,
+            }
+        else:
+            phage_taxonomy[phage] = {
+                "phage": phage,
+                "match_level": "",
+                "taxon": "",
+                "target_receptors": "",
+                "target_family": "unknown",
+                "evidence_note": "No curated lookup entry matched this phage genus or subfamily.",
+            }
+    return [phage_taxonomy[phage] for phage in sorted(phage_taxonomy)]
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    ensure_directory(args.output_dir)
+
+    st02_rows = read_delimited_rows(args.st02_pair_table_path)
+    split_rows = read_delimited_rows(args.st03_split_assignments_path)
+    receptor_rows = read_delimited_rows(args.receptor_clusters_path, delimiter="\t")
+    _require_columns(
+        st02_rows,
+        args.st02_pair_table_path,
+        (
+            "pair_id",
+            "bacteria",
+            "phage",
+            "phage_genus",
+            "phage_subfamily",
+            "label_hard_any_lysis",
+            "host_lps_type",
+            "host_o_type",
+            "host_abc_serotype",
+            *CAPSULE_PROXY_COLUMNS,
+        ),
+    )
+    _require_columns(split_rows, args.st03_split_assignments_path, ("pair_id", "split_holdout", "split_cv5_fold"))
+
+    training_flag_column = resolve_training_flag_column(st02_rows, args.st02_pair_table_path)
+    lookup_by_genus, lookup_by_subfamily = load_lookup(args.lookup_path)
+    receptor_index = build_receptor_index(receptor_rows)
+    host_target_states = build_host_target_states(st02_rows, receptor_index)
+    merged_rows = merge_pair_rows(
+        st02_rows,
+        split_rows,
+        host_target_states,
+        lookup_by_genus,
+        lookup_by_subfamily,
+        training_flag_column,
+    )
+    scenario_indices = build_training_variant_indices(merged_rows)
+    feature_rows = build_feature_rows(merged_rows, scenario_indices)
+    metadata_rows = build_feature_metadata(args.lookup_path)
+    lookup_summary_rows = build_lookup_summary_rows(merged_rows)
+
+    feature_output_path = args.output_dir / f"rbp_receptor_compatibility_features_{args.version}.csv"
+    metadata_output_path = args.output_dir / f"rbp_receptor_compatibility_feature_metadata_{args.version}.csv"
+    lookup_summary_output_path = args.output_dir / f"rbp_receptor_lookup_summary_{args.version}.csv"
+    manifest_output_path = args.output_dir / f"rbp_receptor_compatibility_manifest_{args.version}.json"
+
+    write_csv(feature_output_path, ["pair_id", "bacteria", "phage", *OUTPUT_FEATURE_COLUMNS], feature_rows)
+    write_csv(metadata_output_path, ["column_name", "type", "source_path", "transform"], metadata_rows)
+    write_csv(
+        lookup_summary_output_path,
+        ["phage", "match_level", "taxon", "target_receptors", "target_family", "evidence_note"],
+        lookup_summary_rows,
+    )
+
+    lookup_covered_phages = sum(1 for row in lookup_summary_rows if row["match_level"])
+    training_positive_count = sum(1 for row in merged_rows if _is_training_positive(row))
+    manifest = {
+        "step_name": "build_rbp_receptor_compatibility_feature_block",
+        "version": args.version,
+        "created_at_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "pair_count": len(feature_rows),
+        "distinct_bacteria_count": len({row["bacteria"] for row in feature_rows}),
+        "distinct_phage_count": len({row["phage"] for row in feature_rows}),
+        "feature_count": len(OUTPUT_FEATURE_COLUMNS),
+        "lookup_coverage": {
+            "covered_phage_count": lookup_covered_phages,
+            "uncovered_phage_count": len(lookup_summary_rows) - lookup_covered_phages,
+        },
+        "training_positive_count": training_positive_count,
+        "inputs": {
+            "st02_pair_table": {"path": str(args.st02_pair_table_path), "sha256": _sha256(args.st02_pair_table_path)},
+            "st03_split_assignments": {
+                "path": str(args.st03_split_assignments_path),
+                "sha256": _sha256(args.st03_split_assignments_path),
+            },
+            "receptor_clusters": {
+                "path": str(args.receptor_clusters_path),
+                "sha256": _sha256(args.receptor_clusters_path),
+            },
+            "lookup": {"path": str(args.lookup_path), "sha256": _sha256(args.lookup_path)},
+        },
+        "policies": {
+            "training_flag_column": training_flag_column,
+            "lookup_resolution_order": ["phage_genus", "phage_subfamily"],
+        },
+        "outputs": {
+            "feature_csv": str(feature_output_path),
+            "feature_metadata_csv": str(metadata_output_path),
+            "lookup_summary_csv": str(lookup_summary_output_path),
+        },
+    }
+    write_json(manifest_output_path, manifest)
+
+    print(f"Wrote TE01 pairwise compatibility features to {feature_output_path}")
+    print(f"- Pair rows: {len(feature_rows)}")
+    print(f"- Lookup-covered phages: {lookup_covered_phages} / {len(lookup_summary_rows)}")
+    print(f"- Leakage-safe training positives: {training_positive_count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lyzortx/research_notes/lab_notebooks/track_E.md
+++ b/lyzortx/research_notes/lab_notebooks/track_E.md
@@ -1,0 +1,88 @@
+### 2026-03-22: TE01 RBP-receptor compatibility feature block
+
+#### What was implemented
+
+- Added a dedicated Track E builder:
+  `lyzortx/pipeline/track_e/steps/build_rbp_receptor_compatibility_feature_block.py`.
+- Added a Track E runner and README:
+  - `lyzortx/pipeline/track_e/run_track_e.py`
+  - `lyzortx/pipeline/track_e/README.md`
+- Checked in a narrowed curated lookup at
+  `lyzortx/pipeline/track_e/curated_inputs/genus_receptor_lookup.csv`.
+  The lookup prefers exact `phage_genus` matches and falls back to `phage_subfamily` only when genus-level curation is
+  intentionally absent.
+- Defined the TE01 pairwise feature contract around the canonical ST0.2/ST0.3 grid:
+  - output rows stay joinable on `pair_id`, `bacteria`, and `phage`
+  - leakage-safe training-positive views reuse ST0.3 split logic
+  - holdout rows only see `train_non_holdout` positives
+  - non-holdout rows use out-of-fold positives from the other CV folds
+- Emitted `7` per-pair compatibility features:
+  - `lookup_available`
+  - `target_receptor_present`
+  - `protein_target_present`
+  - `surface_target_present`
+  - `receptor_cluster_matches`
+  - `receptor_variant_seen_in_training_positives`
+  - `receptor_variant_training_positive_count`
+- Added regression tests in `lyzortx/tests/test_rbp_receptor_compatibility_feature_block.py` covering:
+  - lookup loading and target validation
+  - leakage-safe exact-phage and taxon-level training aggregation
+  - end-to-end file emission for the feature matrix, metadata, lookup summary, and manifest
+
+#### Output summary
+
+- The generated TE01 output directory is
+  `lyzortx/generated_outputs/track_e/rbp_receptor_compatibility_feature_block/`.
+- The main joinable artifact is `rbp_receptor_compatibility_features_v1.csv`.
+- Supporting outputs are:
+  - `rbp_receptor_compatibility_feature_metadata_v1.csv`
+  - `rbp_receptor_lookup_summary_v1.csv`
+  - `rbp_receptor_compatibility_manifest_v1.json`
+- Final matrix size: `35,424` rows (`369` bacteria x `96` phages) with `7` engineered compatibility features plus the
+  pair join keys.
+- Curated lookup coverage:
+  - `77 / 96` phages covered (`80.2%`)
+  - `19 / 96` phages uncovered (`19.8%`)
+  - Covered target-family split:
+    - `62` phages mapped to surface-glycan targets
+    - `11` phages mapped to mixed `OMPC|LPS_CORE`
+    - `4` phages mapped to single protein receptors (`NFRA` or `LAMB`)
+  - Covered target split:
+    - `44` phages: `O_ANTIGEN|LPS_CORE`
+    - `18` phages: `CAPSULE`
+    - `11` phages: `OMPC|LPS_CORE`
+    - `3` phages: `NFRA`
+    - `1` phage: `LAMB`
+- Feature prevalence across the full pair grid:
+  - `lookup_available = 28,413 / 35,424` pairs (`80.2%`)
+  - `target_receptor_present = 28,391 / 35,424` pairs (`80.1%`)
+  - `protein_target_present = 5,502 / 35,424` pairs (`15.5%`)
+  - `surface_target_present = 26,937 / 35,424` pairs (`76.0%`)
+  - `receptor_cluster_matches = 4,820 / 35,424` pairs (`13.6%`)
+  - `receptor_variant_seen_in_training_positives = 24,963 / 35,424` pairs (`70.5%`)
+- Leakage-safe training positives used for the out-of-fold / holdout aggregations: `8,149`.
+- Total exact-phage variant support accumulated in `receptor_variant_training_positive_count`: `819,067`.
+- The uncovered taxa are explicit rather than silently guessed:
+  - `Kagunavirus / Guernseyvirinae`: `11` phages
+  - `Dhillonvirus / Other`: `4` phages
+  - `Sashavirus / Other`: `2` phages
+  - `Wanchaivirus / Other`: `1` phage
+  - `Wifcevirus / Other`: `1` phage
+
+#### Interpretation
+
+1. The correct simplification for TE01 was to ship a narrow curated lookup with explicit unknowns, not a fake-complete
+   receptor table. The repository does not currently contain enough in-repo evidence to justify exhaustive genus-level
+   receptor claims for every phage in the panel.
+2. Leakage-safe aggregation matters here. `receptor_variant_seen_in_training_positives` would be optimistic noise if it
+   were computed globally, so the builder treats holdout rows and CV rows as different training views.
+3. The most defensible first-cut signal is a mixed receptor contract: exact OMP-cluster matches where protein receptors
+   are known, and surface-glycan presence/variant reuse where the curated target is LPS, O-antigen, or capsule.
+4. This TE01 block is now ready to join onto the canonical pair grid and should be a cleaner way to attack the current
+   popular-phage bias than adding still more raw phage identity features.
+
+#### Next steps
+
+Use this TE01 block alongside the pending Track E defense-evasion and isolation-host-distance features, then measure
+whether the combined pairwise stack improves phage-family holdouts and rescues the strain-specific miss cases already
+documented in the steel-thread notebook.

--- a/lyzortx/tests/test_rbp_receptor_compatibility_feature_block.py
+++ b/lyzortx/tests/test_rbp_receptor_compatibility_feature_block.py
@@ -1,0 +1,309 @@
+import csv
+import json
+from pathlib import Path
+
+from lyzortx.pipeline.track_e.steps.build_rbp_receptor_compatibility_feature_block import (
+    LookupEntry,
+    build_feature_rows,
+    build_host_target_states,
+    build_training_variant_indices,
+    load_lookup,
+    main,
+    merge_pair_rows,
+)
+
+
+def test_load_lookup_prefers_genus_and_validates_targets(tmp_path: Path) -> None:
+    lookup_path = tmp_path / "lookup.csv"
+    lookup_path.write_text(
+        (
+            "match_level,taxon,target_receptors,target_family,evidence_note\n"
+            "genus,Lambdavirus,LAMB,protein,exact override\n"
+            "subfamily,Tevenvirinae,OMPC|LPS_CORE,mixed,fallback\n"
+        ),
+        encoding="utf-8",
+    )
+
+    lookup_by_genus, lookup_by_subfamily = load_lookup(lookup_path)
+
+    assert lookup_by_genus["Lambdavirus"] == LookupEntry(
+        match_level="genus",
+        taxon="Lambdavirus",
+        target_receptors=("LAMB",),
+        target_family="protein",
+        evidence_note="exact override",
+    )
+    assert lookup_by_subfamily["Tevenvirinae"].target_receptors == ("OMPC", "LPS_CORE")
+
+
+def test_build_feature_rows_uses_leakage_safe_training_views() -> None:
+    st02_rows = [
+        {
+            "pair_id": "B1__P1",
+            "bacteria": "B1",
+            "phage": "P1",
+            "phage_genus": "Tequatrovirus",
+            "phage_subfamily": "Tevenvirinae",
+            "label_hard_any_lysis": "1",
+            "include_in_training": "1",
+            "host_lps_type": "R1",
+            "host_o_type": "O1",
+            "host_abc_serotype": "",
+            "host_capsule_abc": "0",
+            "host_capsule_groupiv_e": "0",
+            "host_capsule_groupiv_e_stricte": "0",
+            "host_capsule_groupiv_s": "0",
+            "host_capsule_wzy_stricte": "0",
+        },
+        {
+            "pair_id": "B2__P1",
+            "bacteria": "B2",
+            "phage": "P1",
+            "phage_genus": "Tequatrovirus",
+            "phage_subfamily": "Tevenvirinae",
+            "label_hard_any_lysis": "1",
+            "include_in_training": "1",
+            "host_lps_type": "R2",
+            "host_o_type": "O2",
+            "host_abc_serotype": "",
+            "host_capsule_abc": "0",
+            "host_capsule_groupiv_e": "0",
+            "host_capsule_groupiv_e_stricte": "0",
+            "host_capsule_groupiv_s": "0",
+            "host_capsule_wzy_stricte": "0",
+        },
+        {
+            "pair_id": "B3__P1",
+            "bacteria": "B3",
+            "phage": "P1",
+            "phage_genus": "Tequatrovirus",
+            "phage_subfamily": "Tevenvirinae",
+            "label_hard_any_lysis": "1",
+            "include_in_training": "1",
+            "host_lps_type": "R3",
+            "host_o_type": "O3",
+            "host_abc_serotype": "",
+            "host_capsule_abc": "0",
+            "host_capsule_groupiv_e": "0",
+            "host_capsule_groupiv_e_stricte": "0",
+            "host_capsule_groupiv_s": "0",
+            "host_capsule_wzy_stricte": "0",
+        },
+        {
+            "pair_id": "B4__P2",
+            "bacteria": "B4",
+            "phage": "P2",
+            "phage_genus": "Vectrevirus",
+            "phage_subfamily": "Molineuxvirinae",
+            "label_hard_any_lysis": "0",
+            "include_in_training": "1",
+            "host_lps_type": "",
+            "host_o_type": "",
+            "host_abc_serotype": "K1",
+            "host_capsule_abc": "1",
+            "host_capsule_groupiv_e": "0",
+            "host_capsule_groupiv_e_stricte": "0",
+            "host_capsule_groupiv_s": "0",
+            "host_capsule_wzy_stricte": "0",
+        },
+    ]
+    split_rows = [
+        {"pair_id": "B1__P1", "split_holdout": "train_non_holdout", "split_cv5_fold": "0"},
+        {"pair_id": "B2__P1", "split_holdout": "train_non_holdout", "split_cv5_fold": "1"},
+        {"pair_id": "B3__P1", "split_holdout": "holdout_test", "split_cv5_fold": "-1"},
+        {"pair_id": "B4__P2", "split_holdout": "train_non_holdout", "split_cv5_fold": "0"},
+    ]
+    receptor_rows = [
+        {
+            "bacteria": "B1",
+            "BTUB": "",
+            "FADL": "",
+            "FHUA": "",
+            "LAMB": "",
+            "LPTD": "",
+            "NFRA": "",
+            "OMPA": "",
+            "OMPC": "99_1",
+            "OMPF": "",
+            "TOLC": "",
+            "TSX": "",
+            "YNCD": "",
+        },
+        {
+            "bacteria": "B2",
+            "BTUB": "",
+            "FADL": "",
+            "FHUA": "",
+            "LAMB": "",
+            "LPTD": "",
+            "NFRA": "",
+            "OMPA": "",
+            "OMPC": "99_1",
+            "OMPF": "",
+            "TOLC": "",
+            "TSX": "",
+            "YNCD": "",
+        },
+        {
+            "bacteria": "B3",
+            "BTUB": "",
+            "FADL": "",
+            "FHUA": "",
+            "LAMB": "",
+            "LPTD": "",
+            "NFRA": "",
+            "OMPA": "",
+            "OMPC": "99_1",
+            "OMPF": "",
+            "TOLC": "",
+            "TSX": "",
+            "YNCD": "",
+        },
+        {
+            "bacteria": "B4",
+            "BTUB": "",
+            "FADL": "",
+            "FHUA": "",
+            "LAMB": "",
+            "LPTD": "",
+            "NFRA": "",
+            "OMPA": "",
+            "OMPC": "",
+            "OMPF": "",
+            "TOLC": "",
+            "TSX": "",
+            "YNCD": "",
+        },
+    ]
+
+    lookup_by_genus = {
+        "Vectrevirus": LookupEntry(
+            match_level="genus",
+            taxon="Vectrevirus",
+            target_receptors=("CAPSULE",),
+            target_family="surface_glycan",
+            evidence_note="capsule-targeting override",
+        )
+    }
+    lookup_by_subfamily = {
+        "Tevenvirinae": LookupEntry(
+            match_level="subfamily",
+            taxon="Tevenvirinae",
+            target_receptors=("OMPC", "LPS_CORE"),
+            target_family="mixed",
+            evidence_note="T-even fallback",
+        )
+    }
+
+    receptor_index = {row["bacteria"]: row for row in receptor_rows}
+    host_target_states = build_host_target_states(st02_rows, receptor_index)
+    merged_rows = merge_pair_rows(
+        st02_rows,
+        split_rows,
+        host_target_states,
+        lookup_by_genus,
+        lookup_by_subfamily,
+        "include_in_training",
+    )
+    scenario_indices = build_training_variant_indices(merged_rows)
+    feature_rows = build_feature_rows(merged_rows, scenario_indices)
+
+    by_pair_id = {row["pair_id"]: row for row in feature_rows}
+
+    assert by_pair_id["B1__P1"]["target_receptor_present"] == 1
+    assert by_pair_id["B1__P1"]["protein_target_present"] == 1
+    assert by_pair_id["B1__P1"]["receptor_cluster_matches"] == 1
+    assert by_pair_id["B1__P1"]["receptor_variant_seen_in_training_positives"] == 1
+    assert by_pair_id["B1__P1"]["receptor_variant_training_positive_count"] == 1
+
+    assert by_pair_id["B3__P1"]["receptor_cluster_matches"] == 1
+    assert by_pair_id["B3__P1"]["receptor_variant_training_positive_count"] == 2
+    assert by_pair_id["B4__P2"]["surface_target_present"] == 1
+    assert by_pair_id["B4__P2"]["receptor_variant_seen_in_training_positives"] == 0
+
+
+def test_main_writes_feature_matrix_metadata_lookup_summary_and_manifest(tmp_path: Path) -> None:
+    st02_path = tmp_path / "st02_pair_table.csv"
+    st03_path = tmp_path / "st03_split_assignments.csv"
+    receptor_path = tmp_path / "receptors.tsv"
+    lookup_path = tmp_path / "lookup.csv"
+    output_dir = tmp_path / "out"
+
+    st02_path.write_text(
+        (
+            "pair_id,bacteria,phage,phage_genus,phage_subfamily,label_hard_any_lysis,include_in_training,"
+            "host_lps_type,host_o_type,host_abc_serotype,host_capsule_abc,host_capsule_groupiv_e,"
+            "host_capsule_groupiv_e_stricte,host_capsule_groupiv_s,host_capsule_wzy_stricte\n"
+            "B1__P1,B1,P1,Tequatrovirus,Tevenvirinae,1,1,R1,O1,,0,0,0,0,0\n"
+            "B2__P1,B2,P1,Tequatrovirus,Tevenvirinae,1,1,R2,O2,,0,0,0,0,0\n"
+            "B3__P2,B3,P2,Vectrevirus,Molineuxvirinae,0,1,,,K1,1,0,0,0,0\n"
+        ),
+        encoding="utf-8",
+    )
+    st03_path.write_text(
+        (
+            "pair_id,split_holdout,split_cv5_fold\n"
+            "B1__P1,train_non_holdout,0\n"
+            "B2__P1,train_non_holdout,1\n"
+            "B3__P2,holdout_test,-1\n"
+        ),
+        encoding="utf-8",
+    )
+    receptor_path.write_text(
+        (
+            "bacteria\tBTUB\tFADL\tFHUA\tLAMB\tLPTD\tNFRA\tOMPA\tOMPC\tOMPF\tTOLC\tTSX\tYNCD\n"
+            "B1\t\t\t\t\t\t\t\t99_1\t\t\t\t\n"
+            "B2\t\t\t\t\t\t\t\t99_1\t\t\t\t\n"
+            "B3\t\t\t\t\t\t\t\t\t\t\t\t\n"
+        ),
+        encoding="utf-8",
+    )
+    lookup_path.write_text(
+        (
+            "match_level,taxon,target_receptors,target_family,evidence_note\n"
+            "subfamily,Tevenvirinae,OMPC|LPS_CORE,mixed,T-even fallback\n"
+            "genus,Vectrevirus,CAPSULE,surface_glycan,capsule override\n"
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--st02-pair-table-path",
+            str(st02_path),
+            "--st03-split-assignments-path",
+            str(st03_path),
+            "--receptor-clusters-path",
+            str(receptor_path),
+            "--lookup-path",
+            str(lookup_path),
+            "--output-dir",
+            str(output_dir),
+            "--version",
+            "test",
+        ]
+    )
+
+    assert exit_code == 0
+
+    feature_path = output_dir / "rbp_receptor_compatibility_features_test.csv"
+    metadata_path = output_dir / "rbp_receptor_compatibility_feature_metadata_test.csv"
+    lookup_summary_path = output_dir / "rbp_receptor_lookup_summary_test.csv"
+    manifest_path = output_dir / "rbp_receptor_compatibility_manifest_test.json"
+
+    with feature_path.open("r", encoding="utf-8", newline="") as handle:
+        feature_rows = list(csv.DictReader(handle))
+    with metadata_path.open("r", encoding="utf-8", newline="") as handle:
+        metadata_rows = list(csv.DictReader(handle))
+    with lookup_summary_path.open("r", encoding="utf-8", newline="") as handle:
+        lookup_summary_rows = list(csv.DictReader(handle))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert len(feature_rows) == 3
+    assert feature_rows[0]["pair_id"] == "B1__P1"
+    assert feature_rows[0]["receptor_cluster_matches"] == "1"
+    assert any(row["column_name"] == "target_receptor_present" for row in metadata_rows)
+    assert lookup_summary_rows[0]["phage"] == "P1"
+    assert manifest["pair_count"] == 3
+    assert manifest["feature_count"] == 7
+    assert manifest["lookup_coverage"]["covered_phage_count"] == 2


### PR DESCRIPTION
## Summary
- add a dedicated Track E TE01 builder that emits leakage-safe per-pair RBP-receptor compatibility features from the canonical ST0.2/ST0.3 pair grid
- check in a narrowed curated genus/subfamily receptor lookup plus Track E runner/README and regression tests for lookup loading, leakage-safe aggregation, and end-to-end file emission
- document the generated TE01 artifact, lookup coverage, uncovered taxa, and feature prevalence in the Track E lab notebook

## Testing
- pytest -q lyzortx/tests/

Closes #94
