### PR TITLE
[ORCH][TI08] Keep external data as a non-blocking training enhancer

### DIFF
--- a/lyzortx/pipeline/track_i/run_track_i.py
+++ b/lyzortx/pipeline/track_i/run_track_i.py
@@ -10,16 +10,20 @@ from pathlib import Path
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
-from lyzortx.pipeline.track_i.steps import build_external_label_confidence_tiers, build_tier_b_weak_label_ingest
+from lyzortx.pipeline.track_i.steps import (
+    build_external_label_confidence_tiers,
+    build_external_training_cohorts,
+    build_tier_b_weak_label_ingest,
+)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--step",
-        choices=["weak-label-ingest", "external-confidence-tiers", "all"],
+        choices=["weak-label-ingest", "external-confidence-tiers", "training-cohorts", "all"],
         default="all",
-        help="Track I step to run. 'all' runs the implemented weak-label ingest and confidence-tier steps.",
+        help="Track I step to run. 'all' runs the implemented weak-label ingest, confidence-tier, and cohort steps.",
     )
     return parser.parse_args(argv)
 
@@ -30,6 +34,8 @@ def main(argv: list[str] | None = None) -> None:
         build_tier_b_weak_label_ingest.main([])
     if args.step in {"external-confidence-tiers", "all"}:
         build_external_label_confidence_tiers.main([])
+    if args.step in {"training-cohorts", "all"}:
+        build_external_training_cohorts.main([])
 
 
 if __name__ == "__main__":

