### PR TITLE
fix: revert TF01 to pending (task ID collision)

### DIFF
--- a/lyzortx/orchestration/plan.yml
+++ b/lyzortx/orchestration/plan.yml
@@ -257,7 +257,7 @@ tracks:
     tasks:
     - id: TF01
       title: Lock ST03 split as v1 benchmark and add bootstrap CIs for all metrics
-      status: done
+      status: pending
       model: gpt-5.4-mini
       acceptance_criteria:
       - Existing ST03 split locked as the canonical v1 evaluation protocol

--- a/lyzortx/research_notes/PLAN.md
+++ b/lyzortx/research_notes/PLAN.md
@@ -143,7 +143,7 @@ graph LR
 
 - **Guiding Principle:** Lock v1 benchmark split and add bootstrap confidence intervals. ST03 already provides
   leakage-safe host-group and phage-family holdouts.
-- [x] Lock ST03 split as v1 benchmark and add bootstrap CIs for all metrics
+- [ ] Lock ST03 split as v1 benchmark and add bootstrap CIs for all metrics Model: `gpt-5.4-mini`.
 - [ ] Before/after comparison of v0 vs v1 with error bucket analysis Model: `gpt-5.4-mini`.
 
 ## Track G: Modeling Pipeline


### PR DESCRIPTION
Old issue #22 completed the original TF01 (pre-revision split protocol). The plan revision reused the TF01 ID for a different task (bootstrap CIs). Orchestrator matched by ID → false completion. Issue #22 patched to not_planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)