### PR TITLE
[ORCH][TE02] Build defense-evasion proxy features

### DIFF
--- a/lyzortx/pipeline/track_e/README.md
+++ b/lyzortx/pipeline/track_e/README.md
@@ -5,7 +5,10 @@
 This command runs the implemented Track E pairwise feature builder:
 
 1. `rbp-receptor-compatibility`: write leakage-safe RBP-receptor compatibility features to
-   `lyzortx/generated_outputs/track_e/rbp_receptor_compatibility_feature_block/rbp_receptor_compatibility_features_v1.csv`
+   `lyzortx/generated_outputs/track_e/rbp_receptor_compatibility_feature_block/`
+   `rbp_receptor_compatibility_features_v1.csv`
+2. `defense-evasion-proxy`: write leakage-safe family-by-defense collaborative-filtering features to
+   `lyzortx/generated_outputs/track_e/defense_evasion_proxy_feature_block/defense_evasion_proxy_features_v1.csv`
 
 The TE01 builder reads the canonical ST0.2 pair table, ST0.3 split assignments, the host OMP receptor-cluster table,
 and a checked-in curated genus/subfamily lookup. Lookup matching prefers `phage_genus` and falls back to
@@ -16,3 +19,14 @@ and a checked-in curated genus/subfamily lookup. Lookup matching prefers `phage_
 
 The final feature CSV is joinable on `pair_id`, `bacteria`, and `phage`, and the output directory also includes a
 column-level metadata CSV, a per-phage lookup summary CSV, and a manifest with input/output hashes.
+
+The TE02 builder reads the Track C v1 pair table so it can reuse the audited `host_defense_subtype_*` host features,
+plus ST0.3 split assignments for leakage-safe training views. It computes phage-family average lysis rates against each
+defense subtype from training data only:
+
+1. Holdout rows only use `train_non_holdout` rows with the training flag enabled.
+2. Non-holdout rows use out-of-fold training rows from the other CV folds only.
+
+Per-pair features are then derived by summing the relevant family-by-subtype success rates for the host defense systems
+present on that pair. The output directory includes the joinable feature CSV, column metadata, a long-form
+family/subtype rate table across leakage scenarios, and a manifest.

--- a/lyzortx/pipeline/track_e/run_track_e.py
+++ b/lyzortx/pipeline/track_e/run_track_e.py
@@ -10,14 +10,17 @@ from pathlib import Path
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
-from lyzortx.pipeline.track_e.steps import build_rbp_receptor_compatibility_feature_block
+from lyzortx.pipeline.track_e.steps import (
+    build_defense_evasion_proxy_feature_block,
+    build_rbp_receptor_compatibility_feature_block,
+)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--step",
-        choices=["rbp-receptor-compatibility", "all"],
+        choices=["rbp-receptor-compatibility", "defense-evasion-proxy", "all"],
         default="all",
         help="Track E step to run. 'all' runs the implemented Track E feature builders.",
     )
@@ -28,6 +31,8 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
     if args.step in {"rbp-receptor-compatibility", "all"}:
         build_rbp_receptor_compatibility_feature_block.main([])
+    if args.step in {"defense-evasion-proxy", "all"}:
+        build_defense_evasion_proxy_feature_block.main([])
 
 
 if __name__ == "__main__":

--- a/lyzortx/pipeline/track_e/steps/build_defense_evasion_proxy_feature_block.py
+++ b/lyzortx/pipeline/track_e/steps/build_defense_evasion_proxy_feature_block.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""TE02: Build leakage-safe defense-evasion proxy features from family-by-subtype training rates."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps.st03b_build_split_suite import family_key
+
+OUTPUT_FEATURE_COLUMNS: Tuple[str, ...] = (
+    "defense_evasion_expected_score",
+    "defense_evasion_mean_score",
+    "defense_evasion_supported_subtype_count",
+    "defense_evasion_family_training_pair_count",
+)
+
+FEATURE_METADATA: Dict[str, Dict[str, str]] = {
+    "defense_evasion_expected_score": {
+        "type": "float",
+        "transform": (
+            "Sum of leakage-safe phage-family lysis-rate estimates across all host defense subtypes "
+            "present on the pair."
+        ),
+    },
+    "defense_evasion_mean_score": {
+        "type": "float",
+        "transform": (
+            "defense_evasion_expected_score divided by the host's present defense subtype count; "
+            "0 when none are present."
+        ),
+    },
+    "defense_evasion_supported_subtype_count": {
+        "type": "integer",
+        "transform": (
+            "Count of host defense subtypes whose phage-family lysis-rate estimate was observed in the leakage-safe "
+            "training view for this row."
+        ),
+    },
+    "defense_evasion_family_training_pair_count": {
+        "type": "integer",
+        "transform": (
+            "Number of leakage-safe training pairs available for this phage family in the row's fold/holdout scenario."
+        ),
+    },
+}
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_c/v1_host_feature_pair_table/pair_table_v1.csv"),
+        help="Input pair table containing phage_family and host_defense_subtype_* columns.",
+    )
+    parser.add_argument(
+        "--st03-split-assignments-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_assignments.csv"),
+        help="Input ST0.3 split assignments used for leakage-safe training views.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_e/defense_evasion_proxy_feature_block"),
+        help="Directory for generated TE02 outputs.",
+    )
+    parser.add_argument(
+        "--version",
+        type=str,
+        default="v1",
+        help="Version tag embedded in output file names and the manifest.",
+    )
+    return parser.parse_args(argv)
+
+
+def read_delimited_rows(path: Path, delimiter: str = ",") -> List[Dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter=delimiter)
+        if reader.fieldnames is None:
+            raise ValueError(f"No header found in {path}")
+        return [
+            {key: (value.strip() if isinstance(value, str) else "") for key, value in row.items()} for row in reader
+        ]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _require_columns(rows: Sequence[Mapping[str, str]], path: Path, columns: Iterable[str]) -> None:
+    if not rows:
+        raise ValueError(f"No rows found in {path}")
+    missing = [column for column in columns if column not in rows[0]]
+    if missing:
+        raise ValueError(f"Missing required columns in {path}: {', '.join(sorted(missing))}")
+
+
+def _parse_binary_flag(value: str) -> int:
+    normalized = value.strip()
+    if normalized in {"", "0", "0.0"}:
+        return 0
+    try:
+        parsed = float(normalized)
+    except ValueError as exc:
+        raise ValueError(f"Expected binary/numeric flag, found {value!r}") from exc
+    if parsed < 0:
+        raise ValueError(f"Expected non-negative flag, found {value!r}")
+    return 1 if parsed > 0 else 0
+
+
+def resolve_training_flag_column(rows: Sequence[Mapping[str, str]], path: Path) -> str:
+    candidates = ("include_in_training", "label_hard_include_in_training")
+    if not rows:
+        raise ValueError(f"No rows found in {path}")
+    for candidate in candidates:
+        if candidate in rows[0]:
+            return candidate
+    raise ValueError(f"Missing training-flag column in {path}; expected one of: {', '.join(candidates)}")
+
+
+def detect_defense_subtype_columns(rows: Sequence[Mapping[str, str]], path: Path) -> List[str]:
+    if not rows:
+        raise ValueError(f"No rows found in {path}")
+    columns = sorted(column for column in rows[0] if column.startswith("host_defense_subtype_"))
+    if not columns:
+        raise ValueError(f"No host_defense_subtype_* columns found in {path}")
+    return columns
+
+
+def merge_pair_rows(
+    pair_rows: Sequence[Mapping[str, str]],
+    split_rows: Sequence[Mapping[str, str]],
+    training_flag_column: str,
+    defense_subtype_columns: Sequence[str],
+) -> List[Dict[str, object]]:
+    split_by_pair_id = {row["pair_id"]: row for row in split_rows}
+
+    merged_rows: List[Dict[str, object]] = []
+    for row in pair_rows:
+        pair_id = row.get("pair_id", "")
+        if not pair_id:
+            raise ValueError("Pair-table row is missing pair_id")
+        split_row = split_by_pair_id.get(pair_id)
+        if split_row is None:
+            raise ValueError(f"Missing ST0.3 split assignment for pair_id {pair_id!r}")
+
+        split_fold_raw = split_row.get("split_cv5_fold", "")
+        split_fold = int(split_fold_raw) if split_fold_raw else -1
+        subtype_state = {column: _parse_binary_flag(row.get(column, "")) for column in defense_subtype_columns}
+
+        merged_rows.append(
+            {
+                "pair_id": pair_id,
+                "bacteria": row.get("bacteria", ""),
+                "phage": row.get("phage", ""),
+                "phage_family": family_key(row.get("phage_family", "")),
+                "label_hard_any_lysis": row.get("label_hard_any_lysis", ""),
+                "include_in_training": row.get(training_flag_column, ""),
+                "split_holdout": split_row.get("split_holdout", ""),
+                "split_cv5_fold": split_fold,
+                "host_defense_subtypes": subtype_state,
+            }
+        )
+
+    merged_rows.sort(key=lambda item: (str(item["bacteria"]), str(item["phage"])))
+    return merged_rows
+
+
+def _is_training_example(row: Mapping[str, object]) -> bool:
+    return str(row.get("include_in_training", "")) == "1" and str(row.get("split_holdout", "")) == "train_non_holdout"
+
+
+def _scenario_key(row: Mapping[str, object]) -> str:
+    if str(row.get("split_holdout", "")) == "holdout_test":
+        return "holdout"
+    return f"cv_fold_{int(row['split_cv5_fold'])}"
+
+
+def build_training_family_defense_profiles(
+    merged_rows: Sequence[Mapping[str, object]],
+    defense_subtype_columns: Sequence[str],
+) -> Dict[str, Dict[str, object]]:
+    fold_ids = sorted(
+        {
+            int(row["split_cv5_fold"])
+            for row in merged_rows
+            if str(row.get("split_holdout", "")) == "train_non_holdout" and int(row["split_cv5_fold"]) >= 0
+        }
+    )
+
+    training_rows_by_scenario: Dict[str, List[Mapping[str, object]]] = {
+        "holdout": [row for row in merged_rows if _is_training_example(row)]
+    }
+    for fold_id in fold_ids:
+        training_rows_by_scenario[f"cv_fold_{fold_id}"] = [
+            row for row in merged_rows if _is_training_example(row) and int(row["split_cv5_fold"]) != fold_id
+        ]
+
+    scenario_profiles: Dict[str, Dict[str, object]] = {}
+    for scenario, training_rows in training_rows_by_scenario.items():
+        family_pair_counts: Counter[str] = Counter()
+        subtype_denominators: Counter[Tuple[str, str]] = Counter()
+        subtype_positive_sums: Dict[Tuple[str, str], float] = defaultdict(float)
+
+        for row in training_rows:
+            family = str(row["phage_family"])
+            family_pair_counts[family] += 1
+            label = float(_parse_binary_flag(str(row.get("label_hard_any_lysis", ""))))
+            subtype_state = row["host_defense_subtypes"]
+            for subtype in defense_subtype_columns:
+                if subtype_state[subtype] != 1:
+                    continue
+                subtype_denominators[(family, subtype)] += 1
+                subtype_positive_sums[(family, subtype)] += label
+
+        subtype_rates = {
+            key: subtype_positive_sums[key] / count for key, count in subtype_denominators.items() if count > 0
+        }
+        scenario_profiles[scenario] = {
+            "family_pair_counts": dict(family_pair_counts),
+            "subtype_denominators": dict(subtype_denominators),
+            "subtype_rates": subtype_rates,
+        }
+
+    return scenario_profiles
+
+
+def build_feature_rows(
+    merged_rows: Sequence[Mapping[str, object]],
+    scenario_profiles: Mapping[str, Mapping[str, object]],
+    defense_subtype_columns: Sequence[str],
+) -> List[Dict[str, object]]:
+    feature_rows: List[Dict[str, object]] = []
+    for row in merged_rows:
+        scenario = _scenario_key(row)
+        scenario_profile = scenario_profiles[scenario]
+        family = str(row["phage_family"])
+        family_pair_counts = scenario_profile["family_pair_counts"]
+        subtype_rates = scenario_profile["subtype_rates"]
+        subtype_state = row["host_defense_subtypes"]
+
+        present_subtypes = [subtype for subtype in defense_subtype_columns if subtype_state[subtype] == 1]
+        expected_score = 0.0
+        supported_subtype_count = 0
+        for subtype in present_subtypes:
+            key = (family, subtype)
+            if key in subtype_rates:
+                supported_subtype_count += 1
+            expected_score += float(subtype_rates.get(key, 0.0))
+
+        mean_score = expected_score / len(present_subtypes) if present_subtypes else 0.0
+        feature_rows.append(
+            {
+                "pair_id": row["pair_id"],
+                "bacteria": row["bacteria"],
+                "phage": row["phage"],
+                "defense_evasion_expected_score": round(expected_score, 6),
+                "defense_evasion_mean_score": round(mean_score, 6),
+                "defense_evasion_supported_subtype_count": supported_subtype_count,
+                "defense_evasion_family_training_pair_count": int(family_pair_counts.get(family, 0)),
+            }
+        )
+
+    feature_rows.sort(key=lambda item: (str(item["bacteria"]), str(item["phage"])))
+    return feature_rows
+
+
+def build_feature_metadata(pair_table_path: Path) -> List[Dict[str, object]]:
+    return [
+        {
+            "column_name": column,
+            "type": FEATURE_METADATA[column]["type"],
+            "source_path": str(pair_table_path),
+            "transform": FEATURE_METADATA[column]["transform"],
+        }
+        for column in OUTPUT_FEATURE_COLUMNS
+    ]
+
+
+def build_family_defense_rate_rows(
+    scenario_profiles: Mapping[str, Mapping[str, object]],
+) -> List[Dict[str, object]]:
+    output_rows: List[Dict[str, object]] = []
+    for scenario, profile in sorted(scenario_profiles.items()):
+        family_pair_counts = profile["family_pair_counts"]
+        subtype_denominators = profile["subtype_denominators"]
+        subtype_rates = profile["subtype_rates"]
+        for (family, subtype), denominator in sorted(subtype_denominators.items()):
+            output_rows.append(
+                {
+                    "scenario": scenario,
+                    "phage_family": family,
+                    "defense_subtype": subtype,
+                    "family_training_pair_count": int(family_pair_counts.get(family, 0)),
+                    "subtype_training_pair_count": int(denominator),
+                    "average_lysis_rate": round(float(subtype_rates[(family, subtype)]), 6),
+                }
+            )
+    return output_rows
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    ensure_directory(args.output_dir)
+
+    pair_rows = read_delimited_rows(args.pair_table_path)
+    split_rows = read_delimited_rows(args.st03_split_assignments_path)
+    _require_columns(
+        pair_rows,
+        args.pair_table_path,
+        ("pair_id", "bacteria", "phage", "phage_family", "label_hard_any_lysis"),
+    )
+    _require_columns(split_rows, args.st03_split_assignments_path, ("pair_id", "split_holdout", "split_cv5_fold"))
+
+    training_flag_column = resolve_training_flag_column(pair_rows, args.pair_table_path)
+    defense_subtype_columns = detect_defense_subtype_columns(pair_rows, args.pair_table_path)
+    merged_rows = merge_pair_rows(pair_rows, split_rows, training_flag_column, defense_subtype_columns)
+    scenario_profiles = build_training_family_defense_profiles(merged_rows, defense_subtype_columns)
+    feature_rows = build_feature_rows(merged_rows, scenario_profiles, defense_subtype_columns)
+    metadata_rows = build_feature_metadata(args.pair_table_path)
+    family_rate_rows = build_family_defense_rate_rows(scenario_profiles)
+
+    feature_output_path = args.output_dir / f"defense_evasion_proxy_features_{args.version}.csv"
+    metadata_output_path = args.output_dir / f"defense_evasion_proxy_feature_metadata_{args.version}.csv"
+    family_rates_output_path = args.output_dir / f"family_defense_lysis_rates_{args.version}.csv"
+    manifest_output_path = args.output_dir / f"defense_evasion_proxy_manifest_{args.version}.json"
+
+    write_csv(feature_output_path, ["pair_id", "bacteria", "phage", *OUTPUT_FEATURE_COLUMNS], feature_rows)
+    write_csv(metadata_output_path, ["column_name", "type", "source_path", "transform"], metadata_rows)
+    write_csv(
+        family_rates_output_path,
+        [
+            "scenario",
+            "phage_family",
+            "defense_subtype",
+            "family_training_pair_count",
+            "subtype_training_pair_count",
+            "average_lysis_rate",
+        ],
+        family_rate_rows,
+    )
+
+    holdout_profile = scenario_profiles["holdout"]
+    manifest = {
+        "step_name": "build_defense_evasion_proxy_feature_block",
+        "version": args.version,
+        "created_at_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "pair_count": len(feature_rows),
+        "distinct_bacteria_count": len({row["bacteria"] for row in feature_rows}),
+        "distinct_phage_count": len({row["phage"] for row in feature_rows}),
+        "distinct_family_count": len({family_key(row["phage_family"]) for row in pair_rows}),
+        "feature_count": len(OUTPUT_FEATURE_COLUMNS),
+        "defense_subtype_count": len(defense_subtype_columns),
+        "training_profiles": {
+            "scenario_count": len(scenario_profiles),
+            "holdout_training_pair_count": sum(int(value) for value in holdout_profile["family_pair_counts"].values()),
+            "holdout_family_subtype_rate_count": len(holdout_profile["subtype_rates"]),
+        },
+        "inputs": {
+            "pair_table": {"path": str(args.pair_table_path), "sha256": _sha256(args.pair_table_path)},
+            "st03_split_assignments": {
+                "path": str(args.st03_split_assignments_path),
+                "sha256": _sha256(args.st03_split_assignments_path),
+            },
+        },
+        "policies": {
+            "training_flag_column": training_flag_column,
+            "phage_family_missing_token": "__MISSING_PHAGE_FAMILY__",
+            "training_views": {
+                "holdout_rows": "Use only train_non_holdout rows with training_flag=1.",
+                "cv_rows": "Use only train_non_holdout rows with training_flag=1 from all other CV folds.",
+            },
+            "rate_definition": (
+                "Average label_hard_any_lysis among leakage-safe training pairs where the defense subtype is present."
+            ),
+            "score_definition": "Sum family-by-subtype lysis rates across the host's present defense subtype columns.",
+        },
+        "outputs": {
+            "feature_csv": str(feature_output_path),
+            "feature_metadata_csv": str(metadata_output_path),
+            "family_defense_rate_csv": str(family_rates_output_path),
+        },
+    }
+    write_json(manifest_output_path, manifest)
+
+    print(f"Wrote TE02 defense-evasion proxy features to {feature_output_path}")
+    print(f"- Pair rows: {len(feature_rows)}")
+    print(f"- Defense subtype columns: {len(defense_subtype_columns)}")
+    print(f"- Holdout training pairs: {manifest['training_profiles']['holdout_training_pair_count']}")
+    print(f"- Holdout family-subtype rates: {manifest['training_profiles']['holdout_family_subtype_rate_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lyzortx/research_notes/lab_notebooks/track_E.md
+++ b/lyzortx/research_notes/lab_notebooks/track_E.md
@@ -86,3 +86,95 @@
 Use this TE01 block alongside the pending Track E defense-evasion and isolation-host-distance features, then measure
 whether the combined pairwise stack improves phage-family holdouts and rescues the strain-specific miss cases already
 documented in the steel-thread notebook.
+
+### 2026-03-22: TE02 Defense-evasion proxy feature block
+
+#### What was implemented
+
+- Added a dedicated Track E builder:
+  `lyzortx/pipeline/track_e/steps/build_defense_evasion_proxy_feature_block.py`.
+- Wired the builder into the Track E entrypoint and README:
+  - `lyzortx/pipeline/track_e/run_track_e.py`
+  - `lyzortx/pipeline/track_e/README.md`
+- Reused the audited Track C host-defense encoding instead of reparsing raw defense-finder inputs in Track E:
+  - input pair grid:
+    `lyzortx/generated_outputs/track_c/v1_host_feature_pair_table/pair_table_v1.csv`
+  - split assignments:
+    `lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_assignments.csv`
+- Defined the TE02 collaborative-filtering contract around phage-family x defense-subtype averages:
+  - detect all `host_defense_subtype_*` columns from the Track C pair table
+  - normalize missing families with the same `__MISSING_PHAGE_FAMILY__` policy used in ST0.3b
+  - for each leakage scenario, compute family-specific average `label_hard_any_lysis` only on
+    `train_non_holdout` rows with the training flag enabled
+  - holdout rows see the full non-holdout training slice
+  - non-holdout rows see out-of-fold training rows from the other CV folds only
+- Emitted `4` per-pair TE02 features:
+  - `defense_evasion_expected_score`
+  - `defense_evasion_mean_score`
+  - `defense_evasion_supported_subtype_count`
+  - `defense_evasion_family_training_pair_count`
+- Added supporting artifacts for traceability:
+  - `family_defense_lysis_rates_v1.csv` with long-form scenario/family/subtype averages
+  - `defense_evasion_proxy_feature_metadata_v1.csv`
+  - `defense_evasion_proxy_manifest_v1.json`
+- Added regression tests in `lyzortx/tests/test_defense_evasion_proxy_feature_block.py` covering:
+  - fold-exclusion leakage protection for CV rows
+  - holdout-only training views
+  - end-to-end emission of the feature matrix, metadata, rate table, and manifest
+
+#### Output summary
+
+- The generated TE02 output directory is
+  `lyzortx/generated_outputs/track_e/defense_evasion_proxy_feature_block/`.
+- The main joinable artifact is `defense_evasion_proxy_features_v1.csv`.
+- Supporting outputs are:
+  - `defense_evasion_proxy_feature_metadata_v1.csv`
+  - `family_defense_lysis_rates_v1.csv`
+  - `defense_evasion_proxy_manifest_v1.json`
+- Final matrix size: `35,424` rows (`369` bacteria x `96` phages) with `4` engineered defense-evasion features plus
+  the pair join keys.
+- The builder consumed:
+  - `79` retained host defense subtype columns from the Track C v1 pair table
+  - `5` phage families across the panel
+  - `29,031` leakage-safe non-holdout training pairs for the holdout scenario
+  - `395` holdout family-subtype rate cells (`5` families x `79` subtypes)
+  - `2,365` total scenario-specific rate rows across `6` scenarios (`holdout` + `5` CV folds)
+- Fold-specific sparsity was minimal:
+  - `cv_fold_3` dropped `5` family/subtype cells because `host_defense_subtype_gao_hhe` only appeared in that fold's
+    excluded training rows
+  - all other scenarios retained the full `395` family/subtype matrix
+- Feature distribution across the full pair grid:
+  - `defense_evasion_expected_score` mean `2.216`, median `1.964`, max `7.534`
+  - `defense_evasion_mean_score` mean `0.284`, median `0.321`
+  - `defense_evasion_supported_subtype_count` mean `7.80`, median `8`, max `15`
+  - all `35,424 / 35,424` pairs had non-zero expected score and non-zero subtype support in the holdout view
+- Family-level score ordering was strong and stable:
+  - `Straboviridae`: mean expected score `4.048`
+  - `Other`: `2.773`
+  - `Autographiviridae`: `1.365`
+  - `Schitoviridae`: `0.937`
+  - `Drexlerviridae`: `0.652`
+- Highest holdout family/subtype rates were concentrated in `Straboviridae`, for example:
+  - `host_defense_subtype_thoeris_i`: `0.848`
+  - `host_defense_subtype_fs_hsd_r_like`: `0.818`
+  - `host_defense_subtype_thoeris_ii`: `0.800`
+
+#### Interpretation
+
+1. The implementation is genuinely leakage-safe with respect to the ST0.3 host-group split. Each evaluation row uses
+   only non-holdout training rows, and non-holdout rows exclude their own CV fold before computing family/subtype
+   averages.
+2. TE02 ended up dense rather than sparse on the current panel. Because all `5` phage families have training support
+   for almost every retained defense subtype, the feature block behaves more like a family-conditioned weighting of host
+   defense burden than a missingness-heavy collaborative filter.
+3. The strongest evasion priors belong to `Straboviridae`, which is exactly the family where a defense-evasion proxy is
+   most likely to matter. The rank ordering also shows that TE02 is carrying real phage-family identity signal rather
+   than only host-side defense counts.
+4. The open limitation is scope: this builder is keyed to the ST0.3 host-group split, not the ST0.3b phage-family
+   holdout suite. When Track F benchmarks the phage-family holdout explicitly, we should decide whether TE02 is
+   disabled there or given an unseen-family fallback instead of pretending those family priors are available.
+
+#### Next steps
+
+Join TE01 and TE02 into the Track F ablation stack, then decide the correct behavior for TE02 under explicit
+phage-family holdouts before using it in the final dual-axis evaluation suite.

--- a/lyzortx/tests/test_defense_evasion_proxy_feature_block.py
+++ b/lyzortx/tests/test_defense_evasion_proxy_feature_block.py
@@ -1,0 +1,156 @@
+import csv
+import json
+from pathlib import Path
+
+from lyzortx.pipeline.track_e.steps.build_defense_evasion_proxy_feature_block import (
+    build_feature_rows,
+    build_training_family_defense_profiles,
+    main,
+    merge_pair_rows,
+)
+
+
+def test_build_feature_rows_uses_leakage_safe_family_subtype_rates() -> None:
+    pair_rows = [
+        {
+            "pair_id": "B1__P1",
+            "bacteria": "B1",
+            "phage": "P1",
+            "phage_family": "FamA",
+            "label_hard_any_lysis": "1",
+            "include_in_training": "1",
+            "host_defense_subtype_abi_d": "1",
+            "host_defense_subtype_cas_type_i": "0",
+        },
+        {
+            "pair_id": "B2__P2",
+            "bacteria": "B2",
+            "phage": "P2",
+            "phage_family": "FamA",
+            "label_hard_any_lysis": "0",
+            "include_in_training": "1",
+            "host_defense_subtype_abi_d": "1",
+            "host_defense_subtype_cas_type_i": "0",
+        },
+        {
+            "pair_id": "B3__P3",
+            "bacteria": "B3",
+            "phage": "P3",
+            "phage_family": "FamA",
+            "label_hard_any_lysis": "1",
+            "include_in_training": "1",
+            "host_defense_subtype_abi_d": "0",
+            "host_defense_subtype_cas_type_i": "1",
+        },
+        {
+            "pair_id": "B4__P4",
+            "bacteria": "B4",
+            "phage": "P4",
+            "phage_family": "FamA",
+            "label_hard_any_lysis": "1",
+            "include_in_training": "1",
+            "host_defense_subtype_abi_d": "1",
+            "host_defense_subtype_cas_type_i": "0",
+        },
+        {
+            "pair_id": "B5__P5",
+            "bacteria": "B5",
+            "phage": "P5",
+            "phage_family": "FamA",
+            "label_hard_any_lysis": "1",
+            "include_in_training": "0",
+            "host_defense_subtype_abi_d": "1",
+            "host_defense_subtype_cas_type_i": "0",
+        },
+    ]
+    split_rows = [
+        {"pair_id": "B1__P1", "split_holdout": "train_non_holdout", "split_cv5_fold": "0"},
+        {"pair_id": "B2__P2", "split_holdout": "train_non_holdout", "split_cv5_fold": "1"},
+        {"pair_id": "B3__P3", "split_holdout": "train_non_holdout", "split_cv5_fold": "1"},
+        {"pair_id": "B4__P4", "split_holdout": "holdout_test", "split_cv5_fold": "-1"},
+        {"pair_id": "B5__P5", "split_holdout": "train_non_holdout", "split_cv5_fold": "1"},
+    ]
+    defense_subtype_columns = ["host_defense_subtype_abi_d", "host_defense_subtype_cas_type_i"]
+
+    merged_rows = merge_pair_rows(pair_rows, split_rows, "include_in_training", defense_subtype_columns)
+    scenario_profiles = build_training_family_defense_profiles(merged_rows, defense_subtype_columns)
+    feature_rows = build_feature_rows(merged_rows, scenario_profiles, defense_subtype_columns)
+
+    by_pair_id = {row["pair_id"]: row for row in feature_rows}
+
+    assert by_pair_id["B1__P1"]["defense_evasion_expected_score"] == 0.0
+    assert by_pair_id["B1__P1"]["defense_evasion_supported_subtype_count"] == 1
+    assert by_pair_id["B1__P1"]["defense_evasion_family_training_pair_count"] == 2
+
+    assert by_pair_id["B4__P4"]["defense_evasion_expected_score"] == 0.5
+    assert by_pair_id["B4__P4"]["defense_evasion_mean_score"] == 0.5
+    assert by_pair_id["B4__P4"]["defense_evasion_family_training_pair_count"] == 3
+
+    holdout_rates = scenario_profiles["holdout"]["subtype_rates"]
+    assert holdout_rates[("FamA", "host_defense_subtype_abi_d")] == 0.5
+    assert holdout_rates[("FamA", "host_defense_subtype_cas_type_i")] == 1.0
+
+
+def test_main_writes_feature_matrix_metadata_rate_table_and_manifest(tmp_path: Path) -> None:
+    pair_table_path = tmp_path / "pair_table.csv"
+    st03_path = tmp_path / "st03_split_assignments.csv"
+    output_dir = tmp_path / "out"
+
+    pair_table_path.write_text(
+        (
+            "pair_id,bacteria,phage,phage_family,label_hard_any_lysis,include_in_training,"
+            "host_defense_subtype_abi_d,host_defense_subtype_cas_type_i\n"
+            "B1__P1,B1,P1,FamA,1,1,1,0\n"
+            "B2__P2,B2,P2,FamA,0,1,1,0\n"
+            "B3__P3,B3,P3,FamA,1,1,0,1\n"
+        ),
+        encoding="utf-8",
+    )
+    st03_path.write_text(
+        (
+            "pair_id,split_holdout,split_cv5_fold\n"
+            "B1__P1,train_non_holdout,0\n"
+            "B2__P2,train_non_holdout,1\n"
+            "B3__P3,holdout_test,-1\n"
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--pair-table-path",
+            str(pair_table_path),
+            "--st03-split-assignments-path",
+            str(st03_path),
+            "--output-dir",
+            str(output_dir),
+            "--version",
+            "test",
+        ]
+    )
+
+    assert exit_code == 0
+
+    feature_path = output_dir / "defense_evasion_proxy_features_test.csv"
+    metadata_path = output_dir / "defense_evasion_proxy_feature_metadata_test.csv"
+    family_rates_path = output_dir / "family_defense_lysis_rates_test.csv"
+    manifest_path = output_dir / "defense_evasion_proxy_manifest_test.json"
+
+    with feature_path.open("r", encoding="utf-8", newline="") as handle:
+        feature_rows = list(csv.DictReader(handle))
+    with metadata_path.open("r", encoding="utf-8", newline="") as handle:
+        metadata_rows = list(csv.DictReader(handle))
+    with family_rates_path.open("r", encoding="utf-8", newline="") as handle:
+        family_rate_rows = list(csv.DictReader(handle))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert len(feature_rows) == 3
+    by_pair_id = {row["pair_id"]: row for row in feature_rows}
+    assert feature_rows[0]["pair_id"] == "B1__P1"
+    assert by_pair_id["B2__P2"]["defense_evasion_expected_score"] == "1.0"
+    assert by_pair_id["B3__P3"]["defense_evasion_expected_score"] == "0.0"
+    assert any(row["column_name"] == "defense_evasion_expected_score" for row in metadata_rows)
+    assert any(row["scenario"] == "holdout" for row in family_rate_rows)
+    assert manifest["pair_count"] == 3
+    assert manifest["feature_count"] == 4
+    assert manifest["training_profiles"]["holdout_training_pair_count"] == 2


### PR DESCRIPTION
## Summary

- add `build_defense_evasion_proxy_feature_block.py` as the TE02 Track E builder
- compute leakage-safe phage-family x defense-subtype average lysis rates from training rows only
- project those rates back onto each pair as four joinable defense-evasion proxy features
- emit traceability artifacts for TE02: feature metadata, long-form family/subtype rate table, and manifest
- wire the new step into `lyzortx/pipeline/track_e/run_track_e.py` and document it in the Track E README
- add TE02 regression tests and write the implementation/results note to the Track E lab notebook

## Validation

- `pytest -q lyzortx/tests/`
- `python -m lyzortx.pipeline.track_e.run_track_e --step defense-evasion-proxy`

## Notes

- The TE02 builder is leakage-safe for the ST0.3 host-group split by using non-holdout training rows only and by
  excluding the current CV fold for non-holdout rows.
- The lab notebook notes one open follow-up: Track F still needs an explicit policy for TE02 under phage-family
  holdouts, because this builder is keyed to ST0.3 host-group splits rather than ST0.3b family holdouts.

Posted by Codex GPT-5.

Closes #96
