### PR TITLE
[ORCH][TG03] Add Track G feature-block ablation suite

### DIFF
--- a/lyzortx/pipeline/track_g/README.md
+++ b/lyzortx/pipeline/track_g/README.md
@@ -9,6 +9,8 @@ This command runs the implemented Track G modeling step:
    `lyzortx/generated_outputs/track_g/tg01_v1_binary_classifier/`
 2. `calibrate-gbm`: fit isotonic and Platt calibrators on TG01 LightGBM outputs using the ST0.3 fold contract and
    write outputs under `lyzortx/generated_outputs/track_g/tg02_gbm_calibration/`
+3. `feature-block-ablation`: run TG03 LightGBM ablations on the fixed ST0.3 holdout split and write outputs under
+   `lyzortx/generated_outputs/track_g/tg03_feature_block_ablation_suite/`
 
 The TG01 trainer reuses the canonical ST0.2 / ST0.3 leakage-safe contract:
 
@@ -34,3 +36,13 @@ The TG02 calibration directory includes:
 2. `tg02_pair_predictions_calibrated.csv`: pair-level raw and calibrated LightGBM probabilities
 3. `tg02_ranked_predictions.csv`: isotonic-ranked per-strain predictions with raw and Platt scores for comparison
 4. `tg02_calibration_artifacts.json`: fitted isotonic thresholds, Platt coefficients, and input hashes
+
+The TG03 ablation directory includes:
+
+1. `tg03_ablation_summary.json`: per-arm metrics, best hyperparameters, feature-block membership, and lift vs the
+   `v0_features_only` reference arm
+2. `tg03_ablation_metrics.csv`: flat arm-level table with holdout AUC, top-3 hit rate, Brier, CV summaries, and deltas
+   vs v0
+3. `tg03_ablation_cv_candidate_results.csv`: candidate-level CV summaries for each ablation arm
+4. `tg03_ablation_pair_predictions.csv`: non-holdout out-of-fold and final holdout probabilities for each arm
+5. `tg03_ablation_holdout_top3_rankings.csv`: holdout top-3 rankings for each arm

--- a/lyzortx/pipeline/track_g/run_track_g.py
+++ b/lyzortx/pipeline/track_g/run_track_g.py
@@ -11,6 +11,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from lyzortx.pipeline.track_g.steps import calibrate_gbm_outputs
+from lyzortx.pipeline.track_g.steps import run_feature_block_ablation_suite
 from lyzortx.pipeline.track_g.steps import train_v1_binary_classifier
 
 
@@ -18,7 +19,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--step",
-        choices=["train-v1-binary", "calibrate-gbm", "all"],
+        choices=["train-v1-binary", "calibrate-gbm", "feature-block-ablation", "all"],
         default="all",
         help="Track G step to run. 'all' runs the implemented Track G modeling steps.",
     )
@@ -31,6 +32,8 @@ def main(argv: list[str] | None = None) -> None:
         train_v1_binary_classifier.main([])
     if args.step in {"calibrate-gbm", "all"}:
         calibrate_gbm_outputs.main([])
+    if args.step in {"feature-block-ablation", "all"}:
+        run_feature_block_ablation_suite.main([])
 
 
 if __name__ == "__main__":

