### PR TITLE
fix: revert false TG05 completion and add issue closure policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,14 @@
 - Use one `Closes #...` line per issue when a PR intentionally resolves multiple issues.
 - Keep closure references explicit so orchestration and audit flows can advance automatically on merge.
 
+# Issue Closure Policy
+
+- Closing a GitHub issue signals completion to the orchestrator, which will mark the corresponding plan task as `done`.
+- If you need to close an issue **without** marking the task as completed (e.g., to re-dispatch with updated criteria),
+  close it as **"not planned"** (`gh issue close --reason "not planned"`). The orchestrator ignores not-planned closures.
+- Never close an orchestrator-task issue with a regular close unless the task is genuinely finished and its acceptance
+  criteria are met.
+
 # Codex Review Connector
 
 - The repo owner has a `chatgpt-codex-connector` GitHub App installed that automatically reviews every pull request.

--- a/lyzortx/orchestration/plan.yml
+++ b/lyzortx/orchestration/plan.yml
@@ -318,7 +318,7 @@ tracks:
         based on SHAP evidence and TG03 ablation results
     - id: TG05
       title: Run feature-subset sweep to find best block combination for top-3 ranking
-      status: done
+      status: pending
       model: gpt-5.4
       acceptance_criteria:
       - Train models on all 2-block and 3-block combinations of the 4 new feature

--- a/lyzortx/research_notes/PLAN.md
+++ b/lyzortx/research_notes/PLAN.md
@@ -154,7 +154,7 @@ graph LR
 - [x] Calibrate GBM outputs with isotonic and Platt scaling
 - [x] Run feature-block ablation suite proving which features deliver lift
 - [x] Compute SHAP explanations for per-pair and global feature importance
-- [x] Run feature-subset sweep to find best block combination for top-3 ranking
+- [ ] Run feature-subset sweep to find best block combination for top-3 ranking Model: `gpt-5.4`.
 
 ## Track H: In-Silico Cocktail Recommendation
 


### PR DESCRIPTION
## Summary

- Revert TG05 from `done` back to `pending` — it was incorrectly marked complete when #119 was closed without `--reason "not planned"`
- Add Issue Closure Policy to AGENTS.md preventing this class of error

## What happened

1. Issue #119 (TG05) was closed with a regular `gh issue close` to re-dispatch with updated criteria
2. GitHub set `state_reason: completed` by default
3. The orchestrator's issue-close trigger saw a completed close and marked TG05 done in plan.yml
4. TG05's downstream dependents (TF02, TH02, TP01) became "ready" despite TG05 having no output

## Fix

- TG05 reverted to `pending`
- AGENTS.md now documents: use `gh issue close --reason "not planned"` when closing issues that should not be marked as completed. The orchestrator already handles this correctly (line 382 of orchestrator.py).

## Test plan

- [ ] Orchestrator `status` shows TG05 as pending/ready
- [ ] Next `run_once` re-dispatches TG05 with fresh issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)