--- a/lyzortx/pipeline/track_i/steps/build_external_training_cohorts.py
+++ b/lyzortx/pipeline/track_i/steps/build_external_training_cohorts.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""TI08: Build internal-only and external-enhanced training cohorts without blocking the baseline."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
+
+REQUIRED_INTERNAL_COLUMNS = ("pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier")
+REQUIRED_EXTERNAL_COLUMNS = (
+    "pair_id",
+    "bacteria",
+    "phage",
+    "label_hard_any_lysis",
+    "label_strict_confidence_tier",
+    "source_system",
+    "external_label_confidence_tier",
+    "external_label_confidence_score",
+    "external_label_training_weight",
+    "external_label_include_in_training",
+)
+
+TRAINING_ARM_ORDER = (
+    "internal_only",
+    "plus_vhrdb",
+    "plus_basel",
+    "plus_klebphacol",
+    "plus_gpb",
+    "plus_tier_b",
+)
+TRAINING_ARM_INDEX = {arm: idx for idx, arm in enumerate(TRAINING_ARM_ORDER)}
+TIER_A_SOURCE_TO_ARM = {
+    "vhrdb": "plus_vhrdb",
+    "basel": "plus_basel",
+    "klebphacol": "plus_klebphacol",
+    "gpb": "plus_gpb",
+}
+TIER_B_SOURCES = {"virus_host_db", "ncbi_virus_biosample"}
+OUTPUT_APPEND_COLUMNS = [
+    "source_family",
+    "first_training_arm",
+    "first_training_arm_index",
+    "effective_training_weight",
+    "integration_status",
+]
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--internal-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st02_pair_table.csv"),
+    )
+    parser.add_argument(
+        "--external-confidence-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_i/external_label_confidence_tiers/ti07_external_label_confidence_pairs.csv"
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_i/training_cohort_integration"),
+    )
+    return parser.parse_args(argv)
+
+
+def _normalize_row(row: Mapping[str, str]) -> Dict[str, str]:
+    return {key: (value.strip() if isinstance(value, str) else "") for key, value in row.items()}
+
+
+def _hash_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def first_training_arm_for_source(source_system: str) -> str:
+    if source_system in TIER_A_SOURCE_TO_ARM:
+        return TIER_A_SOURCE_TO_ARM[source_system]
+    if source_system in TIER_B_SOURCES:
+        return "plus_tier_b"
+    raise ValueError(f"Unsupported external source_system for TI08 integration: {source_system!r}")
+
+
+def source_family_for_source(source_system: str) -> str:
+    if source_system in TIER_A_SOURCE_TO_ARM:
+        return "tier_a"
+    if source_system in TIER_B_SOURCES:
+        return "tier_b"
+    if source_system == "internal":
+        return "internal"
+    raise ValueError(f"Unsupported source_system for TI08 integration: {source_system!r}")
+
+
+def load_external_rows(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        return []
+    return [_normalize_row(row) for row in read_csv_rows(path, REQUIRED_EXTERNAL_COLUMNS)]
+
+
+def build_integrated_training_rows(
+    internal_rows: Sequence[Mapping[str, str]],
+    external_rows: Sequence[Mapping[str, str]],
+) -> List[Dict[str, object]]:
+    integrated_rows: List[Dict[str, object]] = []
+
+    for row in internal_rows:
+        normalized = _normalize_row(row)
+        normalized.update(
+            {
+                "source_system": "internal",
+                "source_family": "internal",
+                "first_training_arm": "internal_only",
+                "first_training_arm_index": TRAINING_ARM_INDEX["internal_only"],
+                "effective_training_weight": 1.0,
+                "integration_status": "baseline_internal",
+            }
+        )
+        integrated_rows.append(normalized)
+
+    for row in external_rows:
+        normalized = _normalize_row(row)
+        source_system = normalized["source_system"]
+        include_in_training = normalized.get("external_label_include_in_training", "") == "1"
+        first_arm = first_training_arm_for_source(source_system)
+        normalized.update(
+            {
+                "source_family": source_family_for_source(source_system),
+                "first_training_arm": first_arm if include_in_training else "excluded",
+                "first_training_arm_index": TRAINING_ARM_INDEX[first_arm] if include_in_training else -1,
+                "effective_training_weight": (
+                    float(normalized.get("external_label_training_weight", "0") or 0.0) if include_in_training else 0.0
+                ),
+                "integration_status": "external_enhancer" if include_in_training else "excluded_by_confidence",
+            }
+        )
+        integrated_rows.append(normalized)
+
+    return sorted(
+        integrated_rows,
+        key=lambda row: (
+            int(row["first_training_arm_index"]),
+            str(row["source_system"]),
+            str(row["pair_id"]),
+            str(row.get("source_native_record_id", "")),
+        ),
+    )
+
+
+def _trainable_rows_for_arm(rows: Sequence[Mapping[str, object]], arm: str) -> List[Mapping[str, object]]:
+    arm_index = TRAINING_ARM_INDEX[arm]
+    return [
+        row
+        for row in rows
+        if int(row["first_training_arm_index"]) >= 0 and int(row["first_training_arm_index"]) <= arm_index
+    ]
+
+
+def compute_training_arm_summary(rows: Sequence[Mapping[str, object]]) -> List[Dict[str, object]]:
+    summary_rows: List[Dict[str, object]] = []
+    previous_pair_ids: set[str] = set()
+    previous_row_count = 0
+
+    for arm in TRAINING_ARM_ORDER:
+        arm_rows = _trainable_rows_for_arm(rows, arm)
+        pair_ids = {str(row["pair_id"]) for row in arm_rows}
+        external_rows = [row for row in arm_rows if str(row["source_system"]) != "internal"]
+        external_pair_ids = {str(row["pair_id"]) for row in external_rows}
+        row_count = len(arm_rows)
+        summary_rows.append(
+            {
+                "arm": arm,
+                "arm_index": TRAINING_ARM_INDEX[arm],
+                "source_system_added": arm.replace("plus_", "") if arm != "internal_only" else "internal",
+                "cumulative_row_count": row_count,
+                "cumulative_pair_count": len(pair_ids),
+                "cumulative_external_row_count": len(external_rows),
+                "cumulative_external_pair_count": len(external_pair_ids),
+                "new_rows_vs_previous_arm": row_count - previous_row_count,
+                "new_pairs_vs_previous_arm": len(pair_ids - previous_pair_ids),
+                "cumulative_training_weight": safe_round(
+                    sum(float(row["effective_training_weight"]) for row in arm_rows)
+                ),
+            }
+        )
+        previous_pair_ids = pair_ids
+        previous_row_count = row_count
+
+    return summary_rows
+
+
+def compute_integration_status_summary(rows: Sequence[Mapping[str, object]]) -> List[Dict[str, object]]:
+    counts: Dict[tuple[str, str], int] = {}
+    for row in rows:
+        key = (str(row["integration_status"]), str(row["source_system"]))
+        counts[key] = counts.get(key, 0) + 1
+    return [
+        {
+            "slice_type": "integration_status_and_source",
+            "slice_value": f"{integration_status}:{source_system}",
+            "row_count": count,
+        }
+        for (integration_status, source_system), count in sorted(counts.items())
+    ]
+
+
+def ordered_fieldnames(rows: Sequence[Mapping[str, object]]) -> List[str]:
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    for column in OUTPUT_APPEND_COLUMNS:
+        if column not in fieldnames:
+            fieldnames.append(column)
+    return fieldnames
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+    ensure_directory(args.output_dir)
+
+    internal_rows = read_csv_rows(args.internal_pair_table_path, REQUIRED_INTERNAL_COLUMNS)
+    external_rows = load_external_rows(args.external_confidence_path)
+
+    integrated_rows = build_integrated_training_rows(internal_rows, external_rows)
+    arm_summary_rows = compute_training_arm_summary(integrated_rows)
+    integration_status_rows = compute_integration_status_summary(integrated_rows)
+
+    rows_output_path = args.output_dir / "ti08_training_cohort_rows.csv"
+    arm_summary_output_path = args.output_dir / "ti08_training_arm_summary.csv"
+    status_summary_output_path = args.output_dir / "ti08_integration_status_summary.csv"
+    manifest_output_path = args.output_dir / "ti08_training_cohort_manifest.json"
+
+    write_csv(rows_output_path, fieldnames=ordered_fieldnames(integrated_rows), rows=integrated_rows)
+    write_csv(
+        arm_summary_output_path,
+        fieldnames=[
+            "arm",
+            "arm_index",
+            "source_system_added",
+            "cumulative_row_count",
+            "cumulative_pair_count",
+            "cumulative_external_row_count",
+            "cumulative_external_pair_count",
+            "new_rows_vs_previous_arm",
+            "new_pairs_vs_previous_arm",
+            "cumulative_training_weight",
+        ],
+        rows=arm_summary_rows,
+    )
+    write_csv(
+        status_summary_output_path,
+        fieldnames=["slice_type", "slice_value", "row_count"],
+        rows=integration_status_rows,
+    )
+    write_json(
+        manifest_output_path,
+        {
+            "generated_at_utc": datetime.now(tz=timezone.utc).isoformat(),
+            "step_name": "build_external_training_cohorts",
+            "training_arm_order": list(TRAINING_ARM_ORDER),
+            "external_confidence_input_present": args.external_confidence_path.exists(),
+            "active_external_sources": sorted({row["source_system"] for row in external_rows}),
+            "input_paths": {
+                "internal_pair_table": str(args.internal_pair_table_path),
+                "external_confidence_pairs": str(args.external_confidence_path),
+            },
+            "input_hashes_sha256": {
+                "internal_pair_table": _hash_path(args.internal_pair_table_path),
+                **(
+                    {"external_confidence_pairs": _hash_path(args.external_confidence_path)}
+                    if args.external_confidence_path.exists()
+                    else {}
+                ),
+            },
+            "output_paths": {
+                "rows": str(rows_output_path),
+                "arm_summary": str(arm_summary_output_path),
+                "integration_status_summary": str(status_summary_output_path),
+            },
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_I.md
+++ b/lyzortx/research_notes/lab_notebooks/track_I.md
@@ -114,3 +114,31 @@ missing BioSample context instead of silently collapsing those cases.
 - TI07 is now an explicit policy boundary between ingestion and training. That is the right abstraction: TI06 preserves
   raw provenance, TI07 translates provenance into training trust, and TI08 can stay focused on optional integration
   rather than re-litigating confidence semantics inside the model pipeline.
+
+### 2026-03-22: TI08 External data as a non-blocking enhancer
+
+#### Executive summary
+
+TI08 now turns the TI07 confidence output into an explicit training-cohort layer rather than forcing external data into
+the baseline path. The new step under `lyzortx/pipeline/track_i/steps/build_external_training_cohorts.py` always emits
+an `internal_only` arm from ST0.2, then stages optional external additions in the planned order
+`+VHRdb -> +BASEL -> +KlebPhaCol -> +GPB -> +Tier B`. When the TI07 artifact is absent, the step still succeeds and
+produces a runnable internal-only cohort plus zero-lift summaries for the future external arms.
+
+#### Findings
+
+- The right TI08 seam was dataset assembly, not estimator surgery. Rewriting baseline trainers to consume partial
+  external supervision now would have coupled baseline reproducibility to still-evolving source harmonization and
+  ablation policy.
+- TI07 already provides the exact integration boundary needed for safe enhancement: every external row arrives with a
+  source ID, confidence tier, include/exclude decision, and training weight.
+- Preserving a `first_training_arm` assignment per row is cleaner than materializing six separate training tables. It
+  keeps provenance intact, makes TI09's ordered ablations mechanical, and avoids duplicating the same row into many
+  output files.
+
+#### Interpretation
+
+- Track I now has a non-blocking external integration layer: internal-only remains the default runnable baseline, while
+  approved external labels can be layered in deterministically when they are present.
+- This is the correct amount of implementation for TI08. It makes the enhancement path executable and testable without
+  prematurely claiming that the current model trainers should already consume every external row.

--- a/lyzortx/tests/test_external_training_cohorts.py
+++ b/lyzortx/tests/test_external_training_cohorts.py
@@ -1,0 +1,165 @@
+"""Unit tests for TI08 external training cohort integration."""
+
+from __future__ import annotations
+
+import csv
+import json
+
+from lyzortx.pipeline.track_i import run_track_i
+from lyzortx.pipeline.track_i.steps.build_external_training_cohorts import (
+    build_integrated_training_rows,
+    compute_training_arm_summary,
+    main,
+)
+
+
+def _write_csv(path, fieldnames, rows) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_build_integrated_training_rows_assigns_planned_training_arms() -> None:
+    rows = build_integrated_training_rows(
+        internal_rows=[
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+            }
+        ],
+        external_rows=[
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "source_system": "vhrdb",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+                "external_label_include_in_training": "1",
+            },
+            {
+                "pair_id": "b2__p2",
+                "bacteria": "b2",
+                "phage": "p2",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "",
+                "source_system": "virus_host_db",
+                "external_label_confidence_tier": "exclude",
+                "external_label_confidence_score": "0",
+                "external_label_training_weight": "0.0",
+                "external_label_include_in_training": "0",
+            },
+        ],
+    )
+
+    by_source = {row["source_system"]: row for row in rows}
+    assert by_source["internal"]["first_training_arm"] == "internal_only"
+    assert by_source["internal"]["effective_training_weight"] == 1.0
+    assert by_source["vhrdb"]["first_training_arm"] == "plus_vhrdb"
+    assert by_source["vhrdb"]["integration_status"] == "external_enhancer"
+    assert by_source["virus_host_db"]["first_training_arm"] == "excluded"
+    assert by_source["virus_host_db"]["first_training_arm_index"] == -1
+    assert by_source["virus_host_db"]["integration_status"] == "excluded_by_confidence"
+
+
+def test_compute_training_arm_summary_keeps_internal_only_runnable() -> None:
+    rows = build_integrated_training_rows(
+        internal_rows=[
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+            },
+            {
+                "pair_id": "b2__p2",
+                "bacteria": "b2",
+                "phage": "p2",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+            },
+        ],
+        external_rows=[],
+    )
+
+    summary = compute_training_arm_summary(rows)
+
+    assert summary[0]["arm"] == "internal_only"
+    assert summary[0]["cumulative_row_count"] == 2
+    assert summary[0]["cumulative_external_row_count"] == 0
+    assert all(row["new_rows_vs_previous_arm"] == 0 for row in summary[1:])
+    assert all(row["cumulative_pair_count"] == 2 for row in summary)
+
+
+def test_main_emits_internal_only_outputs_when_external_confidence_is_missing(tmp_path) -> None:
+    internal_pair_table = tmp_path / "st02_pair_table.csv"
+    _write_csv(
+        internal_pair_table,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier"],
+        [
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+            }
+        ],
+    )
+    output_dir = tmp_path / "out"
+
+    main(
+        [
+            "--internal-pair-table-path",
+            str(internal_pair_table),
+            "--external-confidence-path",
+            str(tmp_path / "missing.csv"),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    with (output_dir / "ti08_training_cohort_rows.csv").open("r", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert len(rows) == 1
+    assert rows[0]["source_system"] == "internal"
+    assert rows[0]["first_training_arm"] == "internal_only"
+
+    manifest = json.loads((output_dir / "ti08_training_cohort_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["step_name"] == "build_external_training_cohorts"
+    assert manifest["external_confidence_input_present"] is False
+
+
+def test_run_track_i_dispatches_ti08_step(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        run_track_i.build_tier_b_weak_label_ingest,
+        "main",
+        lambda argv: calls.append("weak-label-ingest"),
+    )
+    monkeypatch.setattr(
+        run_track_i.build_external_label_confidence_tiers,
+        "main",
+        lambda argv: calls.append("external-confidence-tiers"),
+    )
+    monkeypatch.setattr(
+        run_track_i.build_external_training_cohorts,
+        "main",
+        lambda argv: calls.append("training-cohorts"),
+    )
+
+    run_track_i.main(["--step", "training-cohorts"])
+    assert calls == ["training-cohorts"]
+
+    calls.clear()
+    run_track_i.main(["--step", "all"])
+    assert calls == ["weak-label-ingest", "external-confidence-tiers", "training-cohorts"]


### PR DESCRIPTION
## Summary

- add a TI08 Track I cohort-integration step that always emits an `internal_only` training arm from ST0.2 and stages
  optional external rows in the planned order `+VHRdb -> +BASEL -> +KlebPhaCol -> +GPB -> +Tier B`
- keep external data non-blocking by letting the new step succeed when the TI07 confidence artifact is absent, while
  still emitting internal-only rows and zero-lift arm summaries for future ablations
- wire the new step into `run_track_i.py`, add TI08 unit tests for arm assignment, fallback behavior, and runner
  dispatch, and record findings in the Track I lab notebook

## Acceptance Criteria

- Track I has a runnable TI08 integration step under `lyzortx/pipeline/track_i/steps/` that builds training cohorts
  from ST0.2 internal rows plus optional TI07 external-confidence rows
- the step succeeds without external inputs and still emits an internal-only cohort and summary artifacts
- integrated rows carry deterministic arm membership and effective training weights so TI09 can run the planned
  ablation order mechanically
- `run_track_i.py` exposes the TI08 step and unit tests cover both the fallback and external-enhanced paths

## Validation

- `pytest -q lyzortx/tests/`

Closes #129

Posted by Codex gpt-5.4.
