### PR TITLE
fix: prevent TG05 timeout and add deployment-realistic evaluation

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -22,7 +22,7 @@ jobs:
       github.event_name == 'workflow_dispatch'
       || contains(join(github.event.issue.labels.*.name, ','), 'orchestrator-task')
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     # PAT required: github.token can't trigger other workflows (GitHub anti-recursion).
     env:
       GITHUB_TOKEN: ${{ secrets.ORCHESTRATOR_PAT }}

--- a/lyzortx/orchestration/plan.yml
+++ b/lyzortx/orchestration/plan.yml
@@ -323,10 +323,18 @@ tracks:
       acceptance_criteria:
       - Train models on all 2-block and 3-block combinations of the 4 new feature
         blocks (defense, OMP, phage-genomic, pairwise)
+      - Reuse the TG01 winning hyperparameters for all sweep arms — do NOT run
+        per-arm hyperparameter search. The goal is to isolate the feature-block
+        effect, not confound it with per-arm tuning differences.
       - Report top-3 hit rate, AUC, and Brier on the same ST03 holdout for each combo
       - Identify the winning subset that maximizes top-3 hit rate without degrading
         AUC
       - Compare winning subset against the TG01 all-features model
+      - Include a deployment-realistic arm that excludes all features derived from
+        training labels (host_n_infections, receptor_variant_training_positive_count)
+        to measure generalization to truly novel strains
+      - Report both panel-evaluation and deployment-realistic metrics for the winning
+        configuration
       - Lock the final v1 feature configuration for downstream Track F, H, and P
   H:
     name: In-Silico Cocktail Recommendation

--- a/lyzortx/research_notes/lab_notebooks/project.md
+++ b/lyzortx/research_notes/lab_notebooks/project.md
@@ -508,3 +508,67 @@ Two PRs to minimize risk:
    per-run tokens. After a few tasks run with model selection, we can compare actual mini vs full token usage.
 3. **When should a task be upgraded from mini to full?** If a gpt-5.4-mini run fails, the model assignment can be
    changed in plan.yml and the orchestrator re-dispatched. No code change needed.
+
+### 2026-03-22: Label leakage concern — deployment-realistic evaluation needed
+
+#### Problem identified
+
+The TG04 SHAP analysis revealed that the two highest-impact features in the v1 model are derived from training labels,
+not from genomic content:
+
+| SHAP rank | Feature | Mean |SHAP| | Source |
+|-----------|---------|------------|--------|
+| 1 | `host_n_infections` | 1.183 | Panel metadata: count of lytic phages per strain |
+| 2 | `receptor_variant_training_positive_count` | 0.572 | TE01: training-fold lysis frequency per receptor variant |
+
+These features are powerful within-panel predictors but are **unavailable for truly novel strains** in a deployment
+scenario. A new clinical isolate arrives with a genome assembly — you can derive its defense systems, receptor variants,
+LPS type, and phylogenomic embedding, but you cannot know `host_n_infections` (you haven't screened it yet) or
+`receptor_variant_training_positive_count` (its specific receptor variant may not appear in the training data).
+
+The model leans heavily on these: `host_n_infections` alone has 2x the SHAP impact of the next feature. This means the
+holdout metrics (AUC 0.910, top-3 89.2%) are **optimistic for real-world deployment** because the holdout strains are
+from the same experimental panel and their receptor variants overlap with training strains.
+
+#### What is genuinely novel genomic signal?
+
+The SHAP ranking after the two panel-artifact features shows real genomic signal:
+
+| SHAP rank | Feature | Mean |SHAP| | Deployment-available? |
+|-----------|---------|------------|----------------------|
+| 3 | `phage_gc_content` | 0.217 | Yes — from genome |
+| 4 | `phage_genome_length_nt` | 0.203 | Yes — from genome |
+| 5 | `host_lps_type=R1` | 0.159 | Yes — from genome assembly |
+| 6 | `defense_evasion_mean_score` | 0.130 | Partially — rates from training, defense profile from genome |
+| 7 | `isolation_host_defense_jaccard_distance` | 0.123 | Yes — computable from genome |
+
+These features have 5–10x smaller SHAP values than the panel artifacts. The model *is* learning genomic signal, but the
+panel-memorization features dominate.
+
+#### Why this matters
+
+If we present the 89.2% top-3 hit rate to CDMO partners as "what the model can do for your new clinical isolate," we
+are overpromising. The honest number — what the model achieves using only features available at deployment time — will be
+lower. That's the number partners need to trust.
+
+This also explains the ablation paradox from the previous note: adding the pairwise compatibility block (which includes
+`receptor_variant_training_positive_count`) shifts the model's attention toward collaborative-filtering signal that is
+strong on average but misleading for specific holdout strains.
+
+#### Plan adjustment
+
+Added two acceptance criteria to TG05 (feature-subset sweep):
+
+1. Include a **deployment-realistic arm** that excludes all features derived from training labels
+   (`host_n_infections`, `receptor_variant_training_positive_count`) to measure generalization to truly novel strains.
+2. Report both **panel-evaluation** and **deployment-realistic** metrics for the winning configuration.
+
+This gives us two numbers to present: the panel metric (what the model does on known strains with full context) and the
+deployment metric (what a CDMO partner should expect for a new isolate). Both are valuable — the panel metric validates
+the approach, the deployment metric sets honest expectations.
+
+#### No other plan changes needed
+
+The concern does not invalidate Tracks C, D, or E. The genomic features are the right features — they just need to be
+evaluated separately from the panel-artifact features. TG05 is the right place to do this, and the task is already
+pending.


### PR DESCRIPTION
## Summary

- Fix the TG05 timeout by requiring reuse of TG01 hyperparameters (reduces ~800 fits to ~50)
- Add deployment-realistic evaluation arm that excludes label-derived features
- Bump Codex CI timeout from 30 to 45 minutes as safety margin
- Document label leakage concern from TG04 SHAP analysis

## Root cause of timeout

The TG05 run at [actions/runs/23410737866](https://github.com/LorenaDerezanin/coli_phage_interactions_2023/actions/runs/23410737866) timed out at 30 minutes because the agent ran full hyperparameter search for each of 10 sweep arms. With TG01's winning hyperparameters fixed, the sweep needs only 10 arms × 5 CV folds = 50 LightGBM fits (~2 minutes of compute).

The fix is in the task description (reuse hyperparameters), not the hardware.

## Label leakage concern

TG04 SHAP showed `host_n_infections` (SHAP 1.183) and `receptor_variant_training_positive_count` (SHAP 0.572) dominate the model — both are unavailable for novel strains at deployment time. The deployment-realistic arm measures what CDMO partners should actually expect.

## Test plan

- [ ] Re-dispatch TG05 and verify it completes within timeout
- [ ] Verify deployment-realistic arm is included in sweep output

🤖 Generated with [Claude Code](https://claude.com/claude-code)