### PR TITLE
[ORCH][TI09] Run strict ablations in sequence

### DIFF
--- a/lyzortx/pipeline/track_i/run_track_i.py
+++ b/lyzortx/pipeline/track_i/run_track_i.py
@@ -13,6 +13,7 @@ if __package__ in {None, ""}:
 from lyzortx.pipeline.track_i.steps import (
     build_external_label_confidence_tiers,
     build_external_training_cohorts,
+    build_strict_ablation_sequence,
     build_tier_b_weak_label_ingest,
 )
 
@@ -21,9 +22,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--step",
-        choices=["weak-label-ingest", "external-confidence-tiers", "training-cohorts", "all"],
+        choices=[
+            "weak-label-ingest",
+            "external-confidence-tiers",
+            "training-cohorts",
+            "strict-ablation-sequence",
+            "all",
+        ],
         default="all",
-        help="Track I step to run. 'all' runs the implemented weak-label ingest, confidence-tier, and cohort steps.",
+        help=(
+            "Track I step to run. 'all' runs the implemented weak-label ingest, confidence-tier, cohort, and "
+            "strict-ablation steps."
+        ),
     )
     return parser.parse_args(argv)
 
@@ -36,6 +46,8 @@ def main(argv: list[str] | None = None) -> None:
         build_external_label_confidence_tiers.main([])
     if args.step in {"training-cohorts", "all"}:
         build_external_training_cohorts.main([])
+    if args.step in {"strict-ablation-sequence", "all"}:
+        build_strict_ablation_sequence.main([])
 
 
 if __name__ == "__main__":

