### PR TITLE
[ORCH][TG04] Add SHAP explanations for Track G recommendations

### DIFF
--- a/lyzortx/pipeline/track_g/README.md
+++ b/lyzortx/pipeline/track_g/README.md
@@ -11,6 +11,8 @@ This command runs the implemented Track G modeling step:
    write outputs under `lyzortx/generated_outputs/track_g/tg02_gbm_calibration/`
 3. `feature-block-ablation`: run TG03 LightGBM ablations on the fixed ST0.3 holdout split and write outputs under
    `lyzortx/generated_outputs/track_g/tg03_feature_block_ablation_suite/`
+4. `compute-shap`: compute TG04 TreeExplainer SHAP explanations for the tuned LightGBM and write outputs under
+   `lyzortx/generated_outputs/track_g/tg04_shap_explanations/`
 
 The TG01 trainer reuses the canonical ST0.2 / ST0.3 leakage-safe contract:
 
@@ -46,3 +48,12 @@ The TG03 ablation directory includes:
 3. `tg03_ablation_cv_candidate_results.csv`: candidate-level CV summaries for each ablation arm
 4. `tg03_ablation_pair_predictions.csv`: non-holdout out-of-fold and final holdout probabilities for each arm
 5. `tg03_ablation_holdout_top3_rankings.csv`: holdout top-3 rankings for each arm
+
+The TG04 SHAP explanation directory includes:
+
+1. `tg04_recommendation_pair_explanations.csv`: top-3 per-strain phage recommendations with top positive and negative
+   SHAP drivers for each recommended pair
+2. `tg04_global_feature_importance.csv`: global mean-absolute SHAP ranking across the full hard-trainable panel
+3. `tg04_per_strain_difficulty_summary.csv`: per-strain easy/moderate/hard summary with top drivers and confidence
+   separation metrics
+4. `tg04_shap_summary.json`: top global drivers, difficulty counts, and input hashes for notebook/report reuse

--- a/lyzortx/pipeline/track_g/run_track_g.py
+++ b/lyzortx/pipeline/track_g/run_track_g.py
@@ -11,6 +11,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from lyzortx.pipeline.track_g.steps import calibrate_gbm_outputs
+from lyzortx.pipeline.track_g.steps import compute_shap_explanations
 from lyzortx.pipeline.track_g.steps import run_feature_block_ablation_suite
 from lyzortx.pipeline.track_g.steps import train_v1_binary_classifier
 
@@ -19,7 +20,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--step",
-        choices=["train-v1-binary", "calibrate-gbm", "feature-block-ablation", "all"],
+        choices=["train-v1-binary", "calibrate-gbm", "feature-block-ablation", "compute-shap", "all"],
         default="all",
         help="Track G step to run. 'all' runs the implemented Track G modeling steps.",
     )
@@ -34,6 +35,8 @@ def main(argv: list[str] | None = None) -> None:
         calibrate_gbm_outputs.main([])
     if args.step in {"feature-block-ablation", "all"}:
         run_feature_block_ablation_suite.main([])
+    if args.step in {"compute-shap", "all"}:
+        compute_shap_explanations.main([])
 
 
 if __name__ == "__main__":

