### PR TITLE
Gate codex-pr-lifecycle jobs on orchestrator-task label

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -8,6 +8,7 @@
   open/push, and supports interactive `@claude` mentions on any PR. Requires the `ANTHROPIC_API_KEY` repository secret.
   Claude posts reviews as `claude[bot]` (the action's own OIDC app identity).
 - `codex-pr-lifecycle.yml` triggers on COMMENTED reviews from `chatgpt-codex-connector[bot]` or `claude[bot]` only.
+  Both jobs additionally require the `orchestrator-task` label on the PR (`workflow_dispatch` bypasses the label check).
   Reviews from other users (including the ORCHESTRATOR_PAT holder) are excluded to prevent feedback loops. A concurrency
   group ensures only one lifecycle run per PR at a time.
 

--- a/.github/workflows/codex-pr-lifecycle.yml
+++ b/.github/workflows/codex-pr-lifecycle.yml
@@ -31,6 +31,7 @@ jobs:
     if: >-
       github.event.review.state == 'approved'
       && github.event.review.user.login == 'claude[bot]'
+      && contains(join(github.event.pull_request.labels.*.name, ','), 'orchestrator-task')
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
@@ -66,6 +67,7 @@ jobs:
           github.event.review.user.login == 'chatgpt-codex-connector[bot]'
           || github.event.review.user.login == 'claude[bot]'
         )
+        && contains(join(github.event.pull_request.labels.*.name, ','), 'orchestrator-task')
       )
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/lyzortx/orchestration/README.md
+++ b/lyzortx/orchestration/README.md
@@ -163,9 +163,9 @@ the sole judge of thread resolution (can resolve/unresolve threads via GraphQL m
 ### codex-pr-lifecycle.yml
 
 - `pull_request_review.submitted`: triggers on `COMMENTED` reviews from `chatgpt-codex-connector[bot]` or `claude[bot]`
-  only. Reviews from other users are excluded to prevent feedback loops (Codex replies via `ORCHESTRATOR_PAT` post as
-  the PAT holder).
-- `workflow_dispatch`: manual trigger with a PR number.
+  only, and only on PRs with the `orchestrator-task` label. Reviews from other users are excluded to prevent feedback
+  loops (Codex replies via `ORCHESTRATOR_PAT` post as the PAT holder).
+- `workflow_dispatch`: manual trigger with a PR number (bypasses the label check).
 
 Two jobs: `auto-merge-on-approve` (merges on Claude's `APPROVED` review) and `address-feedback` (Codex fix loop). A
 concurrency group ensures only one lifecycle run per PR at a time, preventing race conditions on the review round cap.


### PR DESCRIPTION
## Summary

- Both jobs in `codex-pr-lifecycle.yml` (`auto-merge-on-approve` and `address-feedback`) now require the `orchestrator-task` label on the PR, matching the gating behavior of `codex-implement.yml`.
- `workflow_dispatch` bypasses the label check (manual dispatch is always allowed).
- Without this gate, any PR reviewed by `claude[bot]` or `chatgpt-codex-connector[bot]` would trigger the Codex fix loop and auto-merge logic, wasting CI minutes and producing noisy failures on non-orchestrator PRs.

## Changes

- `.github/workflows/codex-pr-lifecycle.yml` — added `contains(join(github.event.pull_request.labels.*.name, ','), 'orchestrator-task')` to both job `if` conditions
- `.github/workflows/AGENTS.md` — documented the label requirement
- `lyzortx/orchestration/README.md` — updated trigger model docs

## Test results

- **Non-`orchestrator-task` PR skips both jobs**: Verified — Codex reviewed this PR (#136, no labels) and both `auto-merge-on-approve` and `address-feedback` were skipped (runs [23408455050](https://github.com/LorenaDerezanin/coli_phage_interactions_2023/actions/runs/23408455050), [23408431815](https://github.com/LorenaDerezanin/coli_phage_interactions_2023/actions/runs/23408431815))
- **`orchestrator-task` PRs still trigger**: Verified — PR #135 (labeled `orchestrator-task`) triggered `auto-merge-on-approve` successfully (run [23405283932](https://github.com/LorenaDerezanin/coli_phage_interactions_2023/actions/runs/23405283932))
- **`workflow_dispatch` bypass**: Verified statically — `workflow_dispatch` is evaluated before the parenthesized block containing the label check via `||` short-circuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)