### PR TITLE
[ORCH][TG01] Train LightGBM binary classifier on v1 expanded feature set

### DIFF
--- a/lyzortx/pipeline/track_g/README.md
+++ b/lyzortx/pipeline/track_g/README.md
@@ -1,0 +1,26 @@
+# Track G Modeling Pipeline
+
+`python lyzortx/pipeline/track_g/run_track_g.py`
+
+This command runs the implemented Track G modeling step:
+
+1. `train-v1-binary`: build any missing Track C/D/E prerequisites, train tuned LightGBM and logistic-regression
+   binary classifiers on the v1 expanded feature space, and write outputs under
+   `lyzortx/generated_outputs/track_g/tg01_v1_binary_classifier/`
+
+The TG01 trainer reuses the canonical ST0.2 / ST0.3 leakage-safe contract:
+
+1. ST0.3's `split_holdout` assignment remains the fixed holdout boundary.
+2. ST0.3's `split_cv5_fold` assignments provide the grouped 5-fold non-holdout CV used for tuning.
+3. The feature space combines:
+   - ST0.4's audited v0 metadata feature columns
+   - Track C's additional host-genomic columns from `pair_table_v1.csv`
+   - Track D's phage-genomic feature CSVs
+   - Track E's pairwise compatibility feature CSVs
+
+The output directory includes:
+
+1. `tg01_model_summary.json`: best hyperparameters plus CV and holdout metrics for both models
+2. `tg01_cv_candidate_results.csv`: flattened candidate-level tuning summaries
+3. `tg01_pair_predictions.csv`: non-holdout out-of-fold predictions and final holdout predictions
+4. `tg01_holdout_top3_rankings.csv`: top-3 holdout rankings for both model families

