### PR TITLE
[ORCH][TF01] Fixed host-clade split protocol

### DIFF
--- a/lyzortx/pipeline/steel_thread_v0/README.md
+++ b/lyzortx/pipeline/steel_thread_v0/README.md
@@ -16,6 +16,7 @@ This directory contains a minimal end-to-end pipeline to validate feasibility be
   - `ST0.2` canonical pair table builder: `lyzortx/pipeline/steel_thread_v0/steps/st02_build_pair_table.py`.
   - `ST0.3` split builder: `lyzortx/pipeline/steel_thread_v0/steps/st03_build_splits.py`.
   - `ST0.3b` split-suite builder: `lyzortx/pipeline/steel_thread_v0/steps/st03b_build_split_suite.py`.
+  - `TF01/ST0.3c` fixed split protocol builder: `lyzortx/pipeline/steel_thread_v0/steps/st03c_build_fixed_split_protocol.py`.
   - `ST0.4` baseline model trainer: `lyzortx/pipeline/steel_thread_v0/steps/st04_train_baselines.py`.
   - `ST0.4b` ablation suite: `lyzortx/pipeline/steel_thread_v0/steps/st04b_ablation_suite.py`.
   - `ST0.5` calibrator and ranker: `lyzortx/pipeline/steel_thread_v0/steps/st05_calibrate_rank.py`.
@@ -28,6 +29,7 @@ This directory contains a minimal end-to-end pipeline to validate feasibility be
   - Regression gate for ST0.2: `lyzortx/pipeline/steel_thread_v0/checks/check_st02_regression.py`.
   - Regression gate for ST0.3: `lyzortx/pipeline/steel_thread_v0/checks/check_st03_regression.py`.
   - Regression gate for ST0.3b: `lyzortx/pipeline/steel_thread_v0/checks/check_st03b_regression.py`.
+  - Regression gate for TF01/ST0.3c: `lyzortx/pipeline/steel_thread_v0/checks/check_st03c_regression.py`.
   - Regression gate for ST0.4: `lyzortx/pipeline/steel_thread_v0/checks/check_st04_regression.py`.
   - Regression gate for ST0.5: `lyzortx/pipeline/steel_thread_v0/checks/check_st05_regression.py`.
   - Regression gate for ST0.6: `lyzortx/pipeline/steel_thread_v0/checks/check_st06_regression.py`.
@@ -40,6 +42,7 @@ This directory contains a minimal end-to-end pipeline to validate feasibility be
 - `ST0.2`: Build canonical pair table with IDs, labels, uncertainty, and v0 features.
 - `ST0.3`: Build fixed leakage-safe host-group splits.
 - `ST0.3b`: Build split-suite artifacts for phage-family holdout and host+phage dual-axis stress tests.
+- `TF01/ST0.3c`: Build a versioned fixed split protocol with leave-cluster-out host splits and phage-clade holdouts.
 - `ST0.4`: Train baseline models.
 - `ST0.4b`: Run host-only, phage-only, and no-identity ablations on locked ST0.3b splits.
 - `ST0.5`: Calibrate probabilities and generate rankings.