--- a/lyzortx/pipeline/track_i/steps/build_strict_ablation_sequence.py
+++ b/lyzortx/pipeline/track_i/steps/build_strict_ablation_sequence.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""TI09: Run the strict external-data ablation sequence in the planned source order."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
+from lyzortx.pipeline.track_i.steps.build_external_training_cohorts import TRAINING_ARM_INDEX, TRAINING_ARM_ORDER
+
+REQUIRED_COHORT_COLUMNS = (
+    "pair_id",
+    "source_system",
+    "first_training_arm",
+    "first_training_arm_index",
+    "effective_training_weight",
+)
+
+STRICT_ABLATION_SOURCE_ADDITIONS: Dict[str, Tuple[str, ...]] = {
+    "internal_only": ("internal",),
+    "plus_vhrdb": ("vhrdb",),
+    "plus_basel": ("basel",),
+    "plus_klebphacol": ("klebphacol",),
+    "plus_gpb": ("gpb",),
+    "plus_tier_b": ("virus_host_db", "ncbi_virus_biosample"),
+}
+
+STRICT_SOURCE_ORDER = (
+    "internal",
+    "vhrdb",
+    "basel",
+    "klebphacol",
+    "gpb",
+    "virus_host_db",
+    "ncbi_virus_biosample",
+)
+STRICT_SOURCE_INDEX = {source: idx for idx, source in enumerate(STRICT_SOURCE_ORDER)}
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--training-cohort-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_i/training_cohort_integration/ti08_training_cohort_rows.csv"),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_i/strict_ablation_sequence"),
+    )
+    return parser.parse_args(argv)
+
+
+def _normalize_row(row: Mapping[str, str]) -> Dict[str, str]:
+    return {key: (value.strip() if isinstance(value, str) else "") for key, value in row.items()}
+
+
+def _hash_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _join_sources(sources: Sequence[str]) -> str:
+    return "|".join(sources)
+
+
+def _sorted_unique_sources(sources: Sequence[str]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for source in sources:
+        if source not in STRICT_SOURCE_INDEX:
+            raise ValueError(f"Unsupported source_system in strict ablation sequence: {source!r}")
+        if source not in seen:
+            seen.add(source)
+            ordered.append(source)
+    return sorted(ordered, key=lambda source: STRICT_SOURCE_INDEX[source])
+
+
+def _planned_sources_for_arm(arm: str) -> Tuple[str, ...]:
+    if arm not in STRICT_ABLATION_SOURCE_ADDITIONS:
+        raise ValueError(f"Unsupported training arm in strict ablation sequence: {arm!r}")
+    return STRICT_ABLATION_SOURCE_ADDITIONS[arm]
+
+
+def _cumulative_planned_sources_for_arm(arm: str) -> Tuple[str, ...]:
+    arm_index = TRAINING_ARM_INDEX[arm]
+    cumulative: List[str] = []
+    for prior_arm in TRAINING_ARM_ORDER[: arm_index + 1]:
+        cumulative.extend(_planned_sources_for_arm(prior_arm))
+    return tuple(cumulative)
+
+
+def compute_strict_ablation_summary(rows: Sequence[Mapping[str, str]]) -> List[Dict[str, object]]:
+    summary_rows: List[Dict[str, object]] = []
+    previous_pair_ids: set[str] = set()
+    previous_row_count = 0
+
+    normalized_rows = [_normalize_row(row) for row in rows]
+    for row in normalized_rows:
+        source_system = row.get("source_system", "")
+        if source_system not in STRICT_SOURCE_INDEX:
+            raise ValueError(f"Unsupported source_system in strict ablation sequence: {source_system!r}")
+
+    for arm in TRAINING_ARM_ORDER:
+        arm_index = TRAINING_ARM_INDEX[arm]
+        arm_rows = [row for row in normalized_rows if int(row["first_training_arm_index"]) <= arm_index]
+        pair_ids = {str(row["pair_id"]) for row in arm_rows}
+        observed_sources = _sorted_unique_sources([str(row["source_system"]) for row in arm_rows])
+        current_rows = [row for row in normalized_rows if int(row["first_training_arm_index"]) == arm_index]
+        current_pair_ids = {str(row["pair_id"]) for row in current_rows}
+        current_sources = _sorted_unique_sources([str(row["source_system"]) for row in current_rows])
+        external_rows = [row for row in arm_rows if str(row["source_system"]) != "internal"]
+        external_pair_ids = {str(row["pair_id"]) for row in external_rows}
+
+        summary_rows.append(
+            {
+                "arm": arm,
+                "arm_index": arm_index,
+                "planned_source_systems_added": _join_sources(_planned_sources_for_arm(arm)),
+                "observed_source_systems_added": _join_sources(current_sources),
+                "cumulative_source_systems": _join_sources(observed_sources),
+                "cumulative_row_count": len(arm_rows),
+                "cumulative_pair_count": len(pair_ids),
+                "cumulative_external_row_count": len(external_rows),
+                "cumulative_external_pair_count": len(external_pair_ids),
+                "new_rows_vs_previous_arm": len(arm_rows) - previous_row_count,
+                "new_pairs_vs_previous_arm": len(pair_ids - previous_pair_ids),
+                "new_observed_pairs_vs_previous_arm": len(current_pair_ids - previous_pair_ids),
+                "cumulative_training_weight": safe_round(
+                    sum(float(row["effective_training_weight"]) for row in arm_rows)
+                ),
+                "cumulative_planned_source_count": len(_cumulative_planned_sources_for_arm(arm)),
+            }
+        )
+        previous_pair_ids = pair_ids
+        previous_row_count = len(arm_rows)
+
+    return summary_rows
+
+
+def ordered_fieldnames(rows: Sequence[Mapping[str, object]]) -> List[str]:
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    return fieldnames
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+    ensure_directory(args.output_dir)
+
+    rows = read_csv_rows(args.training_cohort_path, REQUIRED_COHORT_COLUMNS)
+    summary_rows = compute_strict_ablation_summary(rows)
+
+    summary_output_path = args.output_dir / "ti09_strict_ablation_summary.csv"
+    manifest_output_path = args.output_dir / "ti09_strict_ablation_manifest.json"
+
+    write_csv(summary_output_path, fieldnames=ordered_fieldnames(summary_rows), rows=summary_rows)
+    write_json(
+        manifest_output_path,
+        {
+            "generated_at_utc": datetime.now(tz=timezone.utc).isoformat(),
+            "step_name": "build_strict_ablation_sequence",
+            "strict_ablation_order": list(TRAINING_ARM_ORDER),
+            "input_paths": {
+                "training_cohort_rows": str(args.training_cohort_path),
+            },
+            "input_hashes_sha256": {
+                "training_cohort_rows": _hash_path(args.training_cohort_path),
+            },
+            "output_paths": {
+                "summary": str(summary_output_path),
+            },
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_I.md
+++ b/lyzortx/research_notes/lab_notebooks/track_I.md
@@ -142,3 +142,28 @@ produces a runnable internal-only cohort plus zero-lift summaries for the future
   approved external labels can be layered in deterministically when they are present.
 - This is the correct amount of implementation for TI08. It makes the enhancement path executable and testable without
   prematurely claiming that the current model trainers should already consume every external row.
+
+### 2026-03-22: TI09 Strict ablation sequence
+
+#### Executive summary
+
+TI09 now has a dedicated Track I step that reads the TI08 cohort output and materializes the planned strict ablation
+order `internal-only -> +VHRdb -> +BASEL -> +KlebPhaCol -> +GPB -> +Tier B`. The step writes a reproducible summary
+table and manifest under `lyzortx/generated_outputs/track_i/strict_ablation_sequence/`, making the source-addition
+sequence explicit instead of burying it inside the cohort integration step.
+
+#### Findings
+
+- The strict ablation task is a sequencing problem, not a redefinition of the TI08 cohort contract. Reusing TI08 output
+  keeps the implementation honest: the new step only reasons about the order in which rows become eligible for the
+  cumulative arms.
+- Treating `+Tier B` as a final planned addition works cleanly because the TI08 rows already preserve the underlying
+  source-system provenance for Virus-Host DB and NCBI Virus/BioSample separately.
+- The new summary records both the planned source additions and the observed cumulative source coverage, which makes it
+  easy to spot when a planned arm exists but contributes no rows yet.
+
+#### Interpretation
+
+TI09 is now executable as a standalone, ordered ablation pass. That keeps the Track I pipeline modular: TI08 preserves
+integration trust, and TI09 turns that trusted cohort into a strict source-by-source ablation sequence that TI10 can
+use for lift and failure-mode analysis.

--- a/lyzortx/tests/test_external_training_cohorts.py
+++ b/lyzortx/tests/test_external_training_cohorts.py
@@ -156,10 +156,20 @@ def test_run_track_i_dispatches_ti08_step(monkeypatch) -> None:
         "main",
         lambda argv: calls.append("training-cohorts"),
     )
+    monkeypatch.setattr(
+        run_track_i.build_strict_ablation_sequence,
+        "main",
+        lambda argv: calls.append("strict-ablation-sequence"),
+    )
 
     run_track_i.main(["--step", "training-cohorts"])
     assert calls == ["training-cohorts"]
 
     calls.clear()
     run_track_i.main(["--step", "all"])
-    assert calls == ["weak-label-ingest", "external-confidence-tiers", "training-cohorts"]
+    assert calls == [
+        "weak-label-ingest",
+        "external-confidence-tiers",
+        "training-cohorts",
+        "strict-ablation-sequence",
+    ]

--- a/lyzortx/tests/test_strict_ablation_sequence.py
+++ b/lyzortx/tests/test_strict_ablation_sequence.py
@@ -1,0 +1,186 @@
+"""Unit tests for TI09 strict ablation sequencing."""
+
+from __future__ import annotations
+
+import csv
+import json
+
+from lyzortx.pipeline.track_i import run_track_i
+from lyzortx.pipeline.track_i.steps.build_strict_ablation_sequence import (
+    compute_strict_ablation_summary,
+    main,
+)
+
+
+def _write_csv(path, fieldnames, rows) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_compute_strict_ablation_summary_keeps_the_planned_source_order() -> None:
+    rows = [
+        {
+            "pair_id": "b1__p1",
+            "source_system": "internal",
+            "first_training_arm": "internal_only",
+            "first_training_arm_index": "0",
+            "effective_training_weight": "1.0",
+        },
+        {
+            "pair_id": "b2__p2",
+            "source_system": "vhrdb",
+            "first_training_arm": "plus_vhrdb",
+            "first_training_arm_index": "1",
+            "effective_training_weight": "1.0",
+        },
+        {
+            "pair_id": "b3__p3",
+            "source_system": "basel",
+            "first_training_arm": "plus_basel",
+            "first_training_arm_index": "2",
+            "effective_training_weight": "0.8",
+        },
+        {
+            "pair_id": "b4__p4",
+            "source_system": "klebphacol",
+            "first_training_arm": "plus_klebphacol",
+            "first_training_arm_index": "3",
+            "effective_training_weight": "0.6",
+        },
+        {
+            "pair_id": "b5__p5",
+            "source_system": "gpb",
+            "first_training_arm": "plus_gpb",
+            "first_training_arm_index": "4",
+            "effective_training_weight": "0.5",
+        },
+        {
+            "pair_id": "b6__p6",
+            "source_system": "virus_host_db",
+            "first_training_arm": "plus_tier_b",
+            "first_training_arm_index": "5",
+            "effective_training_weight": "0.2",
+        },
+        {
+            "pair_id": "b7__p7",
+            "source_system": "ncbi_virus_biosample",
+            "first_training_arm": "plus_tier_b",
+            "first_training_arm_index": "5",
+            "effective_training_weight": "0.2",
+        },
+    ]
+
+    summary = compute_strict_ablation_summary(rows)
+
+    assert [row["arm"] for row in summary] == [
+        "internal_only",
+        "plus_vhrdb",
+        "plus_basel",
+        "plus_klebphacol",
+        "plus_gpb",
+        "plus_tier_b",
+    ]
+    assert summary[0]["cumulative_source_systems"] == "internal"
+    assert summary[1]["cumulative_source_systems"] == "internal|vhrdb"
+    assert summary[-1]["planned_source_systems_added"] == "virus_host_db|ncbi_virus_biosample"
+    assert summary[-1]["observed_source_systems_added"] == "virus_host_db|ncbi_virus_biosample"
+    assert summary[-1]["cumulative_source_systems"] == (
+        "internal|vhrdb|basel|klebphacol|gpb|virus_host_db|ncbi_virus_biosample"
+    )
+    assert summary[-1]["new_pairs_vs_previous_arm"] == 2
+
+
+def test_main_emits_strict_ablation_outputs(tmp_path) -> None:
+    cohort_rows = tmp_path / "ti08_training_cohort_rows.csv"
+    _write_csv(
+        cohort_rows,
+        [
+            "pair_id",
+            "source_system",
+            "first_training_arm",
+            "first_training_arm_index",
+            "effective_training_weight",
+        ],
+        [
+            {
+                "pair_id": "b1__p1",
+                "source_system": "internal",
+                "first_training_arm": "internal_only",
+                "first_training_arm_index": "0",
+                "effective_training_weight": "1.0",
+            },
+            {
+                "pair_id": "b2__p2",
+                "source_system": "vhrdb",
+                "first_training_arm": "plus_vhrdb",
+                "first_training_arm_index": "1",
+                "effective_training_weight": "1.0",
+            },
+        ],
+    )
+    output_dir = tmp_path / "out"
+
+    main(
+        [
+            "--training-cohort-path",
+            str(cohort_rows),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    with (output_dir / "ti09_strict_ablation_summary.csv").open("r", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert [row["arm"] for row in rows] == [
+        "internal_only",
+        "plus_vhrdb",
+        "plus_basel",
+        "plus_klebphacol",
+        "plus_gpb",
+        "plus_tier_b",
+    ]
+    assert rows[1]["planned_source_systems_added"] == "vhrdb"
+    assert rows[2]["new_rows_vs_previous_arm"] == "0"
+
+    manifest = json.loads((output_dir / "ti09_strict_ablation_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["step_name"] == "build_strict_ablation_sequence"
+    assert manifest["strict_ablation_order"][-1] == "plus_tier_b"
+
+
+def test_run_track_i_dispatches_ti09_step(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        run_track_i.build_tier_b_weak_label_ingest,
+        "main",
+        lambda argv: calls.append("weak-label-ingest"),
+    )
+    monkeypatch.setattr(
+        run_track_i.build_external_label_confidence_tiers,
+        "main",
+        lambda argv: calls.append("external-confidence-tiers"),
+    )
+    monkeypatch.setattr(
+        run_track_i.build_external_training_cohorts,
+        "main",
+        lambda argv: calls.append("training-cohorts"),
+    )
+    monkeypatch.setattr(
+        run_track_i.build_strict_ablation_sequence,
+        "main",
+        lambda argv: calls.append("strict-ablation-sequence"),
+    )
+
+    run_track_i.main(["--step", "strict-ablation-sequence"])
+    assert calls == ["strict-ablation-sequence"]
+
+    calls.clear()
+    run_track_i.main(["--step", "all"])
+    assert calls == [
+        "weak-label-ingest",
+        "external-confidence-tiers",
+        "training-cohorts",
+        "strict-ablation-sequence",
+    ]


### PR DESCRIPTION
Implemented TI09 as a dedicated Track I strict-ablation step.

- Adds a new `build_strict_ablation_sequence` helper that consumes TI08 cohort rows and emits the planned source-by-source order.
- Wires `run_track_i.py` to dispatch `strict-ablation-sequence` and includes it in `--step all`.
- Covers the new sequence summary, manifest emission, and dispatcher behavior with regression tests.

Closes #131