--- a/lyzortx/pipeline/track_g/steps/compute_shap_explanations.py
+++ b/lyzortx/pipeline/track_g/steps/compute_shap_explanations.py
@@ -1,0 +1,620 @@
+#!/usr/bin/env python3
+"""TG04: Compute SHAP explanations for Track G LightGBM recommendations."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+from scipy import sparse
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
+from lyzortx.pipeline.track_g.steps import calibrate_gbm_outputs
+from lyzortx.pipeline.track_g.steps import train_v1_binary_classifier
+
+TG02_REQUIRED_COLUMNS: Tuple[str, ...] = (
+    "pair_id",
+    "bacteria",
+    "phage",
+    "phage_family",
+    "split_holdout",
+    "prediction_context",
+    "is_strict_trainable",
+    "label_hard_any_lysis",
+    "pred_lightgbm_raw",
+    "pred_lightgbm_isotonic",
+    "pred_lightgbm_platt",
+)
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tg01-model-summary-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_g/tg01_v1_binary_classifier/tg01_model_summary.json"),
+        help="TG01 model summary JSON containing the best LightGBM hyperparameters.",
+    )
+    parser.add_argument(
+        "--tg02-predictions-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_g/tg02_gbm_calibration/tg02_pair_predictions_calibrated.csv"),
+        help="TG02 calibrated pair prediction CSV used to select recommended phages.",
+    )
+    parser.add_argument(
+        "--st02-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st02_pair_table.csv"),
+        help="Input ST0.2 pair table path.",
+    )
+    parser.add_argument(
+        "--st03-split-assignments-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_assignments.csv"),
+        help="Input ST0.3 split assignments path.",
+    )
+    parser.add_argument(
+        "--track-c-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_c/v1_host_feature_pair_table/pair_table_v1.csv"),
+        help="Input Track C v1 pair table path.",
+    )
+    parser.add_argument(
+        "--track-d-genome-kmer-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_d/phage_genome_kmer_features/phage_genome_kmer_features.csv"),
+        help="Input Track D genome k-mer feature CSV.",
+    )
+    parser.add_argument(
+        "--track-d-distance-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_d/phage_distance_embedding/phage_distance_embedding_features.csv"
+        ),
+        help="Input Track D phage-distance feature CSV.",
+    )
+    parser.add_argument(
+        "--track-e-rbp-compatibility-path",
+        type=Path,
+        default=train_v1_binary_classifier.TRACK_E_REQUIRED_BLOCKS[0][1],
+        help="Input Track E RBP-receptor compatibility feature CSV.",
+    )
+    parser.add_argument(
+        "--track-e-defense-evasion-path",
+        type=Path,
+        default=train_v1_binary_classifier.TRACK_E_REQUIRED_BLOCKS[1][1],
+        help="Input Track E defense-evasion proxy feature CSV.",
+    )
+    parser.add_argument(
+        "--track-e-isolation-distance-path",
+        type=Path,
+        default=train_v1_binary_classifier.TRACK_E_REQUIRED_BLOCKS[2][1],
+        help="Input Track E isolation-host distance feature CSV.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_g/tg04_shap_explanations"),
+        help="Directory for TG04 artifacts.",
+    )
+    parser.add_argument(
+        "--recommendation-count",
+        type=int,
+        default=3,
+        help="Number of top phages to explain for each strain.",
+    )
+    parser.add_argument(
+        "--top-features-per-pair",
+        type=int,
+        default=3,
+        help="Number of positive and negative SHAP features to surface for each recommended pair.",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=42,
+        help="Fallback random state if TG01 summary is unavailable.",
+    )
+    parser.add_argument(
+        "--skip-prerequisites",
+        action="store_true",
+        help="Assume TG01/TG02 outputs already exist instead of generating them when missing.",
+    )
+    return parser.parse_args(argv)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def ensure_prerequisite_outputs(args: argparse.Namespace) -> None:
+    train_v1_args = train_v1_binary_classifier.parse_args(
+        [
+            "--st02-pair-table-path",
+            str(args.st02_pair_table_path),
+            "--st03-split-assignments-path",
+            str(args.st03_split_assignments_path),
+            "--track-c-pair-table-path",
+            str(args.track_c_pair_table_path),
+            "--track-d-genome-kmer-path",
+            str(args.track_d_genome_kmer_path),
+            "--track-d-distance-path",
+            str(args.track_d_distance_path),
+            "--track-e-rbp-compatibility-path",
+            str(args.track_e_rbp_compatibility_path),
+            "--track-e-defense-evasion-path",
+            str(args.track_e_defense_evasion_path),
+            "--track-e-isolation-distance-path",
+            str(args.track_e_isolation_distance_path),
+            "--skip-prerequisites",
+        ]
+    )
+    train_v1_binary_classifier.ensure_prerequisite_outputs(train_v1_args)
+    if args.skip_prerequisites:
+        return
+    if not args.tg01_model_summary_path.exists():
+        train_v1_binary_classifier.main([])
+    if not args.tg02_predictions_path.exists():
+        calibrate_gbm_outputs.main([])
+
+
+def load_best_lightgbm_params(path: Path) -> Tuple[Dict[str, object], int]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    params = payload["lightgbm"]["best_params"]
+    random_state = int(payload.get("cv_protocol", {}).get("random_state", 42))
+    return dict(params), random_state
+
+
+def _dense_row(matrix: Any, row_index: int) -> np.ndarray:
+    row = matrix[row_index]
+    if sparse.issparse(row):
+        return row.toarray().ravel()
+    return np.asarray(row).ravel()
+
+
+def feature_block_for_vectorized_name(
+    feature_name: str,
+    feature_space: train_v1_binary_classifier.FeatureSpace,
+) -> str:
+    base_name = feature_name.split("=", 1)[0]
+    if base_name in set(feature_space.track_d_columns) or base_name.startswith("phage_"):
+        return "track_d_phage_genomic"
+    if base_name in set(feature_space.track_e_columns):
+        return "track_e_pairwise"
+    if base_name in set(feature_space.track_c_additional_columns):
+        return "track_c_host_genomic"
+    return "st04_v0_baseline"
+
+
+def top_feature_contributions(
+    shap_values: np.ndarray,
+    feature_values: np.ndarray,
+    feature_names: Sequence[str],
+    *,
+    top_k: int,
+) -> Dict[str, List[Dict[str, object]]]:
+    positives = sorted(
+        (
+            {
+                "feature_name": feature_names[index],
+                "feature_value": safe_round(float(feature_values[index])),
+                "shap_value": safe_round(float(shap_values[index])),
+            }
+            for index in np.argsort(-shap_values)
+            if float(shap_values[index]) > 0.0
+        ),
+        key=lambda item: float(item["shap_value"]),
+        reverse=True,
+    )[:top_k]
+    negatives = sorted(
+        (
+            {
+                "feature_name": feature_names[index],
+                "feature_value": safe_round(float(feature_values[index])),
+                "shap_value": safe_round(float(shap_values[index])),
+            }
+            for index in np.argsort(shap_values)
+            if float(shap_values[index]) < 0.0
+        ),
+        key=lambda item: float(item["shap_value"]),
+    )[:top_k]
+    return {"positive": positives, "negative": negatives}
+
+
+def format_contribution_summary(contributions: Sequence[Mapping[str, object]]) -> str:
+    if not contributions:
+        return ""
+    return "; ".join(
+        f"{item['feature_name']}={item['feature_value']} ({float(item['shap_value']):+.4f})" for item in contributions
+    )
+
+
+def build_global_feature_importance_rows(
+    shap_matrix: Any,
+    feature_names: Sequence[str],
+    feature_space: train_v1_binary_classifier.FeatureSpace,
+) -> List[Dict[str, object]]:
+    if sparse.issparse(shap_matrix):
+        abs_mean = np.asarray(np.abs(shap_matrix).mean(axis=0)).ravel()
+        signed_mean = np.asarray(shap_matrix.mean(axis=0)).ravel()
+        nonzero_fraction = np.asarray(shap_matrix.getnnz(axis=0) / shap_matrix.shape[0]).ravel()
+    else:
+        values = np.asarray(shap_matrix)
+        abs_mean = np.mean(np.abs(values), axis=0)
+        signed_mean = np.mean(values, axis=0)
+        nonzero_fraction = np.count_nonzero(values, axis=0) / values.shape[0]
+
+    rows = [
+        {
+            "feature_name": feature_name,
+            "feature_block": feature_block_for_vectorized_name(feature_name, feature_space),
+            "mean_abs_shap": safe_round(float(abs_mean[index])),
+            "mean_shap": safe_round(float(signed_mean[index])),
+            "nonzero_fraction": safe_round(float(nonzero_fraction[index])),
+        }
+        for index, feature_name in enumerate(feature_names)
+    ]
+    rows.sort(
+        key=lambda row: (-float(row["mean_abs_shap"]), -float(abs(float(row["mean_shap"]))), str(row["feature_name"]))
+    )
+    return rows
+
+
+def select_recommendation_rows(
+    calibrated_rows: Sequence[Mapping[str, str]],
+    *,
+    recommendation_count: int,
+) -> List[Dict[str, str]]:
+    rows_by_bacteria: Dict[str, List[Dict[str, str]]] = defaultdict(list)
+    for row in calibrated_rows:
+        rows_by_bacteria[str(row["bacteria"])].append(dict(row))
+
+    selected: List[Dict[str, str]] = []
+    for bacteria in sorted(rows_by_bacteria):
+        ranked = sorted(
+            rows_by_bacteria[bacteria],
+            key=lambda row: (-float(row["pred_lightgbm_isotonic"]), str(row["phage"])),
+        )
+        for rank, row in enumerate(ranked[:recommendation_count], start=1):
+            enriched = dict(row)
+            enriched["recommendation_rank"] = str(rank)
+            selected.append(enriched)
+    return selected
+
+
+def classify_strain_difficulty(
+    *,
+    top_score: float,
+    score_gap: float,
+    mean_margin_from_half: float,
+    top3_hit: bool,
+) -> str:
+    if (not top3_hit) or top_score < 0.45 or score_gap < 0.03 or mean_margin_from_half < 0.08:
+        return "hard"
+    if top3_hit and top_score >= 0.75 and score_gap >= 0.10 and mean_margin_from_half >= 0.18:
+        return "easy"
+    return "moderate"
+
+
+def build_per_strain_summary_rows(
+    calibrated_rows: Sequence[Mapping[str, str]],
+    recommendation_rows: Sequence[Mapping[str, object]],
+    *,
+    recommendation_count: int,
+) -> List[Dict[str, object]]:
+    recommendation_rows_by_bacteria: Dict[str, List[Mapping[str, object]]] = defaultdict(list)
+    for row in recommendation_rows:
+        recommendation_rows_by_bacteria[str(row["bacteria"])].append(row)
+
+    rows_by_bacteria: Dict[str, List[Mapping[str, str]]] = defaultdict(list)
+    for row in calibrated_rows:
+        rows_by_bacteria[str(row["bacteria"])].append(row)
+
+    summary_rows: List[Dict[str, object]] = []
+    for bacteria in sorted(rows_by_bacteria):
+        ranked = sorted(
+            rows_by_bacteria[bacteria],
+            key=lambda row: (-float(row["pred_lightgbm_isotonic"]), str(row["phage"])),
+        )
+        top_score = float(ranked[0]["pred_lightgbm_isotonic"])
+        second_score = float(ranked[1]["pred_lightgbm_isotonic"]) if len(ranked) > 1 else 0.0
+        score_gap = top_score - second_score
+        top_rows = ranked[:recommendation_count]
+        top3_hit = any(int(row["label_hard_any_lysis"]) == 1 for row in top_rows)
+        positive_pair_count = sum(int(row["label_hard_any_lysis"]) for row in ranked)
+        mean_margin = float(np.mean([abs(float(row["pred_lightgbm_raw"]) - 0.5) for row in ranked]))
+        recommendation_details = recommendation_rows_by_bacteria.get(bacteria, [])
+
+        positive_driver = ""
+        negative_driver = ""
+        if recommendation_details:
+            positive_driver = str(recommendation_details[0].get("top_positive_feature_1", ""))
+            negative_driver = str(recommendation_details[0].get("top_negative_feature_1", ""))
+
+        difficulty = classify_strain_difficulty(
+            top_score=top_score,
+            score_gap=score_gap,
+            mean_margin_from_half=mean_margin,
+            top3_hit=top3_hit,
+        )
+        if difficulty == "easy":
+            rationale = (
+                f"Easy because {positive_driver or 'the leading signal'} separates the top recommendation "
+                f"(score {top_score:.3f}, gap {score_gap:.3f})."
+            )
+        elif difficulty == "hard":
+            rationale = (
+                f"Hard because scores are compressed (top score {top_score:.3f}, gap {score_gap:.3f}) and "
+                f"{negative_driver or 'suppressive host features'} keep likely matches uncertain."
+            )
+        else:
+            rationale = (
+                f"Moderate because the model has some separation (top score {top_score:.3f}, gap {score_gap:.3f}) "
+                f"but not enough to treat the strain as clearly easy."
+            )
+
+        summary_rows.append(
+            {
+                "bacteria": bacteria,
+                "difficulty_label": difficulty,
+                "top_recommended_phage": top_rows[0]["phage"],
+                "top_recommendation_score_isotonic": safe_round(top_score),
+                "top1_top2_gap_isotonic": safe_round(score_gap),
+                "mean_margin_from_raw_half": safe_round(mean_margin),
+                "positive_pair_count": positive_pair_count,
+                "top3_hit": int(top3_hit),
+                "top_positive_driver": positive_driver,
+                "top_negative_driver": negative_driver,
+                "rationale": rationale,
+            }
+        )
+
+    difficulty_order = {"hard": 0, "moderate": 1, "easy": 2}
+    summary_rows.sort(key=lambda row: (difficulty_order[str(row["difficulty_label"])], str(row["bacteria"])))
+    return summary_rows
+
+
+def summarize_difficulty_counts(rows: Sequence[Mapping[str, object]]) -> Dict[str, int]:
+    counts = {"hard": 0, "moderate": 0, "easy": 0}
+    for row in rows:
+        counts[str(row["difficulty_label"])] += 1
+    return counts
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    ensure_directory(args.output_dir)
+    ensure_prerequisite_outputs(args)
+
+    best_lightgbm_params, random_state = load_best_lightgbm_params(args.tg01_model_summary_path)
+
+    st02_rows = read_csv_rows(args.st02_pair_table_path)
+    split_rows = read_csv_rows(args.st03_split_assignments_path)
+    track_c_pair_rows = read_csv_rows(args.track_c_pair_table_path)
+    track_d_genome_rows = read_csv_rows(args.track_d_genome_kmer_path)
+    track_d_distance_rows = read_csv_rows(args.track_d_distance_path)
+    track_e_rbp_rows = read_csv_rows(args.track_e_rbp_compatibility_path)
+    track_e_defense_rows = read_csv_rows(args.track_e_defense_evasion_path)
+    track_e_isolation_rows = read_csv_rows(args.track_e_isolation_distance_path)
+    calibrated_rows = read_csv_rows(args.tg02_predictions_path, required_columns=TG02_REQUIRED_COLUMNS)
+
+    track_d_feature_columns = train_v1_binary_classifier._deduplicate_preserving_order(
+        [column for column in track_d_genome_rows[0].keys() if column != "phage"]
+        + [column for column in track_d_distance_rows[0].keys() if column != "phage"]
+    )
+    track_e_feature_columns = train_v1_binary_classifier._deduplicate_preserving_order(
+        [column for column in track_e_rbp_rows[0].keys() if column not in train_v1_binary_classifier.IDENTIFIER_COLUMNS]
+        + [
+            column
+            for column in track_e_defense_rows[0].keys()
+            if column not in train_v1_binary_classifier.IDENTIFIER_COLUMNS
+        ]
+        + [
+            column
+            for column in track_e_isolation_rows[0].keys()
+            if column not in train_v1_binary_classifier.IDENTIFIER_COLUMNS
+        ]
+    )
+    feature_space = train_v1_binary_classifier.build_feature_space(
+        st02_rows,
+        track_c_pair_rows,
+        track_d_feature_columns,
+        track_e_feature_columns,
+    )
+    merged_rows = train_v1_binary_classifier.merge_expanded_feature_rows(
+        track_c_pair_rows,
+        split_rows,
+        phage_feature_blocks=(track_d_genome_rows, track_d_distance_rows),
+        pair_feature_blocks=(track_e_rbp_rows, track_e_defense_rows, track_e_isolation_rows),
+    )
+
+    lightgbm_factory = lambda params, seed_offset: train_v1_binary_classifier.make_lightgbm_estimator(  # noqa: E731
+        params,
+        seed_offset,
+        base_random_state=random_state or args.random_state,
+    )
+    estimator, vectorizer, _, _, _ = train_v1_binary_classifier.fit_final_estimator(
+        merged_rows,
+        feature_space,
+        estimator_factory=lightgbm_factory,
+        params=best_lightgbm_params,
+    )
+
+    explain_rows = [dict(row) for row in merged_rows if str(row["is_hard_trainable"]) == "1"]
+    feature_matrix = vectorizer.transform(
+        [
+            train_v1_binary_classifier._build_feature_dict(
+                row,
+                categorical_columns=feature_space.categorical_columns,
+                numeric_columns=feature_space.numeric_columns,
+            )
+            for row in explain_rows
+        ]
+    )
+    model_probabilities = train_v1_binary_classifier._predict_probabilities(estimator, feature_matrix)
+
+    import shap
+
+    explainer = shap.TreeExplainer(estimator)
+    explanation = explainer(feature_matrix)
+    shap_matrix = explanation.values
+    base_values = np.asarray(explanation.base_values).ravel()
+    feature_names = list(vectorizer.get_feature_names_out())
+
+    explain_index_by_pair_id = {row["pair_id"]: index for index, row in enumerate(explain_rows)}
+
+    recommendation_source_rows = select_recommendation_rows(
+        calibrated_rows,
+        recommendation_count=args.recommendation_count,
+    )
+    recommendation_rows: List[Dict[str, object]] = []
+    for row in recommendation_source_rows:
+        pair_id = row["pair_id"]
+        explain_index = explain_index_by_pair_id.get(pair_id)
+        if explain_index is None:
+            continue
+        shap_row = _dense_row(shap_matrix, explain_index)
+        feature_row = _dense_row(feature_matrix, explain_index)
+        contributions = top_feature_contributions(
+            shap_row,
+            feature_row,
+            feature_names,
+            top_k=args.top_features_per_pair,
+        )
+        total_abs_shap = float(np.abs(shap_row).sum())
+        explanation_text = (
+            f"Recommended at rank {row['recommendation_rank']} because "
+            f"{format_contribution_summary(contributions['positive']) or 'positive feature contributions'} "
+            f"outweighed "
+            f"{format_contribution_summary(contributions['negative']) or 'negative feature contributions'}."
+        )
+
+        pair_row: Dict[str, object] = {
+            "pair_id": pair_id,
+            "bacteria": row["bacteria"],
+            "phage": row["phage"],
+            "phage_family": row["phage_family"],
+            "recommendation_rank": int(row["recommendation_rank"]),
+            "split_holdout": row["split_holdout"],
+            "prediction_context": row["prediction_context"],
+            "label_hard_any_lysis": row["label_hard_any_lysis"],
+            "pred_lightgbm_isotonic": row["pred_lightgbm_isotonic"],
+            "pred_lightgbm_raw_oof_or_holdout": row["pred_lightgbm_raw"],
+            "pred_lightgbm_platt": row["pred_lightgbm_platt"],
+            "pred_lightgbm_raw_final_model": safe_round(model_probabilities[explain_index]),
+            "shap_base_value": safe_round(float(base_values[explain_index])),
+            "total_abs_shap": safe_round(total_abs_shap),
+            "top_positive_feature_1": "",
+            "top_positive_feature_2": "",
+            "top_positive_feature_3": "",
+            "top_positive_shap_1": "",
+            "top_positive_shap_2": "",
+            "top_positive_shap_3": "",
+            "top_negative_feature_1": "",
+            "top_negative_feature_2": "",
+            "top_negative_feature_3": "",
+            "top_negative_shap_1": "",
+            "top_negative_shap_2": "",
+            "top_negative_shap_3": "",
+            "explanation_text": explanation_text,
+        }
+        for position, item in enumerate(contributions["positive"], start=1):
+            pair_row[f"top_positive_feature_{position}"] = item["feature_name"]
+            pair_row[f"top_positive_shap_{position}"] = item["shap_value"]
+        for position, item in enumerate(contributions["negative"], start=1):
+            pair_row[f"top_negative_feature_{position}"] = item["feature_name"]
+            pair_row[f"top_negative_shap_{position}"] = item["shap_value"]
+        recommendation_rows.append(pair_row)
+
+    recommendation_rows.sort(key=lambda row: (str(row["bacteria"]), int(row["recommendation_rank"]), str(row["phage"])))
+    global_rows = build_global_feature_importance_rows(shap_matrix, feature_names, feature_space)
+    strain_summary_rows = build_per_strain_summary_rows(
+        calibrated_rows,
+        recommendation_rows,
+        recommendation_count=args.recommendation_count,
+    )
+    difficulty_counts = summarize_difficulty_counts(strain_summary_rows)
+
+    summary = {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "task_id": "TG04",
+        "recommendation_count": args.recommendation_count,
+        "top_features_per_pair": args.top_features_per_pair,
+        "explained_pair_count": len(recommendation_rows),
+        "strain_count": len(strain_summary_rows),
+        "difficulty_counts": difficulty_counts,
+        "global_top_features": global_rows[:10],
+        "inputs": {
+            "tg01_model_summary": {
+                "path": str(args.tg01_model_summary_path),
+                "sha256": _sha256(args.tg01_model_summary_path),
+            },
+            "tg02_predictions": {
+                "path": str(args.tg02_predictions_path),
+                "sha256": _sha256(args.tg02_predictions_path),
+            },
+            "track_c_pair_table": {
+                "path": str(args.track_c_pair_table_path),
+                "sha256": _sha256(args.track_c_pair_table_path),
+            },
+            "track_d_genome_kmers": {
+                "path": str(args.track_d_genome_kmer_path),
+                "sha256": _sha256(args.track_d_genome_kmer_path),
+            },
+            "track_d_distance": {
+                "path": str(args.track_d_distance_path),
+                "sha256": _sha256(args.track_d_distance_path),
+            },
+            "track_e_rbp_receptor_compatibility": {
+                "path": str(args.track_e_rbp_compatibility_path),
+                "sha256": _sha256(args.track_e_rbp_compatibility_path),
+            },
+            "track_e_defense_evasion": {
+                "path": str(args.track_e_defense_evasion_path),
+                "sha256": _sha256(args.track_e_defense_evasion_path),
+            },
+            "track_e_isolation_host_distance": {
+                "path": str(args.track_e_isolation_distance_path),
+                "sha256": _sha256(args.track_e_isolation_distance_path),
+            },
+        },
+    }
+
+    write_csv(
+        args.output_dir / "tg04_recommendation_pair_explanations.csv",
+        fieldnames=list(recommendation_rows[0].keys()),
+        rows=recommendation_rows,
+    )
+    write_csv(
+        args.output_dir / "tg04_global_feature_importance.csv",
+        fieldnames=list(global_rows[0].keys()),
+        rows=global_rows,
+    )
+    write_csv(
+        args.output_dir / "tg04_per_strain_difficulty_summary.csv",
+        fieldnames=list(strain_summary_rows[0].keys()),
+        rows=strain_summary_rows,
+    )
+    write_json(args.output_dir / "tg04_shap_summary.json", summary)
+
+    print("TG04 completed.")
+    print(f"- Explained recommendation pairs: {len(recommendation_rows)}")
+    print(f"- Global features ranked: {len(global_rows)}")
+    print(f"- Per-strain difficulty rows: {len(strain_summary_rows)}")
+    print(f"- Output directory: {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lyzortx/research_notes/lab_notebooks/track_G.md
+++ b/lyzortx/research_notes/lab_notebooks/track_G.md
@@ -242,3 +242,84 @@
    assuming TE01-TE03 should remain in the final default stack unchanged.
 3. If Track G keeps the full model as the deployment default, consider a follow-up feature-selection or regularization
    pass so the weaker pairwise block does not dilute the stronger defense/phage-genomic signal on the fixed holdout.
+
+### 2026-03-22: TG04 implemented (TreeExplainer SHAP explanations for pair-level and global Track G importance)
+
+#### What was implemented
+
+- Added the TG04 SHAP step at `lyzortx/pipeline/track_g/steps/compute_shap_explanations.py`.
+- Updated `lyzortx/pipeline/track_g/run_track_g.py`, `lyzortx/pipeline/track_g/README.md`, `requirements.txt`, and
+  `lyzortx/tests/test_track_g_v1_binary_classifier.py` so Track G now exposes a dedicated `compute-shap` step with:
+  - pinned `shap==0.51.0` dependency support
+  - CLI dispatch coverage for the new step
+  - pure-function tests for recommendation selection, SHAP contribution extraction, global-importance aggregation, and
+    strain-difficulty labeling
+- TG04 now:
+  - bootstraps missing TG01 and TG02 artifacts automatically when needed
+  - refits the tuned final LightGBM from TG01 on the leakage-safe non-holdout training subset
+  - runs `shap.TreeExplainer` on the full hard-trainable panel
+  - writes reusable artifacts under `lyzortx/generated_outputs/track_g/tg04_shap_explanations/`
+
+#### Output summary
+
+- TG04 output directory:
+  - `tg04_recommendation_pair_explanations.csv`
+  - `tg04_global_feature_importance.csv`
+  - `tg04_per_strain_difficulty_summary.csv`
+  - `tg04_shap_summary.json`
+- Coverage:
+  - `1,107` explained recommendation pairs (`369` strains x top `3` phages each)
+  - `596` vectorized features ranked by global mean absolute SHAP value
+  - `369` per-strain difficulty summaries
+- Top global SHAP features across the hard-trainable panel:
+  - `host_n_infections` (`1.182724` mean absolute SHAP)
+  - `receptor_variant_training_positive_count` (`0.571720`)
+  - `phage_gc_content` (`0.217465`)
+  - `phage_genome_length_nt` (`0.202838`)
+  - `host_lps_type=R1` (`0.158946`)
+  - `defense_evasion_mean_score` (`0.130089`)
+  - `isolation_host_defense_jaccard_distance` (`0.122925`)
+- Per-strain difficulty counts:
+  - `17` easy
+  - `80` moderate
+  - `272` hard
+- Representative pair-level explanations:
+  - strain `001-023` / phage `LF82_P9` ranked `1` with isotonic score `0.941176`; strongest positive SHAP driver:
+    `host_n_infections` (`+1.428614`)
+  - strain `001-031-c1` / phage `LF82_P8` ranked `1` with isotonic score `0.625000`; strongest positive driver:
+    `phage_genome_length_nt` (`+0.464397`), strongest negative driver: `host_n_infections` (`-1.361511`)
+- Common per-strain summary drivers:
+  - easy strains were most often separated by `phage_gc_content` or
+    `receptor_variant_training_positive_count`
+  - hard strains were usually characterized by compressed isotonic top scores plus negative pressure from
+    `host_n_infections`, `host_lps_type=R1`, or phage tetra-SVD dimensions such as `phage_genome_tetra_svd_07`
+
+#### Interpretation
+
+1. TG04 met the acceptance target for pair-level explanations. Every strain now has explicit top-3 recommendation rows
+   with the leading positive and negative SHAP drivers for each recommended phage, which answers why the model surfaced
+   those phages rather than just reporting ranks.
+2. The strongest global signal still comes from the legacy v0 infection-breadth feature. `host_n_infections` is far
+   ahead of the rest of the panel, which means Track G is still leaning heavily on broad host susceptibility signal even
+   after adding the genomic and pairwise blocks.
+3. The next tier of importance is biologically richer. The second-ranked feature is the pairwise
+   `receptor_variant_training_positive_count`, and the next major contributors are phage-genomic variables
+   (`phage_gc_content`, `phage_genome_length_nt`, `phage_viridic_mds_00`) plus pairwise defense/isolation terms. That
+   is consistent with TG03: the added blocks are contributing real explanatory signal even if they do not displace the
+   strongest v0 baseline feature.
+4. Most strains fell into the current "hard" bucket, but the reason is usually score compression rather than total
+   recommendation failure. Many hard rows still have `top3_hit=1`; they are marked hard because the isotonic top scores
+   are tied or nearly tied, so TG04 is surfacing a confidence-separation problem more than a top-3 recall problem.
+5. Easy strains tend to be ones where phage-genomic or receptor-compatibility features create a clear margin. Hard
+   strains are disproportionately the ones where `host_n_infections` or `host_lps_type=R1` pushes many phages in the
+   same direction, leaving the model with limited separation among the top candidates.
+
+#### Next steps
+
+1. Revisit the TG02 isotonic mapping or ranking tie-break policy so TG04's hard/easy summary is not dominated by score
+   compression among otherwise correct top-3 recommendations.
+2. Consider a follow-up analysis that removes or caps the influence of `host_n_infections` to test whether the richer
+   receptor, defense, and phage-genomic features become more discriminative once that broad susceptibility prior is
+   weakened.
+3. Use the per-pair SHAP rows to inspect the remaining false positive top-ranked phages for the hardest strains before
+   changing feature blocks; the explanation artifacts now make that review straightforward.

--- a/lyzortx/tests/test_track_g_v1_binary_classifier.py
+++ b/lyzortx/tests/test_track_g_v1_binary_classifier.py
@@ -1,7 +1,15 @@
 import csv
 
+import numpy as np
+
 from lyzortx.pipeline.track_g import run_track_g
 from lyzortx.pipeline.track_g.steps import calibrate_gbm_outputs
+from lyzortx.pipeline.track_g.steps.compute_shap_explanations import (
+    build_global_feature_importance_rows,
+    classify_strain_difficulty,
+    select_recommendation_rows,
+    top_feature_contributions,
+)
 from lyzortx.pipeline.track_g.steps.run_feature_block_ablation_suite import (
     build_ablation_arms,
     partition_track_c_columns,
@@ -215,13 +223,18 @@ def test_run_track_g_dispatches_training_step(monkeypatch) -> None:
         "main",
         lambda argv: calls.append("feature-block-ablation"),
     )
+    monkeypatch.setattr(
+        run_track_g.compute_shap_explanations,
+        "main",
+        lambda argv: calls.append("compute-shap"),
+    )
 
     run_track_g.main(["--step", "train-v1-binary"])
     assert calls == ["train-v1-binary"]
 
     calls.clear()
     run_track_g.main(["--step", "all"])
-    assert calls == ["train-v1-binary", "calibrate-gbm", "feature-block-ablation"]
+    assert calls == ["train-v1-binary", "calibrate-gbm", "feature-block-ablation", "compute-shap"]
 
 
 def test_run_track_g_dispatches_calibration_step(monkeypatch) -> None:
@@ -241,6 +254,11 @@ def test_run_track_g_dispatches_calibration_step(monkeypatch) -> None:
         run_track_g.run_feature_block_ablation_suite,
         "main",
         lambda argv: calls.append("feature-block-ablation"),
+    )
+    monkeypatch.setattr(
+        run_track_g.compute_shap_explanations,
+        "main",
+        lambda argv: calls.append("compute-shap"),
     )
 
     run_track_g.main(["--step", "calibrate-gbm"])
@@ -265,9 +283,134 @@ def test_run_track_g_dispatches_tg03_ablation_step(monkeypatch) -> None:
         "main",
         lambda argv: calls.append("feature-block-ablation"),
     )
+    monkeypatch.setattr(
+        run_track_g.compute_shap_explanations,
+        "main",
+        lambda argv: calls.append("compute-shap"),
+    )
 
     run_track_g.main(["--step", "feature-block-ablation"])
     assert calls == ["feature-block-ablation"]
+
+
+def test_run_track_g_dispatches_tg04_shap_step(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        run_track_g.train_v1_binary_classifier,
+        "main",
+        lambda argv: calls.append("train-v1-binary"),
+    )
+    monkeypatch.setattr(
+        run_track_g.calibrate_gbm_outputs,
+        "main",
+        lambda argv: calls.append("calibrate-gbm"),
+    )
+    monkeypatch.setattr(
+        run_track_g.run_feature_block_ablation_suite,
+        "main",
+        lambda argv: calls.append("feature-block-ablation"),
+    )
+    monkeypatch.setattr(
+        run_track_g.compute_shap_explanations,
+        "main",
+        lambda argv: calls.append("compute-shap"),
+    )
+
+    run_track_g.main(["--step", "compute-shap"])
+    assert calls == ["compute-shap"]
+
+
+def test_select_recommendation_rows_keeps_top_k_per_bacteria() -> None:
+    selected = select_recommendation_rows(
+        [
+            {"pair_id": "B1__P1", "bacteria": "B1", "phage": "P1", "pred_lightgbm_isotonic": "0.6"},
+            {"pair_id": "B1__P2", "bacteria": "B1", "phage": "P2", "pred_lightgbm_isotonic": "0.9"},
+            {"pair_id": "B1__P3", "bacteria": "B1", "phage": "P3", "pred_lightgbm_isotonic": "0.8"},
+            {"pair_id": "B2__P1", "bacteria": "B2", "phage": "P1", "pred_lightgbm_isotonic": "0.4"},
+            {"pair_id": "B2__P2", "bacteria": "B2", "phage": "P2", "pred_lightgbm_isotonic": "0.5"},
+        ],
+        recommendation_count=2,
+    )
+
+    assert [(row["bacteria"], row["phage"], row["recommendation_rank"]) for row in selected] == [
+        ("B1", "P2", "1"),
+        ("B1", "P3", "2"),
+        ("B2", "P2", "1"),
+        ("B2", "P1", "2"),
+    ]
+
+
+def test_top_feature_contributions_splits_positive_and_negative_drivers() -> None:
+    contributions = top_feature_contributions(
+        np.array([0.7, -0.2, 0.1, -0.5]),
+        np.array([1.0, 0.0, 0.3, 1.0]),
+        ["feat_a", "feat_b", "feat_c", "feat_d"],
+        top_k=2,
+    )
+
+    assert [item["feature_name"] for item in contributions["positive"]] == ["feat_a", "feat_c"]
+    assert [item["feature_name"] for item in contributions["negative"]] == ["feat_d", "feat_b"]
+
+
+def test_build_global_feature_importance_rows_orders_by_mean_abs_shap() -> None:
+    feature_space = FeatureSpace(
+        categorical_columns=("host_pathotype",),
+        numeric_columns=("phage_gc_content", "lookup_available", "host_defense_diversity"),
+        track_c_additional_columns=("host_defense_diversity",),
+        track_d_columns=("phage_gc_content",),
+        track_e_columns=("lookup_available",),
+    )
+
+    rows = build_global_feature_importance_rows(
+        np.array(
+            [
+                [0.8, 0.2, -0.1],
+                [0.4, 0.1, -0.3],
+            ]
+        ),
+        ["phage_gc_content", "lookup_available", "host_defense_diversity"],
+        feature_space,
+    )
+
+    assert [row["feature_name"] for row in rows] == [
+        "phage_gc_content",
+        "host_defense_diversity",
+        "lookup_available",
+    ]
+    assert rows[0]["feature_block"] == "track_d_phage_genomic"
+    assert rows[1]["feature_block"] == "track_c_host_genomic"
+    assert rows[2]["feature_block"] == "track_e_pairwise"
+
+
+def test_classify_strain_difficulty_uses_confidence_and_hits() -> None:
+    assert (
+        classify_strain_difficulty(
+            top_score=0.84,
+            score_gap=0.22,
+            mean_margin_from_half=0.24,
+            top3_hit=True,
+        )
+        == "easy"
+    )
+    assert (
+        classify_strain_difficulty(
+            top_score=0.41,
+            score_gap=0.02,
+            mean_margin_from_half=0.05,
+            top3_hit=False,
+        )
+        == "hard"
+    )
+    assert (
+        classify_strain_difficulty(
+            top_score=0.62,
+            score_gap=0.07,
+            mean_margin_from_half=0.12,
+            top3_hit=True,
+        )
+        == "moderate"
+    )
 
 
 def test_tg02_calibration_outputs_expected_files_and_rows(tmp_path) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ ruff==0.11.6
 scikit-learn==1.8.0
 scipy==1.17.0
 seaborn>=0.11.0
+shap==0.51.0
 threadpoolctl==3.6.0


### PR DESCRIPTION
## Summary

- add a dedicated `compute-shap` Track G step that refits the tuned LightGBM and computes TreeExplainer SHAP values
  across the hard-trainable panel
- emit pair-level recommendation explanations, global feature-importance rankings, per-strain difficulty summaries, and
  a reusable TG04 summary JSON under `lyzortx/generated_outputs/track_g/tg04_shap_explanations/`
- wire the new step into the Track G CLI and README, add `shap==0.51.0`, expand unit coverage, and record the TG04
  findings in the Track G lab notebook

## Validation

- `ruff check lyzortx/pipeline/track_g/steps/compute_shap_explanations.py lyzortx/tests/test_track_g_v1_binary_classifier.py lyzortx/pipeline/track_g/run_track_g.py`
- `pytest -q lyzortx/tests/`
- `python lyzortx/pipeline/track_g/run_track_g.py --step compute-shap`

Posted by Codex gpt-5.4

Closes #106
