### PR TITLE
fix: revert TF02 to pending

### DIFF
--- a/lyzortx/orchestration/plan.yml
+++ b/lyzortx/orchestration/plan.yml
@@ -266,7 +266,7 @@ tracks:
       - Dual-slice reporting (full-label and strict-confidence) for all metrics
     - id: TF02
       title: Before/after comparison of v0 vs v1 with error bucket analysis
-      status: done
+      status: pending
       model: gpt-5.4-mini
       acceptance_criteria:
       - Side-by-side metrics table for v0 (metadata logreg) vs v1 (genomic GBM)

--- a/lyzortx/research_notes/PLAN.md
+++ b/lyzortx/research_notes/PLAN.md
@@ -144,7 +144,7 @@ graph LR
 - **Guiding Principle:** Lock v1 benchmark split and add bootstrap confidence intervals. ST03 already provides
   leakage-safe host-group and phage-family holdouts.
 - [x] Lock ST03 split as v1 benchmark and add bootstrap CIs for all metrics
-- [x] Before/after comparison of v0 vs v1 with error bucket analysis
+- [ ] Before/after comparison of v0 vs v1 with error bucket analysis Model: `gpt-5.4-mini`.
 
 ## Track G: Modeling Pipeline
 


### PR DESCRIPTION
TF02 was falsely marked done by a local orchestrator test run. No implementation PR exists for it. Reverts to pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)