--- a/lyzortx/pipeline/track_g/steps/run_feature_block_ablation_suite.py
+++ b/lyzortx/pipeline/track_g/steps/run_feature_block_ablation_suite.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""TG03: Run holdout-locked feature-block ablations against the v0 reference feature set."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
+from lyzortx.pipeline.steel_thread_v0.steps.st04_train_baselines import (
+    CATEGORICAL_FEATURE_COLUMNS as V0_CATEGORICAL_FEATURE_COLUMNS,
+)
+from lyzortx.pipeline.steel_thread_v0.steps.st04_train_baselines import (
+    NUMERIC_FEATURE_COLUMNS as V0_NUMERIC_FEATURE_COLUMNS,
+)
+from lyzortx.pipeline.track_c.steps.build_v1_host_feature_pair_table import DEFENSE_DERIVED_COLUMNS
+from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import (
+    IDENTIFIER_COLUMNS,
+    LIGHTGBM_PARAMETER_GRID,
+    FeatureSpace,
+    build_feature_space,
+    build_top3_ranking_rows,
+    compute_binary_metrics,
+    compute_top3_hit_rate,
+    ensure_prerequisite_outputs,
+    evaluate_candidate_grid,
+    fit_final_estimator,
+    flatten_candidate_rows,
+    make_lightgbm_estimator,
+    merge_expanded_feature_rows,
+    prepare_fold_datasets,
+    score_rows_with_cv_predictions,
+    select_best_candidate,
+)
+
+
+@dataclass(frozen=True)
+class AblationArm:
+    arm_id: str
+    display_name: str
+    categorical_columns: Tuple[str, ...]
+    numeric_columns: Tuple[str, ...]
+    included_blocks: Tuple[str, ...]
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--st02-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st02_pair_table.csv"),
+        help="Input ST0.2 pair table path.",
+    )
+    parser.add_argument(
+        "--st03-split-assignments-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_assignments.csv"),
+        help="Input ST0.3 split assignments path.",
+    )
+    parser.add_argument(
+        "--track-c-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_c/v1_host_feature_pair_table/pair_table_v1.csv"),
+        help="Input Track C v1 pair table path.",
+    )
+    parser.add_argument(
+        "--track-d-genome-kmer-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_d/phage_genome_kmer_features/phage_genome_kmer_features.csv"),
+        help="Input Track D genome k-mer feature CSV.",
+    )
+    parser.add_argument(
+        "--track-d-distance-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_d/phage_distance_embedding/phage_distance_embedding_features.csv"
+        ),
+        help="Input Track D phage-distance feature CSV.",
+    )
+    parser.add_argument(
+        "--track-e-rbp-compatibility-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_e/rbp_receptor_compatibility_feature_block/"
+            "rbp_receptor_compatibility_features_v1.csv"
+        ),
+        help="Input Track E RBP-receptor compatibility feature CSV.",
+    )
+    parser.add_argument(
+        "--track-e-defense-evasion-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_e/defense_evasion_proxy_feature_block/"
+            "defense_evasion_proxy_features_v1.csv"
+        ),
+        help="Input Track E defense-evasion proxy feature CSV.",
+    )
+    parser.add_argument(
+        "--track-e-isolation-distance-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_e/isolation_host_distance_feature_block/"
+            "isolation_host_distance_features_v1.csv"
+        ),
+        help="Input Track E isolation-host distance feature CSV.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_g/tg03_feature_block_ablation_suite"),
+        help="Directory for generated TG03 artifacts.",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=42,
+        help="Base random seed for tuned LightGBM ablation models.",
+    )
+    parser.add_argument(
+        "--skip-prerequisites",
+        action="store_true",
+        help="Assume prerequisite Track C/D/E outputs already exist instead of generating missing artifacts.",
+    )
+    return parser.parse_args(argv)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def partition_track_c_columns(track_c_columns: Sequence[str]) -> Dict[str, Tuple[str, ...]]:
+    defense_columns: List[str] = []
+    host_genomic_remainder: List[str] = []
+    for column in track_c_columns:
+        if column.startswith("host_defense_subtype_") or column in DEFENSE_DERIVED_COLUMNS:
+            defense_columns.append(column)
+            continue
+        host_genomic_remainder.append(column)
+    return {
+        "defense_subtypes": tuple(defense_columns),
+        "host_genomic_remainder": tuple(host_genomic_remainder),
+    }
+
+
+def build_ablation_arms(feature_space: FeatureSpace) -> List[AblationArm]:
+    track_c_blocks = partition_track_c_columns(feature_space.track_c_additional_columns)
+    v0_categorical = tuple(V0_CATEGORICAL_FEATURE_COLUMNS)
+    v0_numeric = tuple(V0_NUMERIC_FEATURE_COLUMNS)
+
+    return [
+        AblationArm(
+            arm_id="v0_features_only",
+            display_name="v0 features only",
+            categorical_columns=v0_categorical,
+            numeric_columns=v0_numeric,
+            included_blocks=("v0",),
+        ),
+        AblationArm(
+            arm_id="plus_defense_subtypes",
+            display_name="+defense subtypes",
+            categorical_columns=v0_categorical,
+            numeric_columns=v0_numeric + track_c_blocks["defense_subtypes"],
+            included_blocks=("v0", "defense_subtypes"),
+        ),
+        AblationArm(
+            arm_id="plus_omp_receptors",
+            display_name="+OMP receptors",
+            categorical_columns=tuple(
+                column for column in feature_space.categorical_columns if column in set(v0_categorical)
+            )
+            + tuple(column for column in feature_space.categorical_columns if column not in set(v0_categorical)),
+            numeric_columns=v0_numeric + track_c_blocks["host_genomic_remainder"],
+            included_blocks=("v0", "omp_receptors_and_remaining_host_genomic"),
+        ),
+        AblationArm(
+            arm_id="plus_phage_genomic",
+            display_name="+phage genomic",
+            categorical_columns=v0_categorical,
+            numeric_columns=v0_numeric + feature_space.track_d_columns,
+            included_blocks=("v0", "phage_genomic"),
+        ),
+        AblationArm(
+            arm_id="plus_pairwise_compatibility",
+            display_name="+pairwise compatibility",
+            categorical_columns=v0_categorical,
+            numeric_columns=v0_numeric + feature_space.track_e_columns,
+            included_blocks=("v0", "pairwise_compatibility"),
+        ),
+        AblationArm(
+            arm_id="all_features",
+            display_name="all features",
+            categorical_columns=feature_space.categorical_columns,
+            numeric_columns=feature_space.numeric_columns,
+            included_blocks=(
+                "v0",
+                "defense_subtypes",
+                "omp_receptors_and_remaining_host_genomic",
+                "phage_genomic",
+                "pairwise_compatibility",
+            ),
+        ),
+    ]
+
+
+def _delta_vs_reference(value: Optional[float], reference: Optional[float]) -> Optional[float]:
+    if value is None or reference is None:
+        return None
+    return safe_round(value - reference)
+
+
+def _brier_improvement(value: Optional[float], reference: Optional[float]) -> Optional[float]:
+    if value is None or reference is None:
+        return None
+    return safe_round(reference - value)
+
+
+def summarize_arm_result(
+    arm: AblationArm,
+    best_result: Mapping[str, object],
+    holdout_binary_metrics: Mapping[str, Optional[float]],
+    holdout_top3_metrics: Mapping[str, object],
+    *,
+    reference_binary_metrics: Mapping[str, Optional[float]],
+    reference_top3_metrics: Mapping[str, object],
+) -> Dict[str, object]:
+    return {
+        "display_name": arm.display_name,
+        "included_blocks": list(arm.included_blocks),
+        "feature_counts": {
+            "categorical_feature_count": len(arm.categorical_columns),
+            "numeric_feature_count": len(arm.numeric_columns),
+        },
+        "best_params": dict(best_result["params"]),
+        "cv_summary": dict(best_result["summary"]),
+        "holdout_binary_metrics": dict(holdout_binary_metrics),
+        "holdout_top3_metrics": dict(holdout_top3_metrics),
+        "lift_vs_v0": {
+            "roc_auc_delta": _delta_vs_reference(
+                holdout_binary_metrics.get("roc_auc"),
+                reference_binary_metrics.get("roc_auc"),
+            ),
+            "brier_improvement": _brier_improvement(
+                holdout_binary_metrics.get("brier_score"),
+                reference_binary_metrics.get("brier_score"),
+            ),
+            "top3_hit_rate_all_strains_delta": _delta_vs_reference(
+                holdout_top3_metrics.get("top3_hit_rate_all_strains"),
+                reference_top3_metrics.get("top3_hit_rate_all_strains"),
+            ),
+        },
+    }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    ensure_directory(args.output_dir)
+    ensure_prerequisite_outputs(args)
+
+    st02_rows = read_csv_rows(args.st02_pair_table_path)
+    split_rows = read_csv_rows(args.st03_split_assignments_path)
+    track_c_pair_rows = read_csv_rows(args.track_c_pair_table_path)
+    track_d_genome_rows = read_csv_rows(args.track_d_genome_kmer_path)
+    track_d_distance_rows = read_csv_rows(args.track_d_distance_path)
+    track_e_rbp_rows = read_csv_rows(args.track_e_rbp_compatibility_path)
+    track_e_defense_rows = read_csv_rows(args.track_e_defense_evasion_path)
+    track_e_isolation_rows = read_csv_rows(args.track_e_isolation_distance_path)
+
+    track_d_feature_columns = tuple(
+        column
+        for column in list(track_d_genome_rows[0].keys()) + list(track_d_distance_rows[0].keys())
+        if column != "phage"
+    )
+    track_d_feature_columns = tuple(dict.fromkeys(track_d_feature_columns))
+    track_e_feature_columns = tuple(
+        column
+        for column in list(track_e_rbp_rows[0].keys())
+        + list(track_e_defense_rows[0].keys())
+        + list(track_e_isolation_rows[0].keys())
+        if column not in IDENTIFIER_COLUMNS
+    )
+    track_e_feature_columns = tuple(dict.fromkeys(track_e_feature_columns))
+
+    full_feature_space = build_feature_space(
+        st02_rows,
+        track_c_pair_rows,
+        track_d_feature_columns,
+        track_e_feature_columns,
+    )
+    merged_rows = merge_expanded_feature_rows(
+        track_c_pair_rows,
+        split_rows,
+        phage_feature_blocks=(track_d_genome_rows, track_d_distance_rows),
+        pair_feature_blocks=(track_e_rbp_rows, track_e_defense_rows, track_e_isolation_rows),
+    )
+    ablation_arms = build_ablation_arms(full_feature_space)
+    lightgbm_factory = lambda params, seed_offset: make_lightgbm_estimator(  # noqa: E731
+        params,
+        seed_offset,
+        base_random_state=args.random_state,
+    )
+
+    arm_results: Dict[str, Dict[str, object]] = {}
+    metrics_rows: List[Dict[str, object]] = []
+    candidate_rows: List[Dict[str, object]] = []
+    prediction_rows: List[Dict[str, object]] = []
+    ranking_rows: List[Dict[str, object]] = []
+
+    for arm in ablation_arms:
+        feature_space = FeatureSpace(
+            categorical_columns=arm.categorical_columns,
+            numeric_columns=arm.numeric_columns,
+            track_c_additional_columns=full_feature_space.track_c_additional_columns,
+            track_d_columns=full_feature_space.track_d_columns,
+            track_e_columns=full_feature_space.track_e_columns,
+        )
+        fold_datasets = prepare_fold_datasets(merged_rows, feature_space)
+        candidate_results = evaluate_candidate_grid(
+            fold_datasets,
+            candidate_params=LIGHTGBM_PARAMETER_GRID,
+            estimator_factory=lightgbm_factory,
+            model_label=arm.arm_id,
+        )
+        best_result = select_best_candidate(candidate_results)
+        cv_prediction_rows = score_rows_with_cv_predictions(
+            fold_datasets,
+            estimator_factory=lightgbm_factory,
+            best_params=best_result["params"],
+            probability_column="predicted_probability",
+        )
+        _, _, _, holdout_rows, holdout_probabilities = fit_final_estimator(
+            merged_rows,
+            feature_space,
+            estimator_factory=lightgbm_factory,
+            params=best_result["params"],
+        )
+        holdout_prediction_rows: List[Dict[str, object]] = []
+        for row, probability in zip(holdout_rows, holdout_probabilities):
+            scored = dict(row)
+            scored["predicted_probability"] = probability
+            scored["prediction_context"] = "holdout_final"
+            holdout_prediction_rows.append(scored)
+
+        holdout_y = [int(str(row["label_hard_any_lysis"])) for row in holdout_prediction_rows]
+        holdout_binary_metrics = compute_binary_metrics(
+            holdout_y,
+            [float(row["predicted_probability"]) for row in holdout_prediction_rows],
+        )
+        holdout_top3_metrics = compute_top3_hit_rate(holdout_prediction_rows, probability_key="predicted_probability")
+
+        arm_results[arm.arm_id] = {
+            "arm": arm,
+            "best_result": best_result,
+            "holdout_binary_metrics": holdout_binary_metrics,
+            "holdout_top3_metrics": holdout_top3_metrics,
+        }
+
+        candidate_rows.extend(flatten_candidate_rows(arm.arm_id, candidate_results))
+        for row in cv_prediction_rows + holdout_prediction_rows:
+            prediction_rows.append(
+                {
+                    "arm_id": arm.arm_id,
+                    "arm_label": arm.display_name,
+                    "pair_id": row["pair_id"],
+                    "bacteria": row["bacteria"],
+                    "phage": row["phage"],
+                    "split_holdout": row["split_holdout"],
+                    "split_cv5_fold": row["split_cv5_fold"],
+                    "label_hard_any_lysis": row["label_hard_any_lysis"],
+                    "prediction_context": row["prediction_context"],
+                    "predicted_probability": safe_round(float(row["predicted_probability"])),
+                }
+            )
+        ranking_rows.extend(
+            build_top3_ranking_rows(
+                holdout_prediction_rows,
+                probability_key="predicted_probability",
+                model_label=arm.arm_id,
+            )
+        )
+
+    reference = arm_results["v0_features_only"]
+    summary_arms: Dict[str, Dict[str, object]] = {}
+    for arm in ablation_arms:
+        result = arm_results[arm.arm_id]
+        summarized = summarize_arm_result(
+            arm,
+            result["best_result"],
+            result["holdout_binary_metrics"],
+            result["holdout_top3_metrics"],
+            reference_binary_metrics=reference["holdout_binary_metrics"],
+            reference_top3_metrics=reference["holdout_top3_metrics"],
+        )
+        summary_arms[arm.arm_id] = summarized
+        metrics_rows.append(
+            {
+                "arm_id": arm.arm_id,
+                "arm_label": arm.display_name,
+                "categorical_feature_count": summarized["feature_counts"]["categorical_feature_count"],
+                "numeric_feature_count": summarized["feature_counts"]["numeric_feature_count"],
+                "holdout_roc_auc": summarized["holdout_binary_metrics"]["roc_auc"],
+                "holdout_brier_score": summarized["holdout_binary_metrics"]["brier_score"],
+                "holdout_top3_hit_rate_all_strains": summarized["holdout_top3_metrics"]["top3_hit_rate_all_strains"],
+                "holdout_top3_hit_rate_susceptible_only": summarized["holdout_top3_metrics"][
+                    "top3_hit_rate_susceptible_only"
+                ],
+                "cv_mean_roc_auc": summarized["cv_summary"]["mean_roc_auc"],
+                "cv_mean_brier_score": summarized["cv_summary"]["mean_brier_score"],
+                "cv_mean_top3_hit_rate_all_strains": summarized["cv_summary"]["mean_top3_hit_rate_all_strains"],
+                "roc_auc_delta_vs_v0": summarized["lift_vs_v0"]["roc_auc_delta"],
+                "brier_improvement_vs_v0": summarized["lift_vs_v0"]["brier_improvement"],
+                "top3_hit_rate_all_strains_delta_vs_v0": summarized["lift_vs_v0"]["top3_hit_rate_all_strains_delta"],
+                "best_params_json": json.dumps(summarized["best_params"], sort_keys=True),
+            }
+        )
+
+    feature_partitions = partition_track_c_columns(full_feature_space.track_c_additional_columns)
+    summary = {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "task_id": "TG03",
+        "reference_arm": "v0_features_only",
+        "model_family": "lightgbm",
+        "candidate_count_per_arm": len(LIGHTGBM_PARAMETER_GRID),
+        "ablation_protocol": {
+            "holdout_split": "ST0.3 holdout_test",
+            "training_subset": "split_holdout=train_non_holdout and is_hard_trainable=1",
+            "reference_policy": "All arms are compared directly against the v0-only LightGBM baseline.",
+            "model_family_lock": "LightGBM is held fixed across arms so lift is attributable to feature blocks.",
+            "host_genomic_arm_note": (
+                "The '+OMP receptors' arm includes all non-defense Track C host-genomic additions: the OMP receptor "
+                "one-hots plus the remaining capsule/LPS/phylogeny columns. TG03 does not define a separate arm for "
+                "those residual host-genomic features."
+            ),
+        },
+        "feature_blocks": {
+            "v0_categorical_columns": list(V0_CATEGORICAL_FEATURE_COLUMNS),
+            "v0_numeric_columns": list(V0_NUMERIC_FEATURE_COLUMNS),
+            "defense_subtype_columns": list(feature_partitions["defense_subtypes"]),
+            "omp_and_remaining_host_genomic_columns": list(feature_partitions["host_genomic_remainder"]),
+            "phage_genomic_columns": list(full_feature_space.track_d_columns),
+            "pairwise_compatibility_columns": list(full_feature_space.track_e_columns),
+        },
+        "arms": summary_arms,
+        "inputs": {
+            "st02_pair_table": {"path": str(args.st02_pair_table_path), "sha256": _sha256(args.st02_pair_table_path)},
+            "st03_split_assignments": {
+                "path": str(args.st03_split_assignments_path),
+                "sha256": _sha256(args.st03_split_assignments_path),
+            },
+            "track_c_pair_table": {
+                "path": str(args.track_c_pair_table_path),
+                "sha256": _sha256(args.track_c_pair_table_path),
+            },
+            "track_d_genome_kmers": {
+                "path": str(args.track_d_genome_kmer_path),
+                "sha256": _sha256(args.track_d_genome_kmer_path),
+            },
+            "track_d_distance": {
+                "path": str(args.track_d_distance_path),
+                "sha256": _sha256(args.track_d_distance_path),
+            },
+            "track_e_rbp_receptor_compatibility": {
+                "path": str(args.track_e_rbp_compatibility_path),
+                "sha256": _sha256(args.track_e_rbp_compatibility_path),
+            },
+            "track_e_defense_evasion": {
+                "path": str(args.track_e_defense_evasion_path),
+                "sha256": _sha256(args.track_e_defense_evasion_path),
+            },
+            "track_e_isolation_host_distance": {
+                "path": str(args.track_e_isolation_distance_path),
+                "sha256": _sha256(args.track_e_isolation_distance_path),
+            },
+        },
+    }
+
+    write_json(args.output_dir / "tg03_ablation_summary.json", summary)
+    write_csv(
+        args.output_dir / "tg03_ablation_metrics.csv",
+        list(metrics_rows[0].keys()),
+        metrics_rows,
+    )
+    write_csv(
+        args.output_dir / "tg03_ablation_cv_candidate_results.csv",
+        [
+            "model_label",
+            "params_json",
+            "mean_average_precision",
+            "mean_roc_auc",
+            "mean_brier_score",
+            "mean_log_loss",
+            "mean_top3_hit_rate_all_strains",
+            "mean_top3_hit_rate_susceptible_only",
+        ],
+        candidate_rows,
+    )
+    write_csv(
+        args.output_dir / "tg03_ablation_pair_predictions.csv",
+        [
+            "arm_id",
+            "arm_label",
+            "pair_id",
+            "bacteria",
+            "phage",
+            "split_holdout",
+            "split_cv5_fold",
+            "label_hard_any_lysis",
+            "prediction_context",
+            "predicted_probability",
+        ],
+        prediction_rows,
+    )
+    ranking_rows.sort(key=lambda row: (str(row["model_label"]), str(row["bacteria"]), int(row["rank"])))
+    write_csv(
+        args.output_dir / "tg03_ablation_holdout_top3_rankings.csv",
+        [
+            "model_label",
+            "bacteria",
+            "phage",
+            "pair_id",
+            "rank",
+            "predicted_probability",
+            "label_hard_any_lysis",
+        ],
+        ranking_rows,
+    )
+
+    print("TG03 completed.")
+    for arm in ablation_arms:
+        arm_summary = summary_arms[arm.arm_id]
+        print(
+            f"- {arm.display_name}: holdout ROC-AUC {arm_summary['holdout_binary_metrics']['roc_auc']}, "
+            f"top-3 {arm_summary['holdout_top3_metrics']['top3_hit_rate_all_strains']}, "
+            f"Brier {arm_summary['holdout_binary_metrics']['brier_score']}"
+        )
+    print(f"- Output directory: {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lyzortx/research_notes/lab_notebooks/track_G.md
+++ b/lyzortx/research_notes/lab_notebooks/track_G.md
@@ -140,3 +140,105 @@
    comparisons because it has the best holdout log-loss.
 3. In TG03, test whether the remaining strict-confidence calibration gap is driven by feature ablations, class-balance
    shifts, or group-specific error concentration rather than the choice of calibrator alone.
+
+### 2026-03-22: TG03 implemented (feature-block ablation suite on the fixed holdout split)
+
+#### What was implemented
+
+- Added the TG03 ablation runner at `lyzortx/pipeline/track_g/steps/run_feature_block_ablation_suite.py`.
+- Updated `lyzortx/pipeline/track_g/run_track_g.py`, `lyzortx/pipeline/track_g/README.md`, and
+  `lyzortx/tests/test_track_g_v1_binary_classifier.py` so Track G now exposes a dedicated
+  `feature-block-ablation` step with unit coverage for:
+  - Track C column partitioning into defense vs remaining host-genomic features
+  - the required TG03 arm sequence
+  - CLI dispatch of the new Track G step
+- TG03 now:
+  - bootstraps missing ST0.1-ST0.3 plus Track C/D/E prerequisite artifacts when needed
+  - locks one LightGBM model family and one ST0.3 holdout contract across all arms so lift is attributable to feature
+    blocks rather than a model-family swap
+  - evaluates the six required arms with v0 as the direct reference point in every comparison:
+    - `v0_features_only`
+    - `plus_defense_subtypes`
+    - `plus_omp_receptors`
+    - `plus_phage_genomic`
+    - `plus_pairwise_compatibility`
+    - `all_features`
+  - writes reusable artifacts under `lyzortx/generated_outputs/track_g/tg03_feature_block_ablation_suite/`
+- Scope note required by the current plan wording:
+  - the `+OMP receptors` arm includes the full non-defense Track C host-genomic remainder (`22` OMP one-hot columns plus
+    the `2` categorical capsule/LPS columns and `8` host-phylogeny UMAP dimensions) because TG03 does not define a
+    separate acceptance arm for those residual host-genomic features
+
+#### Output summary
+
+- TG03 output directory:
+  - `tg03_ablation_summary.json`
+  - `tg03_ablation_metrics.csv`
+  - `tg03_ablation_cv_candidate_results.csv`
+  - `tg03_ablation_pair_predictions.csv`
+  - `tg03_ablation_holdout_top3_rankings.csv`
+- Arm sizes:
+  - v0 only: `19` categorical + `9` numeric features
+  - +defense subtypes: `19` categorical + `91` numeric features
+  - +OMP receptors: `21` categorical + `42` numeric features
+  - +phage genomic: `19` categorical + `43` numeric features
+  - +pairwise compatibility: `19` categorical + `23` numeric features
+  - all features: `21` categorical + `170` numeric features
+- Holdout metrics on the same ST0.3 split (`65` strains, `6,235` hard-trainable pairs):
+  - v0 only:
+    - ROC-AUC `0.908023`
+    - top-3 hit rate (all strains) `0.861538`
+    - Brier `0.113537`
+  - +defense subtypes:
+    - ROC-AUC `0.906666`
+    - top-3 hit rate `0.907692`
+    - Brier `0.114083`
+    - vs v0: top-3 `+0.046154`, AUC `-0.001357`, Brier `-0.000546`
+  - +OMP receptors:
+    - ROC-AUC `0.910112`
+    - top-3 hit rate `0.876923`
+    - Brier `0.112338`
+    - vs v0: top-3 `+0.015385`, AUC `+0.002089`, Brier improvement `+0.001199`
+  - +phage genomic:
+    - ROC-AUC `0.908743`
+    - top-3 hit rate `0.907692`
+    - Brier `0.112097`
+    - vs v0: top-3 `+0.046154`, AUC `+0.000720`, Brier improvement `+0.001440`
+  - +pairwise compatibility:
+    - ROC-AUC `0.905398`
+    - top-3 hit rate `0.876923`
+    - Brier `0.117343`
+    - vs v0: top-3 `+0.015385`, AUC `-0.002625`, Brier `-0.003806`
+  - all features:
+    - ROC-AUC `0.909089`
+    - top-3 hit rate `0.876923`
+    - Brier `0.113112`
+    - vs v0: top-3 `+0.015385`, AUC `+0.001066`, Brier improvement `+0.000425`
+
+#### Interpretation
+
+1. The v0 baseline remains strong. A LightGBM trained on only the audited ST0.4 metadata features already reaches
+   holdout ROC-AUC `0.908023` and top-3 hit rate `0.861538`, so TG03 is measuring lift on top of a hard baseline
+   rather than rescuing a weak reference model.
+2. The clearest single-block ranking lift comes from defense subtypes and phage-genomic features. Both raise holdout
+   top-3 from `0.861538` to `0.907692` (`+3` strains hit in the top 3), which is the largest ranking gain in the
+   suite.
+3. The strongest discrimination/calibration-style lift comes from the host-genomic remainder grouped under the
+   `+OMP receptors` arm. That arm posts the best holdout AUC (`0.910112`) and improves Brier to `0.112338`, even
+   though its top-3 lift is smaller than the defense/phage-genomic arms.
+4. The pairwise compatibility block is not yet a clean win on this holdout. It gives a modest top-3 improvement over
+   v0, but it degrades both AUC and Brier relative to the reference arm, which suggests the current TE01-TE03 stack is
+   noisier or less transferable on this split than the host-only and phage-genomic additions.
+5. The combined all-features arm does not dominate every metric. It modestly beats v0 on AUC and Brier, but its holdout
+   top-3 hit rate (`0.876923`) is below the best single-block arms. The honest claim is therefore narrower than "more
+   features always helps": the current expanded stack adds some useful signal, but the strongest holdout ranking lift is
+   concentrated in the defense and phage-genomic blocks rather than the full union.
+
+#### Next steps
+
+1. Use the TG03 ablation results to scope TG04 explanations around the blocks that actually delivered holdout lift:
+   defense subtypes, host-genomic remainder, and phage-genomic features.
+2. Inspect the pairwise-only and all-features holdout misses in `tg03_ablation_holdout_top3_rankings.csv` before
+   assuming TE01-TE03 should remain in the final default stack unchanged.
+3. If Track G keeps the full model as the deployment default, consider a follow-up feature-selection or regularization
+   pass so the weaker pairwise block does not dilute the stronger defense/phage-genomic signal on the fixed holdout.

--- a/lyzortx/tests/test_track_g_v1_binary_classifier.py
+++ b/lyzortx/tests/test_track_g_v1_binary_classifier.py
@@ -2,7 +2,12 @@ import csv
 
 from lyzortx.pipeline.track_g import run_track_g
 from lyzortx.pipeline.track_g.steps import calibrate_gbm_outputs
+from lyzortx.pipeline.track_g.steps.run_feature_block_ablation_suite import (
+    build_ablation_arms,
+    partition_track_c_columns,
+)
 from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import (
+    FeatureSpace,
     build_feature_space,
     compute_top3_hit_rate,
     merge_expanded_feature_rows,
@@ -128,6 +133,70 @@ def test_select_best_candidate_prefers_auc_then_top3_then_brier() -> None:
     assert best["params"]["name"] == "b"
 
 
+def test_partition_track_c_columns_splits_defense_from_remaining_host_genomic() -> None:
+    partitioned = partition_track_c_columns(
+        [
+            "host_defense_subtype_abi_a",
+            "host_defense_diversity",
+            "host_receptor_variant_btub_01",
+            "host_surface_lps_core_type",
+            "host_phylogeny_umap_00",
+        ]
+    )
+
+    assert partitioned["defense_subtypes"] == (
+        "host_defense_subtype_abi_a",
+        "host_defense_diversity",
+    )
+    assert partitioned["host_genomic_remainder"] == (
+        "host_receptor_variant_btub_01",
+        "host_surface_lps_core_type",
+        "host_phylogeny_umap_00",
+    )
+
+
+def test_build_ablation_arms_matches_acceptance_sequence() -> None:
+    arms = build_ablation_arms(
+        FeatureSpace(
+            categorical_columns=("host_pathotype", "host_surface_lps_core_type"),
+            numeric_columns=(
+                "host_mouse_killed_10",
+                "host_defense_subtype_abi_a",
+                "host_defense_diversity",
+                "host_receptor_variant_btub_01",
+                "host_phylogeny_umap_00",
+                "phage_gc_content",
+                "target_receptor_present",
+            ),
+            track_c_additional_columns=(
+                "host_defense_subtype_abi_a",
+                "host_defense_diversity",
+                "host_receptor_variant_btub_01",
+                "host_surface_lps_core_type",
+                "host_phylogeny_umap_00",
+            ),
+            track_d_columns=("phage_gc_content",),
+            track_e_columns=("target_receptor_present",),
+        )
+    )
+
+    assert [arm.arm_id for arm in arms] == [
+        "v0_features_only",
+        "plus_defense_subtypes",
+        "plus_omp_receptors",
+        "plus_phage_genomic",
+        "plus_pairwise_compatibility",
+        "all_features",
+    ]
+    assert "host_defense_subtype_abi_a" in arms[1].numeric_columns
+    assert "phage_gc_content" not in arms[1].numeric_columns
+    assert "host_surface_lps_core_type" in arms[2].categorical_columns
+    assert "host_receptor_variant_btub_01" in arms[2].numeric_columns
+    assert "phage_gc_content" in arms[3].numeric_columns
+    assert "target_receptor_present" in arms[4].numeric_columns
+    assert arms[-1].categorical_columns == ("host_pathotype", "host_surface_lps_core_type")
+
+
 def test_run_track_g_dispatches_training_step(monkeypatch) -> None:
     calls: list[str] = []
 
@@ -141,13 +210,18 @@ def test_run_track_g_dispatches_training_step(monkeypatch) -> None:
         "main",
         lambda argv: calls.append("calibrate-gbm"),
     )
+    monkeypatch.setattr(
+        run_track_g.run_feature_block_ablation_suite,
+        "main",
+        lambda argv: calls.append("feature-block-ablation"),
+    )
 
     run_track_g.main(["--step", "train-v1-binary"])
     assert calls == ["train-v1-binary"]
 
     calls.clear()
     run_track_g.main(["--step", "all"])
-    assert calls == ["train-v1-binary", "calibrate-gbm"]
+    assert calls == ["train-v1-binary", "calibrate-gbm", "feature-block-ablation"]
 
 
 def test_run_track_g_dispatches_calibration_step(monkeypatch) -> None:
@@ -163,9 +237,37 @@ def test_run_track_g_dispatches_calibration_step(monkeypatch) -> None:
         "main",
         lambda argv: calls.append("calibrate-gbm"),
     )