--- a/lyzortx/pipeline/track_g/run_track_g.py
+++ b/lyzortx/pipeline/track_g/run_track_g.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Entry point for Track G modeling tasks."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from lyzortx.pipeline.track_g.steps import train_v1_binary_classifier
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--step",
+        choices=["train-v1-binary", "all"],
+        default="all",
+        help="Track G step to run. 'all' runs the implemented Track G modeling steps.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    if args.step in {"train-v1-binary", "all"}:
+        train_v1_binary_classifier.main([])
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/pipeline/track_g/steps/train_v1_binary_classifier.py
+++ b/lyzortx/pipeline/track_g/steps/train_v1_binary_classifier.py
@@ -1,0 +1,931 @@
+#!/usr/bin/env python3
+"""TG01: Train tuned LightGBM and logistic-regression models on the v1 expanded feature set."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import warnings
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from sklearn.feature_extraction import DictVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import average_precision_score, brier_score_loss, log_loss, roc_auc_score
+from sklearn.model_selection import ParameterGrid
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import parse_float, read_csv_rows, safe_round
+from lyzortx.pipeline.steel_thread_v0.steps.st04_train_baselines import (
+    CATEGORICAL_FEATURE_COLUMNS as V0_CATEGORICAL_FEATURE_COLUMNS,
+)
+from lyzortx.pipeline.steel_thread_v0.steps.st04_train_baselines import (
+    NUMERIC_FEATURE_COLUMNS as V0_NUMERIC_FEATURE_COLUMNS,
+)
+from lyzortx.pipeline.track_c.steps.build_v1_host_feature_pair_table import EXTENDED_CATEGORICAL_COLUMNS
+from lyzortx.pipeline.track_c.steps import build_v1_host_feature_pair_table
+from lyzortx.pipeline.track_d import run_track_d
+from lyzortx.pipeline.track_e import run_track_e
+from lyzortx.pipeline.steel_thread_v0.steps import (
+    st01_label_policy,
+    st01b_confidence_tiers,
+    st02_build_pair_table,
+    st03_build_splits,
+)
+
+IDENTIFIER_COLUMNS: Tuple[str, ...] = ("pair_id", "bacteria", "phage")
+TRACK_E_REQUIRED_BLOCKS: Tuple[Tuple[str, Path], ...] = (
+    (
+        "rbp_receptor_compatibility",
+        Path(
+            "lyzortx/generated_outputs/track_e/rbp_receptor_compatibility_feature_block/"
+            "rbp_receptor_compatibility_features_v1.csv"
+        ),
+    ),
+    (
+        "defense_evasion_proxy",
+        Path(
+            "lyzortx/generated_outputs/track_e/defense_evasion_proxy_feature_block/"
+            "defense_evasion_proxy_features_v1.csv"
+        ),
+    ),
+    (
+        "isolation_host_distance",
+        Path(
+            "lyzortx/generated_outputs/track_e/isolation_host_distance_feature_block/"
+            "isolation_host_distance_features_v1.csv"
+        ),
+    ),
+)
+LIGHTGBM_PARAMETER_GRID: Tuple[Dict[str, object], ...] = tuple(
+    ParameterGrid(
+        {
+            "n_estimators": [150, 300],
+            "learning_rate": [0.03, 0.05],
+            "num_leaves": [15, 31],
+            "min_child_samples": [10, 25],
+        }
+    )
+)
+LOGISTIC_PARAMETER_GRID: Tuple[Dict[str, object], ...] = tuple(ParameterGrid({"C": [0.1, 0.3, 1.0, 3.0, 10.0]}))
+
+
+@dataclass(frozen=True)
+class FeatureSpace:
+    categorical_columns: Tuple[str, ...]
+    numeric_columns: Tuple[str, ...]
+    track_c_additional_columns: Tuple[str, ...]
+    track_d_columns: Tuple[str, ...]
+    track_e_columns: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FoldDataset:
+    fold_id: int
+    train_rows: Tuple[Dict[str, object], ...]
+    valid_rows: Tuple[Dict[str, object], ...]
+    y_train: Tuple[int, ...]
+    y_valid: Tuple[int, ...]
+    X_train: Any
+    X_valid: Any
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--st02-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st02_pair_table.csv"),
+        help="Input ST0.2 pair table path.",
+    )
+    parser.add_argument(
+        "--st03-split-assignments-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_assignments.csv"),
+        help="Input ST0.3 split assignments path.",
+    )
+    parser.add_argument(
+        "--track-c-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_c/v1_host_feature_pair_table/pair_table_v1.csv"),
+        help="Input Track C v1 pair table path.",
+    )
+    parser.add_argument(
+        "--track-d-genome-kmer-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_d/phage_genome_kmer_features/phage_genome_kmer_features.csv"),
+        help="Input Track D genome k-mer feature CSV.",
+    )
+    parser.add_argument(
+        "--track-d-distance-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_d/phage_distance_embedding/phage_distance_embedding_features.csv"
+        ),
+        help="Input Track D phage-distance feature CSV.",
+    )
+    parser.add_argument(
+        "--track-e-rbp-compatibility-path",
+        type=Path,
+        default=TRACK_E_REQUIRED_BLOCKS[0][1],
+        help="Input Track E RBP-receptor compatibility feature CSV.",
+    )
+    parser.add_argument(
+        "--track-e-defense-evasion-path",
+        type=Path,
+        default=TRACK_E_REQUIRED_BLOCKS[1][1],
+        help="Input Track E defense-evasion proxy feature CSV.",
+    )
+    parser.add_argument(
+        "--track-e-isolation-distance-path",
+        type=Path,
+        default=TRACK_E_REQUIRED_BLOCKS[2][1],
+        help="Input Track E isolation-host distance feature CSV.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_g/tg01_v1_binary_classifier"),
+        help="Directory for generated TG01 artifacts.",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=42,
+        help="Base random seed for tuned models.",
+    )
+    parser.add_argument(
+        "--skip-prerequisites",
+        action="store_true",
+        help="Assume prerequisite Track C/D/E outputs already exist instead of generating missing artifacts.",
+    )
+    return parser.parse_args(argv)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _deduplicate_preserving_order(values: Iterable[str]) -> Tuple[str, ...]:
+    out: List[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return tuple(out)
+
+
+def _build_feature_dict(
+    row: Mapping[str, object],
+    *,
+    categorical_columns: Sequence[str],
+    numeric_columns: Sequence[str],
+) -> Dict[str, object]:
+    features: Dict[str, object] = {}
+    for column in categorical_columns:
+        value = row.get(column, "")
+        if value not in {"", None}:
+            features[column] = str(value)
+    for column in numeric_columns:
+        raw = row.get(column, "")
+        if raw in {"", None}:
+            continue
+        if isinstance(raw, (int, float)):
+            features[column] = float(raw)
+            continue
+        parsed = parse_float(str(raw))
+        if parsed is not None:
+            features[column] = parsed
+    return features
+
+
+def compute_binary_metrics(y_true: Sequence[int], y_prob: Sequence[float]) -> Dict[str, Optional[float]]:
+    if not y_true:
+        raise ValueError("No labels available for metric computation.")
+
+    metrics: Dict[str, Optional[float]] = {
+        "n": float(len(y_true)),
+        "positive_rate": safe_round(sum(y_true) / len(y_true)),
+        "average_precision": None,
+        "roc_auc": None,
+        "brier_score": safe_round(brier_score_loss(y_true, y_prob)),
+        "log_loss": safe_round(log_loss(y_true, y_prob, labels=[0, 1])),
+    }
+    if len(set(y_true)) >= 2:
+        metrics["average_precision"] = safe_round(average_precision_score(y_true, y_prob))
+        metrics["roc_auc"] = safe_round(roc_auc_score(y_true, y_prob))
+    return metrics
+
+
+def _predict_probabilities(estimator: Any, X: Any) -> List[float]:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="X does not have valid feature names, but LGBMClassifier was fitted with feature names",
+            category=UserWarning,
+        )
+        return [float(value) for value in estimator.predict_proba(X)[:, 1]]
+
+
+def compute_top3_hit_rate(rows: Sequence[Mapping[str, object]], *, probability_key: str) -> Dict[str, object]:
+    rows_by_bacteria: Dict[str, List[Mapping[str, object]]] = {}
+    for row in rows:
+        rows_by_bacteria.setdefault(str(row["bacteria"]), []).append(row)
+
+    total = 0
+    hits = 0
+    susceptible_total = 0
+    susceptible_hits = 0
+    for bacteria_rows in rows_by_bacteria.values():
+        ranked = sorted(bacteria_rows, key=lambda row: (-float(row[probability_key]), str(row["phage"])))
+        top3 = ranked[:3]
+        is_hit = any(int(row["label_hard_any_lysis"]) == 1 for row in top3)
+        total += 1
+        hits += 1 if is_hit else 0
+        is_susceptible = any(int(row["label_hard_any_lysis"]) == 1 for row in ranked)
+        if is_susceptible:
+            susceptible_total += 1
+            susceptible_hits += 1 if is_hit else 0
+
+    return {
+        "strain_count": total,
+        "hit_count": hits,
+        "top3_hit_rate_all_strains": safe_round(hits / total if total else 0.0),
+        "susceptible_strain_count": susceptible_total,
+        "susceptible_hit_count": susceptible_hits,
+        "top3_hit_rate_susceptible_only": safe_round(
+            susceptible_hits / susceptible_total if susceptible_total else 0.0
+        ),
+    }
+
+
+def select_best_candidate(results: Sequence[Mapping[str, object]]) -> Dict[str, object]:
+    if not results:
+        raise ValueError("No CV candidate results available.")
+
+    def _sort_key(result: Mapping[str, object]) -> Tuple[float, float, float, str]:
+        summary = result["summary"]
+        roc_auc = float(summary["mean_roc_auc"] or float("-inf"))
+        top3 = float(summary["mean_top3_hit_rate_all_strains"] or float("-inf"))
+        brier = float(summary["mean_brier_score"] or float("inf"))
+        params = json.dumps(result["params"], sort_keys=True)
+        return (roc_auc, top3, -brier, params)
+
+    return dict(max(results, key=_sort_key))
+
+
+def prepare_fold_datasets(
+    rows: Sequence[Mapping[str, object]],
+    feature_space: FeatureSpace,
+) -> List[FoldDataset]:
+    training_rows = [
+        dict(row)
+        for row in rows
+        if row["split_holdout"] == "train_non_holdout" and str(row["is_hard_trainable"]) == "1"
+    ]
+    if not training_rows:
+        raise ValueError("No non-holdout hard-trainable rows available for TG01.")
+
+    fold_ids = sorted(
+        {int(str(row["split_cv5_fold"])) for row in training_rows if int(str(row["split_cv5_fold"])) >= 0}
+    )
+    if len(fold_ids) < 2:
+        raise ValueError("TG01 requires at least two non-holdout folds.")
+
+    datasets: List[FoldDataset] = []
+    for fold_id in fold_ids:
+        train_rows = tuple(row for row in training_rows if int(str(row["split_cv5_fold"])) != fold_id)
+        valid_rows = tuple(row for row in training_rows if int(str(row["split_cv5_fold"])) == fold_id)
+        if not train_rows or not valid_rows:
+            raise ValueError(f"Fold {fold_id} is missing train or validation rows.")
+        y_train = tuple(int(str(row["label_hard_any_lysis"])) for row in train_rows)
+        y_valid = tuple(int(str(row["label_hard_any_lysis"])) for row in valid_rows)
+        vectorizer = DictVectorizer(sparse=True, sort=True)
+        X_train = vectorizer.fit_transform(
+            [
+                _build_feature_dict(
+                    row,
+                    categorical_columns=feature_space.categorical_columns,
+                    numeric_columns=feature_space.numeric_columns,
+                )
+                for row in train_rows
+            ]
+        )
+        X_valid = vectorizer.transform(
+            [
+                _build_feature_dict(
+                    row,
+                    categorical_columns=feature_space.categorical_columns,
+                    numeric_columns=feature_space.numeric_columns,
+                )
+                for row in valid_rows
+            ]
+        )
+        datasets.append(
+            FoldDataset(
+                fold_id=fold_id,
+                train_rows=train_rows,
+                valid_rows=valid_rows,
+                y_train=y_train,
+                y_valid=y_valid,
+                X_train=X_train,
+                X_valid=X_valid,
+            )
+        )
+    return datasets
+
+
+def evaluate_candidate_grid(
+    fold_datasets: Sequence[FoldDataset],
+    *,
+    candidate_params: Sequence[Mapping[str, object]],
+    estimator_factory: Callable[[Mapping[str, object], int], Any],
+    model_label: str,
+) -> List[Dict[str, object]]:
+    results: List[Dict[str, object]] = []
+    for params in candidate_params:
+        fold_metrics: List[Dict[str, object]] = []
+        for dataset in fold_datasets:
+            estimator = estimator_factory(params, dataset.fold_id)
+            estimator.fit(dataset.X_train, dataset.y_train)
+            probabilities = _predict_probabilities(estimator, dataset.X_valid)
+            scored_rows = []
+            for row, probability in zip(dataset.valid_rows, probabilities):
+                scored = dict(row)
+                scored["predicted_probability"] = probability
+                scored_rows.append(scored)
+
+            binary_metrics = compute_binary_metrics(dataset.y_valid, probabilities)
+            top3_metrics = compute_top3_hit_rate(scored_rows, probability_key="predicted_probability")
+            fold_metrics.append(
+                {
+                    "fold_id": dataset.fold_id,
+                    "train_rows": len(dataset.train_rows),
+                    "validation_rows": len(dataset.valid_rows),
+                    "binary_metrics": binary_metrics,
+                    "top3_metrics": top3_metrics,
+                }
+            )
+
+        summary = summarize_fold_metrics(fold_metrics)
+        results.append(
+            {
+                "model_label": model_label,
+                "params": dict(params),
+                "fold_metrics": fold_metrics,
+                "summary": summary,
+            }
+        )
+    return results
+
+
+def summarize_fold_metrics(fold_metrics: Sequence[Mapping[str, object]]) -> Dict[str, Optional[float]]:
+    if not fold_metrics:
+        raise ValueError("No fold metrics to summarize.")
+
+    def _mean(path: Tuple[str, ...]) -> Optional[float]:
+        values: List[float] = []
+        for metrics in fold_metrics:
+            current: Any = metrics
+            for key in path:
+                current = current[key]
+            if current is None:
+                continue
+            values.append(float(current))
+        if not values:
+            return None
+        return safe_round(sum(values) / len(values))
+
+    return {
+        "mean_average_precision": _mean(("binary_metrics", "average_precision")),
+        "mean_roc_auc": _mean(("binary_metrics", "roc_auc")),
+        "mean_brier_score": _mean(("binary_metrics", "brier_score")),
+        "mean_log_loss": _mean(("binary_metrics", "log_loss")),
+        "mean_top3_hit_rate_all_strains": _mean(("top3_metrics", "top3_hit_rate_all_strains")),
+        "mean_top3_hit_rate_susceptible_only": _mean(("top3_metrics", "top3_hit_rate_susceptible_only")),
+    }
+
+
+def score_rows_with_cv_predictions(
+    fold_datasets: Sequence[FoldDataset],
+    *,
+    estimator_factory: Callable[[Mapping[str, object], int], Any],
+    best_params: Mapping[str, object],
+    probability_column: str,
+) -> List[Dict[str, object]]:
+    scored_rows: List[Dict[str, object]] = []
+    for dataset in fold_datasets:
+        estimator = estimator_factory(best_params, dataset.fold_id)
+        estimator.fit(dataset.X_train, dataset.y_train)
+        probabilities = _predict_probabilities(estimator, dataset.X_valid)
+        for row, probability in zip(dataset.valid_rows, probabilities):
+            scored = dict(row)
+            scored[probability_column] = probability
+            scored["prediction_context"] = "non_holdout_oof"
+            scored_rows.append(scored)
+    scored_rows.sort(key=lambda row: (str(row["bacteria"]), str(row["phage"])))
+    return scored_rows
+
+
+def build_feature_space(
+    st02_rows: Sequence[Mapping[str, str]],
+    track_c_pair_rows: Sequence[Mapping[str, str]],
+    track_d_feature_columns: Sequence[str],
+    track_e_feature_columns: Sequence[str],
+) -> FeatureSpace:
+    st02_columns = tuple(st02_rows[0].keys())
+    track_c_new_columns = tuple(column for column in track_c_pair_rows[0].keys() if column not in st02_columns)
+    track_c_categorical = tuple(column for column in track_c_new_columns if column in set(EXTENDED_CATEGORICAL_COLUMNS))
+    track_c_numeric = tuple(column for column in track_c_new_columns if column not in set(track_c_categorical))
+    categorical_columns = _deduplicate_preserving_order(
+        list(V0_CATEGORICAL_FEATURE_COLUMNS) + list(track_c_categorical)
+    )
+    numeric_columns = _deduplicate_preserving_order(
+        list(V0_NUMERIC_FEATURE_COLUMNS)
+        + list(track_c_numeric)
+        + list(track_d_feature_columns)
+        + list(track_e_feature_columns)
+    )
+    return FeatureSpace(
+        categorical_columns=categorical_columns,
+        numeric_columns=numeric_columns,
+        track_c_additional_columns=track_c_new_columns,
+        track_d_columns=tuple(track_d_feature_columns),
+        track_e_columns=tuple(track_e_feature_columns),
+    )
+
+
+def merge_expanded_feature_rows(
+    track_c_pair_rows: Sequence[Mapping[str, str]],
+    split_rows: Sequence[Mapping[str, str]],
+    phage_feature_blocks: Sequence[Sequence[Mapping[str, str]]],
+    pair_feature_blocks: Sequence[Sequence[Mapping[str, str]]],
+) -> List[Dict[str, object]]:
+    split_by_pair = {row["pair_id"]: row for row in split_rows}
+    phage_indexes: List[Tuple[Dict[str, Dict[str, str]], Tuple[str, ...]]] = []
+    for rows in phage_feature_blocks:
+        if not rows:
+            raise ValueError("Encountered empty phage feature block.")
+        columns = tuple(column for column in rows[0].keys() if column != "phage")
+        phage_indexes.append(({row["phage"]: dict(row) for row in rows}, columns))
+
+    pair_indexes: List[Tuple[Dict[str, Dict[str, str]], Tuple[str, ...]]] = []
+    for rows in pair_feature_blocks:
+        if not rows:
+            raise ValueError("Encountered empty pair feature block.")
+        columns = tuple(column for column in rows[0].keys() if column not in IDENTIFIER_COLUMNS)
+        pair_indexes.append(({row["pair_id"]: dict(row) for row in rows}, columns))
+
+    output_rows: List[Dict[str, object]] = []
+    for row in track_c_pair_rows:
+        pair_id = row["pair_id"]
+        merged = dict(row)
+        split_row = split_by_pair.get(pair_id)
+        if split_row is None:
+            raise KeyError(f"Missing ST0.3 split assignment for pair_id {pair_id}")
+        merged.update(split_row)
+
+        for phage_index, columns in phage_indexes:
+            phage_row = phage_index.get(row["phage"])
+            if phage_row is None:
+                raise KeyError(f"Missing phage-level feature row for phage {row['phage']}")
+            for column in columns:
+                merged[column] = phage_row[column]
+
+        for pair_index, columns in pair_indexes:
+            pair_row = pair_index.get(pair_id)
+            if pair_row is None:
+                raise KeyError(f"Missing pair-level feature row for pair_id {pair_id}")
+            for column in columns:
+                merged[column] = pair_row[column]
+
+        output_rows.append(merged)
+    output_rows.sort(key=lambda row: (str(row["bacteria"]), str(row["phage"])))
+    return output_rows
+
+
+def ensure_prerequisite_outputs(args: argparse.Namespace) -> None:
+    if args.skip_prerequisites:
+        return
+
+    st01_output_path = Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st01_pair_label_audit.csv")
+    st01b_output_path = Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st01b_pair_confidence_audit.csv")
+    if not st01_output_path.exists():
+        st01_label_policy.main([])
+    if not st01b_output_path.exists():
+        st01b_confidence_tiers.main([])
+    if not args.st02_pair_table_path.exists():
+        st02_build_pair_table.main([])
+    if not args.st03_split_assignments_path.exists():
+        st03_build_splits.main([])
+    if not args.track_c_pair_table_path.exists():
+        build_v1_host_feature_pair_table.main([])
+    if not args.track_d_genome_kmer_path.exists() or not args.track_d_distance_path.exists():
+        run_track_d.main(["--step", "all"])
+    if (
+        not args.track_e_rbp_compatibility_path.exists()
+        or not args.track_e_defense_evasion_path.exists()
+        or not args.track_e_isolation_distance_path.exists()
+    ):
+        run_track_e.main(["--step", "all"])
+
+
+def make_lightgbm_estimator(params: Mapping[str, object], seed_offset: int, *, base_random_state: int) -> Any:
+    from lightgbm import LGBMClassifier
+
+    return LGBMClassifier(
+        objective="binary",
+        class_weight="balanced",
+        random_state=base_random_state + seed_offset,
+        n_jobs=1,
+        verbosity=-1,
+        force_col_wise=True,
+        colsample_bytree=0.8,
+        subsample=0.8,
+        reg_lambda=0.0,
+        **params,
+    )
+
+
+def make_logistic_estimator(
+    params: Mapping[str, object],
+    seed_offset: int,
+    *,
+    base_random_state: int,
+) -> LogisticRegression:
+    return LogisticRegression(
+        solver="liblinear",
+        class_weight="balanced",
+        max_iter=3000,
+        random_state=base_random_state + seed_offset,
+        **params,
+    )
+
+
+def fit_final_estimator(
+    rows: Sequence[Mapping[str, object]],
+    feature_space: FeatureSpace,
+    *,
+    estimator_factory: Callable[[Mapping[str, object], int], Any],
+    params: Mapping[str, object],
+) -> Tuple[Any, DictVectorizer, List[Dict[str, object]], List[Dict[str, object]], List[float]]:
+    train_rows = [
+        dict(row)
+        for row in rows
+        if row["split_holdout"] == "train_non_holdout" and str(row["is_hard_trainable"]) == "1"
+    ]
+    eval_rows = [
+        dict(row) for row in rows if row["split_holdout"] == "holdout_test" and str(row["is_hard_trainable"]) == "1"
+    ]
+    if not train_rows:
+        raise ValueError("No non-holdout hard-trainable rows available for final training.")
+    if not eval_rows:
+        raise ValueError("No holdout hard-trainable rows available for final evaluation.")
+
+    vectorizer = DictVectorizer(sparse=True, sort=True)
+    X_train = vectorizer.fit_transform(
+        [
+            _build_feature_dict(
+                row,
+                categorical_columns=feature_space.categorical_columns,
+                numeric_columns=feature_space.numeric_columns,
+            )
+            for row in train_rows
+        ]
+    )
+    y_train = [int(str(row["label_hard_any_lysis"])) for row in train_rows]
+    X_eval = vectorizer.transform(
+        [
+            _build_feature_dict(
+                row,
+                categorical_columns=feature_space.categorical_columns,
+                numeric_columns=feature_space.numeric_columns,
+            )
+            for row in eval_rows
+        ]
+    )
+    estimator = estimator_factory(params, 0)
+    estimator.fit(X_train, y_train)
+    probabilities = _predict_probabilities(estimator, X_eval)
+    return estimator, vectorizer, train_rows, eval_rows, probabilities
+
+
+def build_top3_ranking_rows(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    probability_key: str,
+    model_label: str,
+) -> List[Dict[str, object]]:
+    rows_by_bacteria: Dict[str, List[Mapping[str, object]]] = {}
+    for row in rows:
+        rows_by_bacteria.setdefault(str(row["bacteria"]), []).append(row)
+
+    ranking_rows: List[Dict[str, object]] = []
+    for bacteria, bacteria_rows in sorted(rows_by_bacteria.items()):
+        ranked = sorted(bacteria_rows, key=lambda row: (-float(row[probability_key]), str(row["phage"])))
+        for rank, row in enumerate(ranked[:3], start=1):
+            ranking_rows.append(
+                {
+                    "model_label": model_label,
+                    "bacteria": bacteria,
+                    "phage": row["phage"],
+                    "pair_id": row["pair_id"],
+                    "rank": rank,
+                    "predicted_probability": safe_round(float(row[probability_key])),
+                    "label_hard_any_lysis": row["label_hard_any_lysis"],
+                }
+            )
+    return ranking_rows
+
+
+def flatten_candidate_rows(model_label: str, results: Sequence[Mapping[str, object]]) -> List[Dict[str, object]]:
+    rows: List[Dict[str, object]] = []
+    for result in results:
+        summary = result["summary"]
+        rows.append(
+            {
+                "model_label": model_label,
+                "params_json": json.dumps(result["params"], sort_keys=True),
+                "mean_average_precision": summary["mean_average_precision"],
+                "mean_roc_auc": summary["mean_roc_auc"],
+                "mean_brier_score": summary["mean_brier_score"],
+                "mean_log_loss": summary["mean_log_loss"],
+                "mean_top3_hit_rate_all_strains": summary["mean_top3_hit_rate_all_strains"],
+                "mean_top3_hit_rate_susceptible_only": summary["mean_top3_hit_rate_susceptible_only"],
+            }
+        )
+    return rows
+
+
+def project_rows_to_fields(rows: Sequence[Mapping[str, object]], fieldnames: Sequence[str]) -> List[Dict[str, object]]:
+    return [{fieldname: row.get(fieldname, "") for fieldname in fieldnames} for row in rows]
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    ensure_directory(args.output_dir)
+    ensure_prerequisite_outputs(args)
+
+    st02_rows = read_csv_rows(args.st02_pair_table_path)
+    split_rows = read_csv_rows(args.st03_split_assignments_path)
+    track_c_pair_rows = read_csv_rows(args.track_c_pair_table_path)
+    track_d_genome_rows = read_csv_rows(args.track_d_genome_kmer_path)
+    track_d_distance_rows = read_csv_rows(args.track_d_distance_path)
+    track_e_rbp_rows = read_csv_rows(args.track_e_rbp_compatibility_path)
+    track_e_defense_rows = read_csv_rows(args.track_e_defense_evasion_path)
+    track_e_isolation_rows = read_csv_rows(args.track_e_isolation_distance_path)
+
+    track_d_feature_columns = _deduplicate_preserving_order(
+        [column for column in track_d_genome_rows[0].keys() if column != "phage"]
+        + [column for column in track_d_distance_rows[0].keys() if column != "phage"]
+    )
+    track_e_feature_columns = _deduplicate_preserving_order(
+        [column for column in track_e_rbp_rows[0].keys() if column not in IDENTIFIER_COLUMNS]
+        + [column for column in track_e_defense_rows[0].keys() if column not in IDENTIFIER_COLUMNS]
+        + [column for column in track_e_isolation_rows[0].keys() if column not in IDENTIFIER_COLUMNS]
+    )
+    feature_space = build_feature_space(
+        st02_rows,
+        track_c_pair_rows,
+        track_d_feature_columns,
+        track_e_feature_columns,
+    )
+    merged_rows = merge_expanded_feature_rows(
+        track_c_pair_rows,
+        split_rows,
+        phage_feature_blocks=(track_d_genome_rows, track_d_distance_rows),
+        pair_feature_blocks=(track_e_rbp_rows, track_e_defense_rows, track_e_isolation_rows),
+    )
+    fold_datasets = prepare_fold_datasets(merged_rows, feature_space)
+    lightgbm_factory = lambda params, seed_offset: make_lightgbm_estimator(  # noqa: E731
+        params,
+        seed_offset,
+        base_random_state=args.random_state,
+    )
+    logreg_factory = lambda params, seed_offset: make_logistic_estimator(  # noqa: E731
+        params,
+        seed_offset,
+        base_random_state=args.random_state,
+    )
+
+    lightgbm_results = evaluate_candidate_grid(
+        fold_datasets,
+        candidate_params=LIGHTGBM_PARAMETER_GRID,
+        estimator_factory=lightgbm_factory,
+        model_label="lightgbm",
+    )
+    logreg_results = evaluate_candidate_grid(
+        fold_datasets,
+        candidate_params=LOGISTIC_PARAMETER_GRID,
+        estimator_factory=logreg_factory,
+        model_label="logistic_regression",
+    )
+    best_lightgbm = select_best_candidate(lightgbm_results)
+    best_logreg = select_best_candidate(logreg_results)
+
+    cv_scored_lightgbm = score_rows_with_cv_predictions(
+        fold_datasets,
+        estimator_factory=lightgbm_factory,
+        best_params=best_lightgbm["params"],
+        probability_column="lightgbm_probability",
+    )
+    cv_scored_logreg = score_rows_with_cv_predictions(
+        fold_datasets,
+        estimator_factory=logreg_factory,
+        best_params=best_logreg["params"],
+        probability_column="logreg_probability",
+    )
+    cv_scored_by_pair = {row["pair_id"]: dict(row) for row in cv_scored_lightgbm}
+    for row in cv_scored_logreg:
+        cv_scored_by_pair[row["pair_id"]]["logreg_probability"] = row["logreg_probability"]
+    cv_prediction_rows = [cv_scored_by_pair[pair_id] for pair_id in sorted(cv_scored_by_pair)]
+
+    _, _, _, holdout_rows_lightgbm, holdout_lightgbm_prob = fit_final_estimator(
+        merged_rows,
+        feature_space,
+        estimator_factory=lightgbm_factory,
+        params=best_lightgbm["params"],
+    )
+    _, _, _, holdout_rows_logreg, holdout_logreg_prob = fit_final_estimator(
+        merged_rows,
+        feature_space,
+        estimator_factory=logreg_factory,
+        params=best_logreg["params"],
+    )
+    holdout_prediction_rows: List[Dict[str, object]] = []
+    for lightgbm_row, logreg_row, lightgbm_prob, logreg_prob in zip(
+        holdout_rows_lightgbm,
+        holdout_rows_logreg,
+        holdout_lightgbm_prob,
+        holdout_logreg_prob,
+    ):
+        if lightgbm_row["pair_id"] != logreg_row["pair_id"]:
+            raise ValueError("Holdout row alignment mismatch between LightGBM and logistic regression.")
+        scored = dict(lightgbm_row)
+        scored["lightgbm_probability"] = lightgbm_prob
+        scored["logreg_probability"] = logreg_prob
+        scored["prediction_context"] = "holdout_final"
+        holdout_prediction_rows.append(scored)
+
+    holdout_y = [int(str(row["label_hard_any_lysis"])) for row in holdout_prediction_rows]
+    lightgbm_holdout_metrics = compute_binary_metrics(
+        holdout_y,
+        [float(row["lightgbm_probability"]) for row in holdout_prediction_rows],
+    )
+    logreg_holdout_metrics = compute_binary_metrics(
+        holdout_y,
+        [float(row["logreg_probability"]) for row in holdout_prediction_rows],
+    )
+    lightgbm_holdout_top3 = compute_top3_hit_rate(holdout_prediction_rows, probability_key="lightgbm_probability")
+    logreg_holdout_top3 = compute_top3_hit_rate(holdout_prediction_rows, probability_key="logreg_probability")
+
+    pair_prediction_rows = cv_prediction_rows + holdout_prediction_rows
+    pair_prediction_rows.sort(key=lambda row: (str(row["prediction_context"]), str(row["bacteria"]), str(row["phage"])))
+
+    top3_ranking_rows = build_top3_ranking_rows(
+        holdout_prediction_rows,
+        probability_key="lightgbm_probability",
+        model_label="lightgbm",
+    ) + build_top3_ranking_rows(
+        holdout_prediction_rows,
+        probability_key="logreg_probability",
+        model_label="logistic_regression",
+    )
+    top3_ranking_rows.sort(key=lambda row: (str(row["model_label"]), str(row["bacteria"]), int(row["rank"])))
+
+    summary = {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "task_id": "TG01",
+        "feature_space": {
+            "categorical_columns": list(feature_space.categorical_columns),
+            "numeric_columns": list(feature_space.numeric_columns),
+            "track_c_additional_columns": list(feature_space.track_c_additional_columns),
+            "track_d_columns": list(feature_space.track_d_columns),
+            "track_e_columns": list(feature_space.track_e_columns),
+            "categorical_feature_count": len(feature_space.categorical_columns),
+            "numeric_feature_count": len(feature_space.numeric_columns),
+        },
+        "cv_protocol": {
+            "group_source": "ST0.2 cv_group via canonical ST0.3 split assignments",
+            "fold_ids": sorted(
+                {int(str(row["split_cv5_fold"])) for row in merged_rows if int(str(row["split_cv5_fold"])) >= 0}
+            ),
+            "holdout_split": "ST0.3 holdout_test",
+            "training_subset": "split_holdout=train_non_holdout and is_hard_trainable=1",
+            "candidate_counts": {
+                "lightgbm": len(LIGHTGBM_PARAMETER_GRID),
+                "logistic_regression": len(LOGISTIC_PARAMETER_GRID),
+            },
+        },
+        "lightgbm": {
+            "best_params": best_lightgbm["params"],
+            "cv_summary": best_lightgbm["summary"],
+            "holdout_binary_metrics": lightgbm_holdout_metrics,
+            "holdout_top3_metrics": lightgbm_holdout_top3,
+        },
+        "logistic_regression": {
+            "best_params": best_logreg["params"],
+            "cv_summary": best_logreg["summary"],
+            "holdout_binary_metrics": logreg_holdout_metrics,
+            "holdout_top3_metrics": logreg_holdout_top3,
+        },
+        "inputs": {
+            "st02_pair_table": {"path": str(args.st02_pair_table_path), "sha256": _sha256(args.st02_pair_table_path)},
+            "st03_split_assignments": {
+                "path": str(args.st03_split_assignments_path),
+                "sha256": _sha256(args.st03_split_assignments_path),
+            },
+            "track_c_pair_table": {
+                "path": str(args.track_c_pair_table_path),
+                "sha256": _sha256(args.track_c_pair_table_path),
+            },
+            "track_d_genome_kmers": {
+                "path": str(args.track_d_genome_kmer_path),
+                "sha256": _sha256(args.track_d_genome_kmer_path),
+            },
+            "track_d_distance": {
+                "path": str(args.track_d_distance_path),
+                "sha256": _sha256(args.track_d_distance_path),
+            },
+            "track_e_rbp_receptor_compatibility": {
+                "path": str(args.track_e_rbp_compatibility_path),
+                "sha256": _sha256(args.track_e_rbp_compatibility_path),
+            },
+            "track_e_defense_evasion": {
+                "path": str(args.track_e_defense_evasion_path),
+                "sha256": _sha256(args.track_e_defense_evasion_path),
+            },
+            "track_e_isolation_host_distance": {
+                "path": str(args.track_e_isolation_distance_path),
+                "sha256": _sha256(args.track_e_isolation_distance_path),
+            },
+        },
+    }
+
+    write_json(args.output_dir / "tg01_model_summary.json", summary)
+    write_csv(
+        args.output_dir / "tg01_cv_candidate_results.csv",
+        [
+            "model_label",
+            "params_json",
+            "mean_average_precision",
+            "mean_roc_auc",
+            "mean_brier_score",
+            "mean_log_loss",
+            "mean_top3_hit_rate_all_strains",
+            "mean_top3_hit_rate_susceptible_only",
+        ],
+        flatten_candidate_rows("lightgbm", lightgbm_results)
+        + flatten_candidate_rows("logistic_regression", logreg_results),
+    )
+    pair_prediction_fieldnames = [
+        "pair_id",
+        "bacteria",
+        "phage",
+        "cv_group",
+        "split_holdout",
+        "split_cv5_fold",
+        "label_hard_any_lysis",
+        "prediction_context",
+        "lightgbm_probability",
+        "logreg_probability",
+    ]
+    write_csv(
+        args.output_dir / "tg01_pair_predictions.csv",
+        pair_prediction_fieldnames,
+        project_rows_to_fields(pair_prediction_rows, pair_prediction_fieldnames),
+    )
+    write_csv(
+        args.output_dir / "tg01_holdout_top3_rankings.csv",
+        [
+            "model_label",
+            "bacteria",
+            "phage",
+            "pair_id",
+            "rank",
+            "predicted_probability",
+            "label_hard_any_lysis",
+        ],
+        top3_ranking_rows,
+    )
+
+    print("TG01 completed.")
+    print(f"- LightGBM best CV ROC-AUC: {best_lightgbm['summary']['mean_roc_auc']}")
+    print(f"- LightGBM holdout ROC-AUC: {lightgbm_holdout_metrics['roc_auc']}")
+    print(f"- LightGBM holdout top-3 hit rate: {lightgbm_holdout_top3['top3_hit_rate_all_strains']}")
+    print(f"- Logistic holdout ROC-AUC: {logreg_holdout_metrics['roc_auc']}")
+    print(f"- Output directory: {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lyzortx/research_notes/lab_notebooks/track_G.md
+++ b/lyzortx/research_notes/lab_notebooks/track_G.md
@@ -1,0 +1,77 @@
+### 2026-03-22: TG01 implemented (LightGBM binary classifier on v1 expanded feature set)
+
+#### What was implemented
+
+- Added a new Track G entrypoint at `lyzortx/pipeline/track_g/run_track_g.py` and the main TG01 trainer at
+  `lyzortx/pipeline/track_g/steps/train_v1_binary_classifier.py`.
+- The TG01 trainer now:
+  - bootstraps missing prerequisite outputs from ST0.1 through ST0.3 plus Tracks C, D, and E
+  - merges the canonical Track C `pair_table_v1.csv` with Track D phage-genomic features and Track E pairwise
+    compatibility features
+  - tunes LightGBM on the existing leakage-safe ST0.3 5-fold grouped CV contract (`split_cv5_fold` derived from
+    `cv_group`)
+  - keeps logistic regression as an interpretable comparator on the same expanded feature space
+  - writes reusable artifacts under `lyzortx/generated_outputs/track_g/tg01_v1_binary_classifier/`
+- Added tests in `lyzortx/tests/test_track_g_v1_binary_classifier.py` covering:
+  - expanded-feature row merging across Track C/D/E
+  - feature-space construction
+  - top-3 hit-rate calculation
+  - CV candidate selection rules
+  - `run_track_g.py` dispatch
+
+#### Output summary
+
+- TG01 output directory:
+  - `tg01_model_summary.json`
+  - `tg01_cv_candidate_results.csv`
+  - `tg01_pair_predictions.csv`
+  - `tg01_holdout_top3_rankings.csv`
+- Final modeled feature space:
+  - `21` categorical columns
+  - `170` numeric columns
+  - composition: `115` Track C host-genomic columns, `34` Track D phage-genomic columns, `14` Track E pairwise
+    columns, plus the audited ST0.4 v0 baseline feature columns
+- Scored-pair coverage:
+  - `35,266` rows in `tg01_pair_predictions.csv`
+  - this is the union of non-holdout out-of-fold predictions and final-model holdout predictions for hard-trainable
+    pairs
+- Best hyperparameters:
+  - LightGBM: `learning_rate=0.05`, `min_child_samples=10`, `n_estimators=300`, `num_leaves=31`
+  - Logistic regression: `C=3.0`
+- Best LightGBM metrics:
+  - mean CV ROC-AUC: `0.908344`
+  - mean CV top-3 hit rate (all strains): `0.933153`
+  - holdout ROC-AUC: `0.910007`
+  - holdout top-3 hit rate (all strains): `0.892308`
+  - holdout top-3 hit rate (susceptible strains only): `0.920635`
+- Logistic regression comparator metrics:
+  - mean CV ROC-AUC: `0.867378`
+  - mean CV top-3 hit rate (all strains): `0.825475`
+  - holdout ROC-AUC: `0.856172`
+  - holdout top-3 hit rate (all strains): `0.723077`
+
+#### Interpretation
+
+1. The core Track G modeling upgrade is validated. The tuned LightGBM model materially outperforms the logistic
+   comparator on both CV and holdout, so the nonlinear expanded-feature stack is carrying real signal rather than just
+   overfitting the grouped folds.
+2. The AUC target was met and slightly exceeded. Holdout ROC-AUC reached `0.910007`, which is above the stated
+   `0.87-0.90` target band.
+3. The top-3 target was almost met but not fully met on the strictest denominator. Holdout top-3 on all holdout strains
+   reached `0.892308`, just below the `90%+` target, while susceptible-only holdout top-3 reached `0.920635`.
+4. That denominator split matters. The all-strain miss is small in absolute terms (`58 / 65` strains hit), but the two
+   non-susceptible or effectively no-hit holdout strains keep the all-strain metric below the acceptance threshold even
+   though ranking quality on susceptible strains is already above target.
+5. TG01 should therefore be considered a successful model-training milestone with one honest caveat: the LightGBM model
+   is strong enough to move forward to calibration and interpretation work, but the repo should not claim that the
+   all-strain top-3 target is fully achieved yet.
+
+#### Next steps
+
+1. Use `tg01_pair_predictions.csv` as the raw-score input for TG02 calibration work so isotonic and Platt scaling are
+   evaluated on the exact tuned LightGBM configuration rather than a proxy model.
+2. Use the same TG01 output directory as the reference point for TG03 ablations, with the logistic comparator retained
+   as the linear baseline.
+3. Inspect the `7` holdout miss strains in `tg01_holdout_top3_rankings.csv` before claiming the remaining gap is purely
+   calibration-related; some of that gap may still be a ranking or abstention-policy problem rather than a probability
+   problem.

--- a/lyzortx/tests/test_track_g_v1_binary_classifier.py
+++ b/lyzortx/tests/test_track_g_v1_binary_classifier.py
@@ -1,0 +1,142 @@
+from lyzortx.pipeline.track_g import run_track_g
+from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import (
+    build_feature_space,
+    compute_top3_hit_rate,
+    merge_expanded_feature_rows,
+    select_best_candidate,
+)
+
+
+def test_merge_expanded_feature_rows_adds_split_phage_and_pair_features() -> None:
+    merged = merge_expanded_feature_rows(
+        track_c_pair_rows=[
+            {
+                "pair_id": "B1__P1",
+                "bacteria": "B1",
+                "phage": "P1",
+                "label_hard_any_lysis": "1",
+                "host_surface_lps_core_type": "R1",
+            }
+        ],
+        split_rows=[
+            {
+                "pair_id": "B1__P1",
+                "bacteria": "B1",
+                "phage": "P1",
+                "cv_group": "G1",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "0",
+                "is_hard_trainable": "1",
+            }
+        ],
+        phage_feature_blocks=[
+            [{"phage": "P1", "phage_gc_content": "0.5"}],
+            [{"phage": "P1", "phage_viridic_mds_00": "0.2"}],
+        ],
+        pair_feature_blocks=[
+            [{"pair_id": "B1__P1", "bacteria": "B1", "phage": "P1", "lookup_available": "1"}],
+            [{"pair_id": "B1__P1", "bacteria": "B1", "phage": "P1", "defense_evasion_score": "0.7"}],
+            [{"pair_id": "B1__P1", "bacteria": "B1", "phage": "P1", "isolation_host_distance": "0.3"}],
+        ],
+    )
+
+    assert merged[0]["cv_group"] == "G1"
+    assert merged[0]["phage_gc_content"] == "0.5"
+    assert merged[0]["lookup_available"] == "1"
+    assert merged[0]["defense_evasion_score"] == "0.7"
+    assert merged[0]["isolation_host_distance"] == "0.3"
+
+
+def test_build_feature_space_keeps_v0_columns_and_adds_track_specific_blocks() -> None:
+    feature_space = build_feature_space(
+        st02_rows=[
+            {
+                "pair_id": "B1__P1",
+                "bacteria": "B1",
+                "phage": "P1",
+                "host_pathotype": "pt",
+                "host_mouse_killed_10": "0",
+            }
+        ],
+        track_c_pair_rows=[
+            {
+                "pair_id": "B1__P1",
+                "bacteria": "B1",
+                "phage": "P1",
+                "host_pathotype": "pt",
+                "host_mouse_killed_10": "0",
+                "host_surface_lps_core_type": "R1",
+                "host_phylogeny_umap_00": "0.1",
+            }
+        ],
+        track_d_feature_columns=["phage_gc_content", "phage_viridic_mds_00"],
+        track_e_feature_columns=["lookup_available", "isolation_host_distance"],
+    )
+
+    assert "host_pathotype" in feature_space.categorical_columns
+    assert "host_surface_lps_core_type" in feature_space.categorical_columns
+    assert "host_phylogeny_umap_00" in feature_space.numeric_columns
+    assert "phage_gc_content" in feature_space.numeric_columns
+    assert "lookup_available" in feature_space.numeric_columns
+
+
+def test_compute_top3_hit_rate_reports_all_and_susceptible_denominators() -> None:
+    metrics = compute_top3_hit_rate(
+        [
+            {"bacteria": "B1", "phage": "P1", "label_hard_any_lysis": "1", "predicted_probability": 0.9},
+            {"bacteria": "B1", "phage": "P2", "label_hard_any_lysis": "0", "predicted_probability": 0.8},
+            {"bacteria": "B1", "phage": "P3", "label_hard_any_lysis": "0", "predicted_probability": 0.7},
+            {"bacteria": "B2", "phage": "P1", "label_hard_any_lysis": "0", "predicted_probability": 0.9},
+            {"bacteria": "B2", "phage": "P2", "label_hard_any_lysis": "0", "predicted_probability": 0.8},
+            {"bacteria": "B2", "phage": "P3", "label_hard_any_lysis": "0", "predicted_probability": 0.7},
+        ],
+        probability_key="predicted_probability",
+    )
+
+    assert metrics["strain_count"] == 2
+    assert metrics["hit_count"] == 1
+    assert metrics["top3_hit_rate_all_strains"] == 0.5
+    assert metrics["susceptible_strain_count"] == 1
+    assert metrics["top3_hit_rate_susceptible_only"] == 1.0
+
+
+def test_select_best_candidate_prefers_auc_then_top3_then_brier() -> None:
+    best = select_best_candidate(
+        [
+            {
+                "params": {"name": "a"},
+                "summary": {
+                    "mean_roc_auc": 0.81,
+                    "mean_top3_hit_rate_all_strains": 0.80,
+                    "mean_brier_score": 0.20,
+                },
+            },
+            {
+                "params": {"name": "b"},
+                "summary": {
+                    "mean_roc_auc": 0.81,
+                    "mean_top3_hit_rate_all_strains": 0.85,
+                    "mean_brier_score": 0.25,
+                },
+            },
+        ]
+    )
+
+    assert best["params"]["name"] == "b"
+
+
+def test_run_track_g_dispatches_training_step(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        run_track_g.train_v1_binary_classifier,
+        "main",
+        lambda argv: calls.append("train-v1-binary"),
+    )
+
+    run_track_g.main(["--step", "train-v1-binary"])
+    assert calls == ["train-v1-binary"]
+
+    calls.clear()
+    run_track_g.main(["--step", "all"])
+    assert calls == ["train-v1-binary"]


### PR DESCRIPTION
## Summary
- add a new Track G pipeline entrypoint and TG01 training step that bootstraps missing ST0.1-ST0.3 and Track C/D/E prerequisites, assembles the v1 expanded feature set, and tunes LightGBM plus a logistic-regression comparator on the canonical leakage-safe 5-fold CV contract
- emit reusable TG01 artifacts under `lyzortx/generated_outputs/track_g/tg01_v1_binary_classifier/`, including model summary JSON, candidate-level CV results, scored pair predictions, and holdout top-3 rankings
- document the implementation and findings in `lyzortx/research_notes/lab_notebooks/track_G.md`, including the honest result that holdout ROC-AUC exceeded target while all-strain holdout top-3 narrowly missed the 90% goal

## Validation
- `python lyzortx/pipeline/track_g/run_track_g.py`
- `pytest -q lyzortx/tests/`

## Key results
- LightGBM best CV ROC-AUC: `0.908344`
- LightGBM holdout ROC-AUC: `0.910007`
- LightGBM holdout top-3 hit rate (all strains): `0.892308`
- LightGBM holdout top-3 hit rate (susceptible-only): `0.920635`
- Logistic regression holdout ROC-AUC: `0.856172`

Posted by Codex gpt-5.4.
Closes #100
