### PR TITLE
fix: revert TG05 to pending (orchestrator race)

### DIFF
--- a/lyzortx/orchestration/plan.yml
+++ b/lyzortx/orchestration/plan.yml
@@ -318,7 +318,7 @@ tracks:
         based on SHAP evidence and TG03 ablation results
     - id: TG05
       title: Run feature-subset sweep to find best block combination for top-3 ranking
-      status: done
+      status: pending
       model: gpt-5.4
       acceptance_criteria:
       - Train models on all 2-block and 3-block combinations of the 4 new feature

--- a/lyzortx/research_notes/PLAN.md
+++ b/lyzortx/research_notes/PLAN.md
@@ -154,7 +154,7 @@ graph LR
 - [x] Calibrate GBM outputs with isotonic and Platt scaling
 - [x] Run feature-block ablation suite proving which features deliver lift
 - [x] Compute SHAP explanations for per-pair and global feature importance
-- [x] Run feature-subset sweep to find best block combination for top-3 ranking
+- [ ] Run feature-subset sweep to find best block combination for top-3 ranking Model: `gpt-5.4`.
 
 ## Track H: In-Silico Cocktail Recommendation
 


### PR DESCRIPTION
## Summary

Revert TG05 from `done` to `pending`. The orchestrator re-synced from issue #119 and overwrote the PR #148 fix.

## Sequence after merge

1. ✅ Orchestrator paused
2. ✅ Issue #119 patched to `not_planned` via API
3. **Merge this PR** ← you are here
4. Close #149, #150, #151 as not-planned
5. Resume orchestrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)