+    monkeypatch.setattr(
+        run_track_g.run_feature_block_ablation_suite,
+        "main",
+        lambda argv: calls.append("feature-block-ablation"),
+    )
 
     run_track_g.main(["--step", "calibrate-gbm"])
     assert calls == ["calibrate-gbm"]
+
+
+def test_run_track_g_dispatches_tg03_ablation_step(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        run_track_g.train_v1_binary_classifier,
+        "main",
+        lambda argv: calls.append("train-v1-binary"),
+    )
+    monkeypatch.setattr(
+        run_track_g.calibrate_gbm_outputs,
+        "main",
+        lambda argv: calls.append("calibrate-gbm"),
+    )
+    monkeypatch.setattr(
+        run_track_g.run_feature_block_ablation_suite,
+        "main",
+        lambda argv: calls.append("feature-block-ablation"),
+    )
+
+    run_track_g.main(["--step", "feature-block-ablation"])
+    assert calls == ["feature-block-ablation"]
 
 
 def test_tg02_calibration_outputs_expected_files_and_rows(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- add a new Track G `feature-block-ablation` step that runs the six required TG03 ablation arms on the fixed ST0.3
  holdout split using one locked LightGBM model family
- write structured TG03 outputs under `lyzortx/generated_outputs/track_g/tg03_feature_block_ablation_suite/`,
  including per-arm metrics, candidate summaries, pair predictions, and holdout top-3 rankings
- document the implementation, generated artifacts, and holdout interpretation in
  `lyzortx/research_notes/lab_notebooks/track_G.md`

## Details

- wire the new step into `lyzortx/pipeline/track_g/run_track_g.py` and document it in
  `lyzortx/pipeline/track_g/README.md`
- add tests for Track C block partitioning, TG03 arm sequencing, and CLI dispatch; full test suite passes with
  `pytest -q lyzortx/tests/`
- keep `v0_features_only` as the explicit reference arm in all comparisons and record deltas for ROC-AUC, top-3 hit
  rate, and Brier score
- treat the `+OMP receptors` arm as the full non-defense Track C host-genomic remainder
  (`22` OMP one-hot columns plus `2` capsule/LPS categoricals and `8` host-phylogeny UMAP dimensions), since the plan
  does not define a separate acceptance arm for those residual host-genomic features

## Holdout Findings

- `v0_features_only`: ROC-AUC `0.908023`, top-3 `0.861538`, Brier `0.113537`
- `+defense subtypes`: top-3 improved to `0.907692` (`+0.046154` vs v0), but AUC/Brier were slightly worse
- `+OMP receptors`: best holdout ROC-AUC at `0.910112` and better Brier at `0.112338`
- `+phage genomic`: matched the best top-3 lift at `0.907692` and delivered the best holdout Brier at `0.112097`
- `+pairwise compatibility`: modest top-3 lift, but worse AUC and Brier than v0 on this holdout
- `all features`: slight AUC/Brier improvement over v0, but not the best top-3 arm

Posted by Codex gpt-5.

Closes #104
