### PR TITLE
Fix PR verification to avoid GitHub search index lag

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -113,10 +113,9 @@ jobs:
       - name: Verify Codex created a PR
         run: |
           ISSUE_NUM="${{ steps.issue.outputs.number }}"
-          # Use --json filtering instead of --search to avoid GitHub search index lag.
-          PR_JSON=$(gh pr list --state open --json number,headRefName,body \
-            --jq "[.[] | select(.body | test(\"[Cc]loses #${ISSUE_NUM}\\\\b\"))] | .[0]")
-          if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
+          # Use Python instead of gh pr list --search to avoid GitHub search index lag.
+          PR_JSON=$(python -m lyzortx.orchestration.find_pr_for_issue "$ISSUE_NUM")
+          if [ $? -ne 0 ] || [ -z "$PR_JSON" ]; then
             echo "::error::Codex did not create a PR for issue #${ISSUE_NUM}."
             exit 1
           fi

--- a/lyzortx/orchestration/find_pr_for_issue.py
+++ b/lyzortx/orchestration/find_pr_for_issue.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Find an open PR that closes a given issue number.
+
+Usage (CLI):
+    python -m lyzortx.orchestration.find_pr_for_issue 120
+
+Prints JSON ``{"number": 125, "headRefName": "branch-name"}`` to stdout,
+or exits with code 1 if no matching PR is found.
+
+Designed for CI workflows where ``gh pr list --search`` suffers from
+GitHub search index lag.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+
+CLOSES_RE = re.compile(r"[Cc]loses\s+#(\d+)\b")
+
+
+def pr_closes_issue(pr_body: str, issue_number: int) -> bool:
+    """Return True if *pr_body* contains a ``Closes #N`` reference matching *issue_number*."""
+    return any(int(m.group(1)) == issue_number for m in CLOSES_RE.finditer(pr_body))
+
+
+def find_pr_for_issue(issue_number: int) -> dict[str, object] | None:
+    """Find an open PR whose body contains ``Closes #<issue_number>``.
+
+    Returns ``{"number": int, "headRefName": str}`` or *None*.
+    """
+    result = subprocess.run(
+        ["gh", "pr", "list", "--state", "open", "--json", "number,headRefName,body"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    prs = json.loads(result.stdout)
+    for pr in prs:
+        if pr_closes_issue(pr.get("body", ""), issue_number):
+            return {"number": pr["number"], "headRefName": pr["headRefName"]}
+    return None
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <issue_number>", file=sys.stderr)
+        sys.exit(2)
+    issue_num = int(sys.argv[1])
+    match = find_pr_for_issue(issue_num)
+    if match is None:
+        sys.exit(1)
+    print(json.dumps(match))

--- a/lyzortx/tests/test_orchestrator_pure_functions.py
+++ b/lyzortx/tests/test_orchestrator_pure_functions.py
@@ -11,6 +11,7 @@ from lyzortx.orchestration.orchestrator import Task
 from lyzortx.orchestration.orchestrator import choose_preferred_issue
 from lyzortx.orchestration.orchestrator import extract_task_id_from_issue
 from lyzortx.orchestration.orchestrator import sync_status_from_issues
+from lyzortx.orchestration.find_pr_for_issue import pr_closes_issue
 from lyzortx.orchestration.parse_model_directive import extract_model
 
 
@@ -267,3 +268,39 @@ def test_sync_pending_when_no_issue() -> None:
     task_status: dict[str, str] = {"TG04": "pending"}
     sync_status_from_issues([task], task_status, {})
     assert task_status["TG04"] == "pending"
+
+
+# --- pr_closes_issue ---
+
+
+def test_pr_closes_issue_exact_match() -> None:
+    assert pr_closes_issue("Closes #120", 120)
+
+
+def test_pr_closes_issue_lowercase() -> None:
+    assert pr_closes_issue("closes #120", 120)
+
+
+def test_pr_closes_issue_no_prefix_collision() -> None:
+    """#12 must not match #120."""
+    assert not pr_closes_issue("Closes #120", 12)
+
+
+def test_pr_closes_issue_no_suffix_collision() -> None:
+    """#120 must not match #12."""
+    assert not pr_closes_issue("Closes #12", 120)
+
+
+def test_pr_closes_issue_in_longer_body() -> None:
+    body = "## Summary\nFixes the thing.\n\nCloses #42\n"
+    assert pr_closes_issue(body, 42)
+
+
+def test_pr_closes_issue_missing() -> None:
+    assert not pr_closes_issue("No closure reference here", 42)
+
+
+def test_pr_closes_issue_multiple_references() -> None:
+    body = "Closes #10\nCloses #20\n"
+    assert pr_closes_issue(body, 20)
+    assert not pr_closes_issue(body, 200)


### PR DESCRIPTION
## Summary

- Replace `gh pr list --search` + jq regex with a tested Python function (`find_pr_for_issue.py`) in the Codex implement workflow's verify step
- The GitHub search index lags behind PR creation, causing false negatives; the REST list endpoint is authoritative
- `pr_closes_issue()` is a pure function with 7 unit tests covering exact match, case insensitivity, prefix/suffix collision prevention, multiple references, and missing references
- CLI entry point: `python -m lyzortx.orchestration.find_pr_for_issue <issue_number>` — prints JSON or exits 1

## Context

TI06 run [23403190137](https://github.com/LorenaDerezanin/coli_phage_interactions_2023/actions/runs/23403190137) — Codex successfully created PR #125 (61K tokens, gpt-5.4-mini) but the verify step failed because `gh pr list --search "Closes #120"` returned empty due to search index lag. Initial fix attempted jq regex filtering but hit shell escaping issues with `\b` word boundaries. Replaced with a Python function that is properly unit-tested.

## Test plan

- [x] 28 orchestrator tests pass including 7 new `pr_closes_issue` tests
- [x] Pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)