@@ -109,6 +112,18 @@ Run the ST0.3b regression gate (recomputes ST0.1, ST0.1b, ST0.2, ST0.3, and ST0.
 
 ```bash
 python -m lyzortx.pipeline.steel_thread_v0.checks.check_st03b_regression --run-st01 --run-st01b --run-st02 --run-st03 --run-st03b
+```
+
+Run TF01/ST0.3c fixed split protocol:
+
+```bash
+python -m lyzortx.pipeline.steel_thread_v0.run_steel_thread_v0 --step st03c
+```
+
+Run the TF01/ST0.3c regression gate:
+
+```bash
+python -m lyzortx.pipeline.steel_thread_v0.checks.check_st03c_regression --run-st03c
 ```
 
 Run ST0.4 baseline training:

--- a/lyzortx/pipeline/steel_thread_v0/baselines/st03c_expected_metrics.json
+++ b/lyzortx/pipeline/steel_thread_v0/baselines/st03c_expected_metrics.json
@@ -1,0 +1,145 @@
+{
+  "artifacts": {
+    "split_assignments_csv_sha256": "9d9ee654001197cea8fcd2eccc878ef82e0a98a8e191c569c7172ed3a350a1fc"
+  },
+  "leakage_summary": {
+    "holdout_membership": {
+      "host_cluster_holdout_ids_sorted": [
+        "106",
+        "108",
+        "11",
+        "114",
+        "12",
+        "122",
+        "129",
+        "130",
+        "132",
+        "133",
+        "136",
+        "137",
+        "139",
+        "140",
+        "141",
+        "144",
+        "158",
+        "175",
+        "18",
+        "180",
+        "186",
+        "201",
+        "202",
+        "204",
+        "215",
+        "220",
+        "221",
+        "222",
+        "227",
+        "230",
+        "235",
+        "241",
+        "243",
+        "250",
+        "252",
+        "255",
+        "258",
+        "26",
+        "269",
+        "28",
+        "288",
+        "290",
+        "293",
+        "299",
+        "38",
+        "46",
+        "47",
+        "49",
+        "52",
+        "56",
+        "6",
+        "60",
+        "66",
+        "75",
+        "8",
+        "83",
+        "87"
+      ],
+      "phage_clade_holdout_ids_sorted": [
+        "Guernseyvirinae",
+        "Straboviridae"
+      ]
+    },
+    "leakage_checks": {
+      "dual_axis_train_vs_dual_holdout_clade_overlap_count": 0,
+      "dual_axis_train_vs_dual_holdout_cv_group_overlap_count": 0,
+      "host_cluster_holdout_cv_group_overlap_count": 0,
+      "phage_clade_holdout_clade_overlap_count": 0
+    }
+  },
+  "protocol_summary": {
+    "dual_axis": {
+      "evaluation_membership": [
+        "dual_holdout_test",
+        "host_only_holdout",
+        "phage_only_holdout"
+      ]
+    },
+    "host_axis": {
+      "assignment": "hash-based deterministic assignment by cv_group",
+      "group_key": "cv_group",
+      "holdout_fraction": 0.2,
+      "split_salt": "steel_thread_v0_tf01_host_cluster_v1"
+    },
+    "phage_axis": {
+      "assignment": "hash-based deterministic assignment by phage_clade",
+      "clade_definition": {
+        "missing_value_tokens": [
+          "",
+          "Other",
+          "NA",
+          "N/A",
+          "none",
+          "missing"
+        ],
+        "preferred_columns": [
+          "phage_family",
+          "phage_subfamily",
+          "phage_genus",
+          "phage_old_family",
+          "phage_old_genus"
+        ]
+      },
+      "group_key": "phage_clade",
+      "holdout_fraction": 0.2,
+      "split_salt": "steel_thread_v0_tf01_phage_clade_v1"
+    },
+    "protocol_id": "tf01_fixed_split_protocol_v1",
+    "protocol_version": "v1",
+    "split_type": "leave_cluster_out_host_plus_phage_clade_holdout",
+    "step_name": "st03c_build_fixed_split_protocol"
+  },
+  "split_summary": {
+    "host_cluster_count": 283,
+    "host_cluster_holdout_count": 57,
+    "host_cluster_holdout_fraction_actual": 0.201413,
+    "phage_clade_count": 12,
+    "phage_clade_holdout_count": 2,
+    "phage_clade_holdout_fraction_actual": 0.166667,
+    "row_count": 35424,
+    "split_counts": {
+      "dual_axis": {
+        "dual_holdout_test": 1518,
+        "host_only_holdout": 5106,
+        "phage_only_holdout": 6600,
+        "train_non_holdout": 22200
+      },
+      "host_cluster_holdout": {
+        "holdout_test": 6624,
+        "train_non_holdout": 28800
+      },
+      "phage_clade_holdout": {
+        "holdout_test": 8118,
+        "train_non_holdout": 27306
+      }
+    }
+  }
+}

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st03c_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st03c_regression.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Regression check for TF01/ST0.3c fixed split protocol outputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from lyzortx.pipeline.steel_thread_v0.checks._check_helpers import compare_dicts, load_json
+from lyzortx.pipeline.steel_thread_v0.steps import st03c_build_fixed_split_protocol
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--expected-baseline-path",
+        type=Path,
+        default=Path("lyzortx/pipeline/steel_thread_v0/baselines/st03c_expected_metrics.json"),
+        help="Path to expected regression baseline JSON.",
+    )
+    parser.add_argument(
+        "--intermediate-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate"),
+        help="Directory containing TF01/ST0.3c generated artifacts.",
+    )
+    parser.add_argument("--run-st03c", action="store_true", help="Run TF01/ST0.3c before checking.")
+    return parser.parse_args(argv)
+
+
+def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
+    audit_path = intermediate_dir / "st03c_fixed_split_protocol_v1_audit.json"
+    protocol_path = intermediate_dir / "st03c_fixed_split_protocol_v1_protocol.json"
+    assignments_path = intermediate_dir / "st03c_fixed_split_protocol_v1_assignments.csv"
+
+    if not audit_path.exists() or not protocol_path.exists() or not assignments_path.exists():
+        missing = [str(p) for p in (audit_path, protocol_path, assignments_path) if not p.exists()]
+        raise FileNotFoundError(
+            "TF01/ST0.3c artifacts missing. Run the step first or pass --run-st03c. Missing: " + ", ".join(missing)
+        )
+
+    audit = load_json(audit_path)
+    protocol = load_json(protocol_path)
+    assignment_sha256 = hashlib.sha256(assignments_path.read_bytes()).hexdigest()
+
+    return {
+        "split_summary": {
+            "row_count": audit["row_count"],
+            "host_cluster_count": audit["host_cluster_count"],
+            "host_cluster_holdout_count": audit["host_cluster_holdout_count"],
+            "host_cluster_holdout_fraction_actual": audit["host_cluster_holdout_fraction_actual"],
+            "phage_clade_count": audit["phage_clade_count"],
+            "phage_clade_holdout_count": audit["phage_clade_holdout_count"],
+            "phage_clade_holdout_fraction_actual": audit["phage_clade_holdout_fraction_actual"],
+            "split_counts": audit["split_counts"],
+        },
+        "leakage_summary": {
+            "leakage_checks": audit["leakage_checks"],
+            "holdout_membership": audit["holdout_membership"],
+        },
+        "protocol_summary": {
+            "step_name": protocol["step_name"],
+            "protocol_id": protocol["protocol_id"],
+            "protocol_version": protocol["protocol_version"],
+            "split_type": protocol["split_type"],
+            "host_axis": protocol["host_axis"],
+            "phage_axis": protocol["phage_axis"],
+            "dual_axis": protocol["dual_axis"],
+        },
+        "artifacts": {
+            "split_assignments_csv_sha256": assignment_sha256,
+        },
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+
+    if args.run_st03c:
+        st03c_build_fixed_split_protocol.main([])
+
+    expected = load_json(args.expected_baseline_path)
+    actual = build_actual_summary(args.intermediate_dir)
+    errors = compare_dicts(expected, actual)
+
+    if errors:
+        print("TF01/ST0.3c regression check failed:")
+        for err in errors:
+            print(f"- {err}")
+        raise SystemExit(1)
+
+    print("TF01/ST0.3c regression check passed.")
+    print(f"- Baseline: {args.expected_baseline_path}")
+    print(f"- Intermediate: {args.intermediate_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/pipeline/steel_thread_v0/run_steel_thread_v0.py
+++ b/lyzortx/pipeline/steel_thread_v0/run_steel_thread_v0.py
@@ -10,6 +10,7 @@ from lyzortx.pipeline.steel_thread_v0.checks import check_st01b_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st02_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st03_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st03b_regression
+from lyzortx.pipeline.steel_thread_v0.checks import check_st03c_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st04_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st05_regression
 from lyzortx.pipeline.steel_thread_v0.checks import check_st06_regression
@@ -20,6 +21,7 @@ from lyzortx.pipeline.steel_thread_v0.steps import (
     st02_build_pair_table,
     st03_build_splits,
     st03b_build_split_suite,
+    st03c_build_fixed_split_protocol,
     st04_train_baselines,
     st04b_ablation_suite,
     st05_calibrate_rank,
@@ -40,6 +42,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "st02",
             "st03",
             "st03b",
+            "st03c",
             "st04",
             "st04b",
             "st05",
@@ -52,6 +55,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "check-st02",
             "check-st03",
             "check-st03b",
+            "check-st03c",
             "check-st04",
             "check-st05",
             "check-st06",
@@ -75,6 +79,8 @@ def main(argv: list[str] | None = None) -> None:
         st03_build_splits.main([])
     elif args.step == "st03b":
         st03b_build_split_suite.main([])
+    elif args.step == "st03c":
+        st03c_build_fixed_split_protocol.main([])
     elif args.step == "st04":
         st04_train_baselines.main([])
     elif args.step == "st04b":
@@ -99,6 +105,8 @@ def main(argv: list[str] | None = None) -> None:
         check_st03_regression.main([])
     elif args.step == "check-st03b":
         check_st03b_regression.main([])
+    elif args.step == "check-st03c":
+        check_st03c_regression.main([])
     elif args.step == "check-st04":
         check_st04_regression.main([])
     elif args.step == "check-st05":

--- a/lyzortx/pipeline/steel_thread_v0/steps/st03c_build_fixed_split_protocol.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st03c_build_fixed_split_protocol.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""TF01/ST0.3c: Build a fixed split protocol with host clusters and phage clades."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence, Set, Tuple
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps.st03b_build_split_suite import select_holdout_items
+from lyzortx.pipeline.steel_thread_v0.steps.st02_build_pair_table import read_delimited_rows
+
+ST02_REQUIRED_COLUMNS: Sequence[str] = (
+    "pair_id",
+    "bacteria",
+    "phage",
+    "cv_group",
+    "phage_family",
+    "phage_subfamily",
+    "phage_genus",
+    "phage_old_family",
+    "phage_old_genus",
+)
+
+PROTOCOL_VERSION = "v1"
+PROTOCOL_ID = f"tf01_fixed_split_protocol_{PROTOCOL_VERSION}"
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--st02-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st02_pair_table.csv"),
+        help="Input ST0.2 canonical pair table path.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate"),
+        help="Output directory for TF01/ST0.3c artifacts.",
+    )
+    parser.add_argument(
+        "--host-holdout-fraction",
+        type=float,
+        default=0.2,
+        help="Target fraction of host CV groups routed to holdout.",
+    )
+    parser.add_argument(
+        "--phage-clade-holdout-fraction",
+        type=float,
+        default=0.2,
+        help="Target fraction of phage clades routed to holdout.",
+    )
+    parser.add_argument(
+        "--host-split-salt",
+        type=str,
+        default="steel_thread_v0_tf01_host_cluster_v1",
+        help="Deterministic salt for host-cluster holdout selection.",
+    )
+    parser.add_argument(
+        "--phage-split-salt",
+        type=str,
+        default="steel_thread_v0_tf01_phage_clade_v1",
+        help="Deterministic salt for phage-clade holdout selection.",
+    )
+    return parser.parse_args(argv)
+
+
+def _normalized_taxon_label(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        return ""
+    if cleaned.lower() in {"other", "na", "n/a", "none", "missing"}:
+        return ""
+    return cleaned
+
+
+def phage_clade_key(row: Mapping[str, str]) -> str:
+    """Derive a stable phage clade label from the available taxonomy columns."""
+    for column in ("phage_family", "phage_subfamily", "phage_genus", "phage_old_family", "phage_old_genus"):
+        label = _normalized_taxon_label(row.get(column, ""))
+        if label:
+            return label
+    return "__MISSING_PHAGE_CLADE__"
+
+
+def build_fixed_split_assignments(
+    rows: Sequence[Mapping[str, str]],
+    *,
+    host_holdout_fraction: float,
+    phage_clade_holdout_fraction: float,
+    host_split_salt: str,
+    phage_split_salt: str,
+) -> Tuple[List[Dict[str, object]], Dict[str, object], Dict[str, object]]:
+    if not rows:
+        raise ValueError("No rows were provided.")
+    if not 0 < host_holdout_fraction < 1:
+        raise ValueError("host_holdout_fraction must be between 0 and 1.")
+    if not 0 < phage_clade_holdout_fraction < 1:
+        raise ValueError("phage_clade_holdout_fraction must be between 0 and 1.")
+
+    host_groups = sorted(
+        {(row.get("cv_group", "") or "").strip() for row in rows if (row.get("cv_group", "") or "").strip()}
+    )
+    if not host_groups:
+        raise ValueError("No non-empty cv_group values were found.")
+    host_holdout_groups = select_holdout_items(host_groups, host_holdout_fraction, host_split_salt)
+
+    phage_clades = sorted({phage_clade_key(row) for row in rows})
+    phage_holdout_clades = select_holdout_items(phage_clades, phage_clade_holdout_fraction, phage_split_salt)
+
+    assignments: List[Dict[str, object]] = []
+    host_split_counts = Counter()
+    phage_split_counts = Counter()
+    dual_split_counts = Counter()
+
+    train_host_groups: Set[str] = set()
+    holdout_host_groups_seen: Set[str] = set()
+    train_phage_clades: Set[str] = set()
+    holdout_phage_clades_seen: Set[str] = set()
+
+    train_host_groups_dual: Set[str] = set()
+    dual_holdout_host_groups: Set[str] = set()
+    train_phage_clades_dual: Set[str] = set()
+    dual_holdout_phage_clades: Set[str] = set()
+
+    for row in rows:
+        bacteria = (row.get("bacteria", "") or "").strip()
+        phage = (row.get("phage", "") or "").strip()
+        pair_id = (row.get("pair_id", "") or "").strip()
+        cv_group = (row.get("cv_group", "") or "").strip()
+        phage_clade = phage_clade_key(row)
+
+        if not pair_id:
+            raise ValueError("Encountered a row with an empty pair_id.")
+        if not cv_group:
+            raise ValueError(f"Encountered an empty cv_group for pair {pair_id}.")
+
+        host_split = "holdout_test" if cv_group in host_holdout_groups else "train_non_holdout"
+        phage_split = "holdout_test" if phage_clade in phage_holdout_clades else "train_non_holdout"
+        if host_split == "holdout_test" and phage_split == "holdout_test":
+            dual_split = "dual_holdout_test"
+        elif host_split == "holdout_test":
+            dual_split = "host_only_holdout"
+        elif phage_split == "holdout_test":
+            dual_split = "phage_only_holdout"
+        else:
+            dual_split = "train_non_holdout"
+
+        host_split_counts[host_split] += 1
+        phage_split_counts[phage_split] += 1
+        dual_split_counts[dual_split] += 1
+
+        if host_split == "train_non_holdout":
+            train_host_groups.add(cv_group)
+        else:
+            holdout_host_groups_seen.add(cv_group)
+
+        if phage_split == "train_non_holdout":
+            train_phage_clades.add(phage_clade)
+        else:
+            holdout_phage_clades_seen.add(phage_clade)
+
+        if dual_split == "train_non_holdout":
+            train_host_groups_dual.add(cv_group)
+            train_phage_clades_dual.add(phage_clade)
+        elif dual_split == "dual_holdout_test":
+            dual_holdout_host_groups.add(cv_group)
+            dual_holdout_phage_clades.add(phage_clade)
+
+        assignments.append(
+            {
+                "pair_id": pair_id,
+                "bacteria": bacteria,
+                "phage": phage,
+                "cv_group": cv_group,
+                "phage_clade": phage_clade,
+                "split_protocol_id": PROTOCOL_ID,
+                "split_host_cluster_holdout": host_split,
+                "split_phage_clade_holdout": phage_split,
+                "split_dual_axis": dual_split,
+                "split_dual_axis_is_eval": 0 if dual_split == "train_non_holdout" else 1,
+            }
+        )
+
+    assignments.sort(key=lambda row: (str(row["bacteria"]), str(row["phage"])))
+
+    protocol = {
+        "step_name": "st03c_build_fixed_split_protocol",
+        "protocol_id": PROTOCOL_ID,
+        "protocol_version": PROTOCOL_VERSION,
+        "split_type": "leave_cluster_out_host_plus_phage_clade_holdout",
+        "host_axis": {
+            "group_key": "cv_group",
+            "assignment": "hash-based deterministic assignment by cv_group",
+            "holdout_fraction": host_holdout_fraction,
+            "split_salt": host_split_salt,
+        },
+        "phage_axis": {
+            "group_key": "phage_clade",
+            "assignment": "hash-based deterministic assignment by phage_clade",
+            "holdout_fraction": phage_clade_holdout_fraction,
+            "split_salt": phage_split_salt,
+            "clade_definition": {
+                "preferred_columns": [
+                    "phage_family",
+                    "phage_subfamily",
+                    "phage_genus",
+                    "phage_old_family",
+                    "phage_old_genus",
+                ],
+                "missing_value_tokens": ["", "Other", "NA", "N/A", "none", "missing"],
+            },
+        },
+        "dual_axis": {
+            "evaluation_membership": [
+                "dual_holdout_test",
+                "host_only_holdout",
+                "phage_only_holdout",
+            ]
+        },
+    }
+
+    audit = {
+        "row_count": len(assignments),
+        "host_cluster_count": len(host_groups),
+        "host_cluster_holdout_count": len(host_holdout_groups),
+        "host_cluster_holdout_fraction_actual": round(len(host_holdout_groups) / len(host_groups), 6),
+        "phage_clade_count": len(phage_clades),
+        "phage_clade_holdout_count": len(phage_holdout_clades),
+        "phage_clade_holdout_fraction_actual": round(len(phage_holdout_clades) / len(phage_clades), 6),
+        "split_counts": {
+            "host_cluster_holdout": dict(sorted(host_split_counts.items())),
+            "phage_clade_holdout": dict(sorted(phage_split_counts.items())),
+            "dual_axis": dict(sorted(dual_split_counts.items())),
+        },
+        "leakage_checks": {
+            "host_cluster_holdout_cv_group_overlap_count": len(train_host_groups & holdout_host_groups_seen),
+            "phage_clade_holdout_clade_overlap_count": len(train_phage_clades & holdout_phage_clades_seen),
+            "dual_axis_train_vs_dual_holdout_cv_group_overlap_count": len(
+                train_host_groups_dual & dual_holdout_host_groups
+            ),
+            "dual_axis_train_vs_dual_holdout_clade_overlap_count": len(
+                train_phage_clades_dual & dual_holdout_phage_clades
+            ),
+        },
+        "holdout_membership": {
+            "host_cluster_holdout_ids_sorted": sorted(host_holdout_groups),
+            "phage_clade_holdout_ids_sorted": sorted(phage_holdout_clades),
+        },
+    }
+
+    return assignments, protocol, audit
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+    ensure_directory(args.output_dir)
+
+    st02_rows = read_delimited_rows(args.st02_pair_table_path, delimiter=",")
+    if not st02_rows:
+        raise ValueError(f"No rows found in {args.st02_pair_table_path}.")
+    missing = [column for column in ST02_REQUIRED_COLUMNS if column not in st02_rows[0]]
+    if missing:
+        raise ValueError(f"Missing required columns in {args.st02_pair_table_path}: {', '.join(sorted(missing))}")
+
+    assignments, protocol, audit = build_fixed_split_assignments(
+        st02_rows,
+        host_holdout_fraction=args.host_holdout_fraction,
+        phage_clade_holdout_fraction=args.phage_clade_holdout_fraction,
+        host_split_salt=args.host_split_salt,
+        phage_split_salt=args.phage_split_salt,
+    )
+
+    assignments_path = args.output_dir / f"st03c_fixed_split_protocol_{PROTOCOL_VERSION}_assignments.csv"
+    protocol_path = args.output_dir / f"st03c_fixed_split_protocol_{PROTOCOL_VERSION}_protocol.json"
+    audit_path = args.output_dir / f"st03c_fixed_split_protocol_{PROTOCOL_VERSION}_audit.json"
+
+    write_csv(assignments_path, fieldnames=list(assignments[0].keys()), rows=assignments)
+    write_json(protocol_path, protocol)
+    write_json(audit_path, audit)
+
+    print("TF01/ST0.3c completed.")
+    print(f"- Rows: {len(assignments)}")
+    print(f"- Host clusters: {audit['host_cluster_count']}")
+    print(f"- Host holdouts: {audit['host_cluster_holdout_count']}")
+    print(f"- Phage clades: {audit['phage_clade_count']}")
+    print(f"- Phage holdouts: {audit['phage_clade_holdout_count']}")
+    print(f"- Output assignments: {assignments_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_ST.md
+++ b/lyzortx/research_notes/lab_notebooks/track_ST.md
@@ -397,3 +397,42 @@ Why:
    three phages even when no labeled susceptible phage exists.
 4. The next technically highest-value iteration is not more calibration tuning; it is adding host-compatibility signal
    plus an abstention/no-match mechanism, then re-checking this exact 10-strain bucket.
+
+### 2026-03-22: TF01 fixed split protocol implemented (host clusters + phage clades)
+
+#### Executive summary
+
+Implemented a versioned fixed split protocol at `lyzortx/pipeline/steel_thread_v0/steps/st03c_build_fixed_split_protocol.py`
+that deterministically assigns host CV groups to leave-cluster-out holdouts and assigns phage clades to a separate holdout
+axis. The exported assignment table and protocol JSON are versioned (`v1`) and the leakage audit is clean: zero overlap
+for host clusters and phage clades across train/test, including the dual-axis holdout view.
+
+#### Protocol definition
+
+- Host axis: deterministic hash assignment on `cv_group` with salt `steel_thread_v0_tf01_host_cluster_v1`.
+- Phage axis: deterministic hash assignment on `phage_clade` with salt `steel_thread_v0_tf01_phage_clade_v1`.
+- Phage clade label: first non-empty taxon from `phage_family`, `phage_subfamily`, `phage_genus`, `phage_old_family`,
+  or `phage_old_genus`, skipping generic `Other` / missing tokens.
+- Outputs:
+  - `lyzortx/generated_outputs/steel_thread_v0/intermediate/st03c_fixed_split_protocol_v1_assignments.csv`
+  - `lyzortx/generated_outputs/steel_thread_v0/intermediate/st03c_fixed_split_protocol_v1_protocol.json`
+  - `lyzortx/generated_outputs/steel_thread_v0/intermediate/st03c_fixed_split_protocol_v1_audit.json`
+
+#### Findings
+
+- Total rows: `35,424`.
+- Host clusters: `283`, with `57` routed to holdout (`0.201413` actual fraction).
+- Phage clades: `12`, with `2` routed to holdout (`0.166667` actual fraction).
+- Leakage checks:
+  - host cluster overlap: `0`
+  - phage clade overlap: `0`
+  - dual-axis host overlap: `0`
+  - dual-axis clade overlap: `0`
+
+#### Interpretation
+
+1. The split contract is deterministic and reproducible from the published salts and group labels.
+2. The host holdout behavior matches the earlier ST0.3 contract closely, while the phage axis now holds out explicit
+   clades rather than family labels alone.
+3. Because the protocol is versioned and hashed, downstream evaluation can cite the exact CSV payload rather than
+   reconstructing the split ad hoc.

--- a/lyzortx/tests/test_st03c_fixed_split_protocol.py
+++ b/lyzortx/tests/test_st03c_fixed_split_protocol.py
@@ -1,0 +1,162 @@
+"""Unit tests for TF01/ST0.3c fixed split protocol helpers."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from lyzortx.pipeline.steel_thread_v0.steps.st03c_build_fixed_split_protocol import build_fixed_split_assignments
+from lyzortx.pipeline.steel_thread_v0.steps.st03c_build_fixed_split_protocol import phage_clade_key
+
+
+def test_phage_clade_key_uses_taxonomy_fallbacks() -> None:
+    assert phage_clade_key({"phage_family": "Other", "phage_subfamily": "Ounavirinae"}) == "Ounavirinae"
+    assert phage_clade_key({"phage_family": "Autographiviridae", "phage_subfamily": "Other"}) == "Autographiviridae"
+    assert phage_clade_key({"phage_family": "", "phage_subfamily": "", "phage_genus": ""}) == "__MISSING_PHAGE_CLADE__"
+
+
+def test_build_fixed_split_assignments_is_deterministic_and_leakage_free() -> None:
+    rows = [
+        {
+            "pair_id": "B1__P1",
+            "bacteria": "B1",
+            "phage": "P1",
+            "cv_group": "G1",
+            "phage_family": "Other",
+            "phage_subfamily": "CladeA",
+            "phage_genus": "GenusA",
+            "phage_old_family": "",
+            "phage_old_genus": "",
+        },
+        {
+            "pair_id": "B2__P1",
+            "bacteria": "B2",
+            "phage": "P1",
+            "cv_group": "G2",
+            "phage_family": "Other",
+            "phage_subfamily": "CladeA",
+            "phage_genus": "GenusA",
+            "phage_old_family": "",
+            "phage_old_genus": "",
+        },
+        {
+            "pair_id": "B3__P2",
+            "bacteria": "B3",
+            "phage": "P2",
+            "cv_group": "G3",
+            "phage_family": "FamB",
+            "phage_subfamily": "Other",
+            "phage_genus": "GenusB",
+            "phage_old_family": "",
+            "phage_old_genus": "",
+        },
+    ]
+
+    first_assignments, first_protocol, first_audit = build_fixed_split_assignments(
+        rows,
+        host_holdout_fraction=0.34,
+        phage_clade_holdout_fraction=0.34,
+        host_split_salt="salt-host",
+        phage_split_salt="salt-phage",
+    )
+    second_assignments, second_protocol, second_audit = build_fixed_split_assignments(
+        rows,
+        host_holdout_fraction=0.34,
+        phage_clade_holdout_fraction=0.34,
+        host_split_salt="salt-host",
+        phage_split_salt="salt-phage",
+    )
+
+    assert first_assignments == second_assignments
+    assert first_protocol == second_protocol
+    assert first_audit == second_audit
+    assert first_audit["leakage_checks"]["host_cluster_holdout_cv_group_overlap_count"] == 0
+    assert first_audit["leakage_checks"]["phage_clade_holdout_clade_overlap_count"] == 0
+    assert {row["split_protocol_id"] for row in first_assignments} == {"tf01_fixed_split_protocol_v1"}
+    assert any(row["split_host_cluster_holdout"] == "holdout_test" for row in first_assignments)
+    assert any(row["split_phage_clade_holdout"] == "holdout_test" for row in first_assignments)
+
+
+def test_main_writes_versioned_outputs(tmp_path: Path) -> None:
+    from lyzortx.pipeline.steel_thread_v0.steps.st03c_build_fixed_split_protocol import main
+
+    st02_path = tmp_path / "st02_pair_table.csv"
+    output_dir = tmp_path / "out"
+    with st02_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "pair_id",
+                "bacteria",
+                "phage",
+                "cv_group",
+                "phage_family",
+                "phage_subfamily",
+                "phage_genus",
+                "phage_old_family",
+                "phage_old_genus",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "pair_id": "B1__P1",
+                "bacteria": "B1",
+                "phage": "P1",
+                "cv_group": "G1",
+                "phage_family": "Other",
+                "phage_subfamily": "CladeA",
+                "phage_genus": "GenusA",
+                "phage_old_family": "",
+                "phage_old_genus": "",
+            }
+        )
+        writer.writerow(
+            {
+                "pair_id": "B2__P2",
+                "bacteria": "B2",
+                "phage": "P2",
+                "cv_group": "G2",
+                "phage_family": "FamB",
+                "phage_subfamily": "Other",
+                "phage_genus": "GenusB",
+                "phage_old_family": "",
+                "phage_old_genus": "",
+            }
+        )
+
+    main(
+        [
+            "--st02-pair-table-path",
+            str(st02_path),
+            "--output-dir",
+            str(output_dir),
+            "--host-holdout-fraction",
+            "0.5",
+            "--phage-clade-holdout-fraction",
+            "0.5",
+            "--host-split-salt",
+            "salt-host",
+            "--phage-split-salt",
+            "salt-phage",
+        ]
+    )
+
+    assignments_path = output_dir / "st03c_fixed_split_protocol_v1_assignments.csv"
+    protocol_path = output_dir / "st03c_fixed_split_protocol_v1_protocol.json"
+    audit_path = output_dir / "st03c_fixed_split_protocol_v1_audit.json"
+
+    assert assignments_path.exists()
+    assert protocol_path.exists()
+    assert audit_path.exists()
+
+    with assignments_path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows[0]["split_protocol_id"] == "tf01_fixed_split_protocol_v1"
+
+    protocol = json.loads(protocol_path.read_text(encoding="utf-8"))
+    audit = json.loads(audit_path.read_text(encoding="utf-8"))
+    assert protocol["split_type"] == "leave_cluster_out_host_plus_phage_clade_holdout"
+    assert audit["leakage_checks"]["host_cluster_holdout_cv_group_overlap_count"] == 0
+    assert audit["leakage_checks"]["phage_clade_holdout_clade_overlap_count"] == 0


### PR DESCRIPTION
Implements a versioned fixed split protocol for TF01/ST0.3c.

- Deterministic leave-cluster-out host assignment on ST0.2 cv_group labels.
- Deterministic phage-clade holdouts using a documented taxonomy fallback chain.
- Versioned assignment CSV plus protocol and audit JSON artifacts.
- Regression check and unit tests for determinism, leakage, and CLI wiring.
- Notebook entry added with the measured split summary and leakage results.

Validation:
- pytest -q lyzortx/tests/
- python -m lyzortx.pipeline.steel_thread_v0.checks.check_st03c_regression --run-st03c

Closes #22