### PR TITLE
Update graphite skill: plain git for non-stacked work, gt create over deprecated commands

### DIFF
--- a/.agents/skills/graphite/SKILL.md
+++ b/.agents/skills/graphite/SKILL.md
@@ -79,3 +79,9 @@ git push                         # Push the fixed branch (gt submit will not wor
 
 Do **not** run `gt continue -a` immediately after `gt sync` — there is no in-progress operation to continue
 at that point.
+
+### When to use Graphite vs plain git
+
+Use Graphite (`gt`) **only** when creating stacked PRs. For single-branch workflows (one PR, no stack), use plain
+`git` commands for branching, committing, and pushing. Graphite adds overhead and branch-naming surprises (e.g.,
+`gt create` generates its own branch name from the commit message) that are unnecessary for non-stacked work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,18 +132,17 @@ Do NOT nitpick style — ruff handles formatting. Focus on substantive issues on
 
 # Graphite Stacked PRs
 
-- This repo uses Graphite CLI (`gt`) for local stacked PR workflows. Use `gt` commands instead of `git` for commit and
-  branch operations.
+- Use plain `git` for single-branch workflows (one PR, no stack). Only use Graphite CLI (`gt`) when creating stacked
+  PRs.
 - **This repo is not synced with Graphite's remote service.** `gt submit` and other remote-dependent commands will
   fail. Use `git push` (with `-u` for new branches) instead of `gt submit` for pushing.
-- Use `gt create` (not the deprecated `gt commit` or `gt commit create`) for creating new branches with commits.
+- Use `gt create` (not the deprecated `gt commit` or `gt commit create`) for creating new branches with commits in a
+  stack. Always pass `--no-interactive`.
 - When a task naturally decomposes into multiple sequential, dependent changes, use the `/graphite` skill to create a
   stack of PRs rather than one large PR.
 - Prefer stacked PRs when: the diff would exceed ~300 lines, the work has clear layered stages (data, logic,
   integration), or review would benefit from smaller focused units.
 - Each PR in a stack must be atomic and pass CI independently.
-- Always pass `--no-interactive` to `gt create` and other commands that support it.
-- Use `gt sync` instead of `git fetch && git rebase` to stay current with trunk.
 
 # Agent Transparency
 


### PR DESCRIPTION
## Summary

- Clarify that `gt` should only be used for stacked PRs; plain `git` for single-branch workflows
- Note that this repo is not synced with Graphite's remote service (`gt submit` fails)
- Use `gt create` instead of deprecated `gt commit` / `gt commit create`
- Document that `gt create` generates its own branch name, which can surprise agents in worktrees

## Test plan

- [ ] Verify `/graphite` skill loads updated instructions
- [ ] Confirm agents use plain `git` for non-stacked work

🤖 Generated with [Claude Code](https://claude.com/claude-code)