### PR TITLE
[ORCH][TF01] Lock ST03 v1 benchmark and add bootstrap CIs

### DIFF
--- a/lyzortx/pipeline/steel_thread_v0/baselines/st03_expected_metrics.json
+++ b/lyzortx/pipeline/steel_thread_v0/baselines/st03_expected_metrics.json
@@ -27,6 +27,7 @@
   "protocol_summary": {
     "holdout_group_fraction": 0.2,
     "n_cv_folds": 5,
+    "split_protocol_id": "steel_thread_v0_st03_split_v1",
     "split_salt": "steel_thread_v0_st03_split_v1",
     "split_type": "grouped_host_split",
     "step_name": "st03_build_splits"

--- a/lyzortx/pipeline/steel_thread_v0/checks/check_st03_regression.py
+++ b/lyzortx/pipeline/steel_thread_v0/checks/check_st03_regression.py
@@ -71,6 +71,7 @@ def build_actual_summary(intermediate_dir: Path) -> Dict[str, Any]:
         },
         "protocol_summary": {
             "step_name": protocol["step_name"],
+            "split_protocol_id": protocol["split_protocol_id"],
             "split_type": protocol["split_type"],
             "n_cv_folds": protocol["split_rules"]["n_cv_folds"],
             "holdout_group_fraction": protocol["split_rules"]["holdout_group_fraction"],

--- a/lyzortx/pipeline/steel_thread_v0/steps/st03_build_splits.py
+++ b/lyzortx/pipeline/steel_thread_v0/steps/st03_build_splits.py
@@ -204,6 +204,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     protocol = {
         "generated_at_utc": datetime.now(tz=timezone.utc).isoformat(),
         "step_name": "st03_build_splits",
+        "split_protocol_id": "steel_thread_v0_st03_split_v1",
         "split_type": "grouped_host_split",
         "split_rules": {
             "group_key": "cv_group",

--- a/lyzortx/pipeline/track_g/README.md
+++ b/lyzortx/pipeline/track_g/README.md
@@ -40,6 +40,11 @@ The TG02 calibration directory includes:
 2. `tg02_pair_predictions_calibrated.csv`: pair-level raw and calibrated LightGBM probabilities
 3. `tg02_ranked_predictions.csv`: isotonic-ranked per-strain predictions with raw and Platt scores for comparison
 4. `tg02_calibration_artifacts.json`: fitted isotonic thresholds, Platt coefficients, and input hashes
+5. `tg02_benchmark_summary.json`: v1 benchmark protocol summary with dual-slice point estimates and bootstrap CIs for
+   ROC-AUC, Brier score, ECE, and top-3 hit rate
+
+The benchmark summary is locked to the ST0.3 split protocol (`steel_thread_v0_st03_split_v1`) so downstream Track F
+and Track G analyses stay on the same canonical evaluation contract.
 
 The TG03 ablation directory includes:
 

--- a/lyzortx/pipeline/track_g/steps/calibrate_gbm_outputs.py
+++ b/lyzortx/pipeline/track_g/steps/calibrate_gbm_outputs.py
@@ -13,10 +13,11 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence
 import numpy as np
 from sklearn.isotonic import IsotonicRegression
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import brier_score_loss, log_loss
+from sklearn.metrics import brier_score_loss, log_loss, roc_auc_score
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
-from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import load_json, read_csv_rows, safe_round
+from lyzortx.pipeline.steel_thread_v0.steps.st06_recommend_top3 import bootstrap_topk_ci, evaluate_holdout_slice
 from lyzortx.pipeline.track_g.steps import train_v1_binary_classifier
 
 SLICE_FILTERS = {
@@ -88,6 +89,24 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         action="store_true",
         help="Assume TG01 outputs already exist instead of generating them when missing.",
     )
+    parser.add_argument(
+        "--st03-split-protocol-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_protocol.json"),
+        help="Input ST0.3 split protocol JSON.",
+    )
+    parser.add_argument(
+        "--bootstrap-samples",
+        type=int,
+        default=1000,
+        help="Number of bootstrap resamples for benchmark confidence intervals.",
+    )
+    parser.add_argument(
+        "--bootstrap-random-state",
+        type=int,
+        default=42,
+        help="Random seed for bootstrap confidence intervals.",
+    )
     return parser.parse_args(argv)
 
 
@@ -135,10 +154,14 @@ def ece_score(y_true: Sequence[int], y_prob: Sequence[float], n_bins: int) -> fl
     return ece
 
 
-def binary_metrics(y_true: Sequence[int], y_prob: Sequence[float], ece_bins: int) -> Dict[str, float]:
+def binary_metrics(y_true: Sequence[int], y_prob: Sequence[float], ece_bins: int) -> Dict[str, Optional[float]]:
+    roc_auc = None
+    if len(set(y_true)) >= 2:
+        roc_auc = safe_round(roc_auc_score(y_true, y_prob))
     return {
         "n": float(len(y_true)),
         "positive_rate": safe_round(sum(y_true) / len(y_true) if y_true else 0.0),
+        "roc_auc": roc_auc,
         "brier_score": safe_round(brier_score_loss(y_true, y_prob)),
         "log_loss": safe_round(log_loss(y_true, y_prob, labels=[0, 1])),
         "ece": safe_round(ece_score(y_true, y_prob, n_bins=ece_bins)),
@@ -149,6 +172,149 @@ def rows_for_slice(rows: Sequence[Mapping[str, str]], *, slice_name: str) -> Lis
     if slice_name not in SLICE_FILTERS:
         raise ValueError(f"Unknown slice name: {slice_name}")
     return [dict(row) for row in rows if SLICE_FILTERS[slice_name](row)]
+
+
+def bootstrap_binary_metric_ci(
+    holdout_by_bacteria: Mapping[str, Sequence[Mapping[str, str]]],
+    *,
+    slice_name: str,
+    probability_key: str,
+    metric_name: str,
+    bootstrap_samples: int,
+    bootstrap_random_state: int,
+    ece_bins: int,
+) -> Dict[str, Optional[float]]:
+    eligible_strains = [
+        bacteria
+        for bacteria, rows in sorted(holdout_by_bacteria.items())
+        if rows_for_slice(list(rows), slice_name=slice_name)
+    ]
+    if not eligible_strains:
+        return {
+            "bootstrap_samples": bootstrap_samples,
+            "ci_low": None,
+            "ci_high": None,
+        }
+
+    rng = np.random.default_rng(bootstrap_random_state)
+    values: List[float] = []
+    for _ in range(bootstrap_samples):
+        sampled_ids = rng.choice(eligible_strains, size=len(eligible_strains), replace=True)
+        sampled_rows: List[Dict[str, str]] = []
+        for bacteria in sampled_ids:
+            sampled_rows.extend(dict(row) for row in holdout_by_bacteria[bacteria])
+
+        sliced_rows = rows_for_slice(sampled_rows, slice_name=slice_name)
+        if not sliced_rows:
+            continue
+
+        y_true = [int(row["label_hard_any_lysis"]) for row in sliced_rows]
+        y_prob = [float(row[probability_key]) for row in sliced_rows]
+        if metric_name == "roc_auc":
+            if len(set(y_true)) < 2:
+                continue
+            value = float(roc_auc_score(y_true, y_prob))
+        elif metric_name == "brier_score":
+            value = float(brier_score_loss(y_true, y_prob))
+        elif metric_name == "ece":
+            value = float(ece_score(y_true, y_prob, n_bins=ece_bins))
+        else:
+            raise ValueError(f"Unsupported metric for bootstrap CI: {metric_name}")
+        values.append(value)
+
+    if not values:
+        return {
+            "bootstrap_samples": bootstrap_samples,
+            "ci_low": None,
+            "ci_high": None,
+        }
+
+    ci_low, ci_high = np.quantile(np.asarray(values, dtype=float), [0.025, 0.975])
+    return {
+        "bootstrap_samples": bootstrap_samples,
+        "ci_low": safe_round(float(ci_low)),
+        "ci_high": safe_round(float(ci_high)),
+    }
+
+
+def bootstrap_metric_suite(
+    holdout_by_bacteria: Mapping[str, Sequence[Mapping[str, str]]],
+    recs_by_bacteria: Mapping[str, Sequence[Mapping[str, object]]],
+    *,
+    bootstrap_samples: int,
+    bootstrap_random_state: int,
+    ece_bins: int,
+) -> Dict[str, Dict[str, Dict[str, Optional[float]]]]:
+    topk_holdout_by_bacteria, topk_recs_by_bacteria = build_topk_bootstrap_inputs(holdout_by_bacteria, recs_by_bacteria)
+
+    suite: Dict[str, Dict[str, Dict[str, Optional[float]]]] = {}
+    for slice_name in ("full_label", "strict_confidence"):
+        suite[slice_name] = {
+            "roc_auc": bootstrap_binary_metric_ci(
+                holdout_by_bacteria,
+                slice_name=slice_name,
+                probability_key="pred_lightgbm_isotonic",
+                metric_name="roc_auc",
+                bootstrap_samples=bootstrap_samples,
+                bootstrap_random_state=bootstrap_random_state,
+                ece_bins=ece_bins,
+            ),
+            "brier_score": bootstrap_binary_metric_ci(
+                holdout_by_bacteria,
+                slice_name=slice_name,
+                probability_key="pred_lightgbm_isotonic",
+                metric_name="brier_score",
+                bootstrap_samples=bootstrap_samples,
+                bootstrap_random_state=bootstrap_random_state,
+                ece_bins=ece_bins,
+            ),
+            "ece": bootstrap_binary_metric_ci(
+                holdout_by_bacteria,
+                slice_name=slice_name,
+                probability_key="pred_lightgbm_isotonic",
+                metric_name="ece",
+                bootstrap_samples=bootstrap_samples,
+                bootstrap_random_state=bootstrap_random_state,
+                ece_bins=ece_bins,
+            ),
+            "topk_hit_rate_all_strains": bootstrap_topk_ci(
+                holdout_by_bacteria=topk_holdout_by_bacteria,
+                recs_by_bacteria=topk_recs_by_bacteria,
+                slice_name=slice_name,
+                bootstrap_samples=bootstrap_samples,
+                bootstrap_random_state=bootstrap_random_state,
+            ),
+        }
+    return suite
+
+
+def build_topk_bootstrap_inputs(
+    holdout_by_bacteria: Mapping[str, Sequence[Mapping[str, str]]],
+    recs_by_bacteria: Mapping[str, Sequence[Mapping[str, object]]],
+) -> tuple[Dict[str, List[Dict[str, str]]], Dict[str, List[Dict[str, str]]]]:
+    topk_holdout_by_bacteria = {
+        bacteria: [
+            {
+                "label_hard_binary": row["label_hard_any_lysis"],
+                "is_strict_trainable": row["is_strict_trainable"],
+            }
+            for row in rows
+        ]
+        for bacteria, rows in holdout_by_bacteria.items()
+    }
+    topk_recs_by_bacteria = {
+        bacteria: [
+            {
+                "split_holdout": row["split_holdout"],
+                "bacteria": row["bacteria"],
+                "label_hard_binary": row["label_hard_any_lysis"],
+                "label_strict_confidence_tier": row["label_strict_confidence_tier"],
+            }
+            for row in rows
+        ]
+        for bacteria, rows in recs_by_bacteria.items()
+    }
+    return topk_holdout_by_bacteria, topk_recs_by_bacteria
 
 
 def merge_prediction_metadata(
@@ -192,6 +358,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         raise ValueError("TG01 prediction input is empty.")
 
     merged_rows = merge_prediction_metadata(tg01_rows, st02_rows, st03_rows)
+    split_protocol = load_json(args.st03_split_protocol_path)
     row_index_by_pair_id = {row["pair_id"]: idx for idx, row in enumerate(merged_rows)}
     calibration_rows = [
         row
@@ -304,12 +471,64 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 }
             )
 
+    holdout_by_bacteria: Dict[str, List[Dict[str, str]]] = defaultdict(list)
+    for row in output_rows:
+        if row["split_holdout"] == "holdout_test":
+            holdout_by_bacteria[str(row["bacteria"])].append(
+                {
+                    "label_hard_any_lysis": row["label_hard_any_lysis"],
+                    "is_strict_trainable": row["is_strict_trainable"],
+                    "pred_lightgbm_isotonic": row["pred_lightgbm_isotonic"],
+                }
+            )
+
+    recs_by_bacteria: Dict[str, List[Dict[str, object]]] = defaultdict(list)
+    for row in ranked_rows:
+        recs_by_bacteria[str(row["bacteria"])].append(row)
+
+    topk_holdout_by_bacteria, topk_recs_by_bacteria = build_topk_bootstrap_inputs(
+        holdout_by_bacteria=holdout_by_bacteria,
+        recs_by_bacteria=recs_by_bacteria,
+    )
+    benchmark_point_metrics: Dict[str, Dict[str, Any]] = {}
+    holdout_output_rows = [row for row in output_rows if row["split_holdout"] == "holdout_test"]
+    for slice_name in ("full_label", "strict_confidence"):
+        sliced_rows = rows_for_slice(holdout_output_rows, slice_name=slice_name)
+        if not sliced_rows:
+            continue
+        point_binary = binary_metrics(
+            [int(row["label_hard_any_lysis"]) for row in sliced_rows],
+            [float(row["pred_lightgbm_isotonic"]) for row in sliced_rows],
+            ece_bins=args.ece_bins,
+        )
+        point_topk = evaluate_holdout_slice(
+            holdout_by_bacteria=topk_holdout_by_bacteria,
+            recs_by_bacteria=topk_recs_by_bacteria,
+            slice_name=slice_name,
+        )
+        benchmark_point_metrics[slice_name] = {
+            "roc_auc": point_binary["roc_auc"],
+            "brier_score": point_binary["brier_score"],
+            "ece": point_binary["ece"],
+            "topk_hit_rate_all_strains": point_topk["topk_hit_rate_all_strains"],
+            "topk_hit_rate_susceptible_only": point_topk["topk_hit_rate_susceptible_only"],
+        }
+
+    benchmark_bootstrap_ci = bootstrap_metric_suite(
+        holdout_by_bacteria=holdout_by_bacteria,
+        recs_by_bacteria=recs_by_bacteria,
+        bootstrap_samples=args.bootstrap_samples,
+        bootstrap_random_state=args.bootstrap_random_state,
+        ece_bins=args.ece_bins,
+    )
+
     summary_rows.sort(key=lambda row: (str(row["model"]), str(row["dataset"]), str(row["variant"])))
     output_rows.sort(key=lambda row: (str(row["bacteria"]), str(row["phage"])))
     calibration_artifacts = {
         "generated_at_utc": datetime.now(tz=timezone.utc).isoformat(),
         "task_id": "TG02",
         "model": "lightgbm",
+        "split_protocol_id": split_protocol["split_protocol_id"],
         "calibration_fold": args.calibration_fold,
         "raw_column": "lightgbm_probability",
         "isotonic_x_thresholds": [safe_round(float(value)) for value in isotonic.X_thresholds_.tolist()],
@@ -329,6 +548,30 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 "path": str(args.st03_split_assignments_path),
                 "sha256": _sha256(args.st03_split_assignments_path),
             },
+            "st03_split_protocol": {
+                "path": str(args.st03_split_protocol_path),
+                "sha256": _sha256(args.st03_split_protocol_path),
+            },
+        },
+    }
+
+    benchmark_summary = {
+        "generated_at_utc": datetime.now(tz=timezone.utc).isoformat(),
+        "task_id": "TG02",
+        "split_protocol": {
+            "split_protocol_id": split_protocol["split_protocol_id"],
+            "split_type": split_protocol["split_type"],
+            "holdout_group_fraction": split_protocol["split_rules"]["holdout_group_fraction"],
+            "n_cv_folds": split_protocol["split_rules"]["n_cv_folds"],
+            "split_salt": split_protocol["split_rules"]["split_salt"],
+        },
+        "score_variant": "isotonic",
+        "label_slices": {
+            slice_name: {
+                "metrics": benchmark_point_metrics[slice_name],
+                "bootstrap_ci": benchmark_bootstrap_ci[slice_name],
+            }
+            for slice_name in benchmark_point_metrics
         },
     }
 
@@ -348,12 +591,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         rows=ranked_rows,
     )
     write_json(args.output_dir / "tg02_calibration_artifacts.json", calibration_artifacts)
+    write_json(args.output_dir / "tg02_benchmark_summary.json", benchmark_summary)
 
     print("TG02 completed.")
     print(f"- Calibration rows: {len(calibration_rows)}")
     print(f"- Holdout eval rows: {len(holdout_eval_rows)}")
     print(f"- Output calibrated predictions: {args.output_dir / 'tg02_pair_predictions_calibrated.csv'}")
     print(f"- Output ranking: {args.output_dir / 'tg02_ranked_predictions.csv'}")
+    print(f"- Output benchmark summary: {args.output_dir / 'tg02_benchmark_summary.json'}")
     return 0
 
 

--- a/lyzortx/research_notes/TIER_BENCHMARK_DENOMINATOR_POLICY.md
+++ b/lyzortx/research_notes/TIER_BENCHMARK_DENOMINATOR_POLICY.md
@@ -116,7 +116,7 @@ Every benchmark table/report must include:
 - `host_denominator_n`
 - `phage_denominator_n`
 - `label_slice`: `full_label` or `strict_confidence`
-- `split_protocol_id`
+- `split_protocol_id`: for the locked ST0.3 benchmark, `steel_thread_v0_st03_split_v1`
 - `metric_name`
 - `metric_value`
 - `support_n` (when metric-specific support differs from cohort denominator)

--- a/lyzortx/research_notes/lab_notebooks/track_F.md
+++ b/lyzortx/research_notes/lab_notebooks/track_F.md
@@ -1,0 +1,14 @@
+### 2026-03-22: TF01 ST03 v1 benchmark protocol and bootstrap CIs
+#### Executive summary
+Locked the ST0.3 grouped host split as the canonical v1 benchmark protocol by surfacing the protocol ID in the split
+artifacts and carrying it through the TG02 benchmark summary. Added 1000-strain bootstrap confidence intervals for the
+v1 benchmark's dual-slice metrics on the isotonic LightGBM outputs: ROC-AUC, Brier score, ECE, and top-3 hit rate.
+The benchmark summary now records both full-label and strict-confidence results against the same ST0.3 contract.
+
+#### Interpretation
+- The split contract is now explicit rather than implied by the salt string alone, which makes downstream benchmark
+  reporting easier to audit and compare across model revisions.
+- Bootstrapping at the holdout-strain level keeps the confidence intervals aligned with the evaluation denominator used
+  by the recommendation metric, instead of treating pairs as independent samples.
+- The strict-confidence slice remains a materially smaller and harder evaluation set, so the dual-slice reporting is
+  still necessary to avoid overstating benchmark performance.

--- a/lyzortx/tests/test_track_g_v1_binary_classifier.py
+++ b/lyzortx/tests/test_track_g_v1_binary_classifier.py
@@ -1,3 +1,4 @@
+import json
 import csv
 
 import numpy as np
@@ -577,6 +578,7 @@ def test_tg02_calibration_outputs_expected_files_and_rows(tmp_path) -> None:
     predictions_path = tmp_path / "tg01_pair_predictions.csv"
     st02_path = tmp_path / "st02_pair_table.csv"
     st03_path = tmp_path / "st03_split_assignments.csv"
+    protocol_path = tmp_path / "st03_split_protocol.json"
     output_dir = tmp_path / "tg02"
 
     with predictions_path.open("w", newline="", encoding="utf-8") as handle:
@@ -718,6 +720,21 @@ def test_tg02_calibration_outputs_expected_files_and_rows(tmp_path) -> None:
         ]:
             writer.writerow({"pair_id": pair_id, "is_strict_trainable": flag})
 
+    protocol_path.write_text(
+        json.dumps(
+            {
+                "split_protocol_id": "steel_thread_v0_st03_split_v1",
+                "split_type": "grouped_host_split",
+                "split_rules": {
+                    "holdout_group_fraction": 0.2,
+                    "n_cv_folds": 5,
+                    "split_salt": "steel_thread_v0_st03_split_v1",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
     exit_code = calibrate_gbm_outputs.main(
         [
             "--tg01-predictions-path",
@@ -726,8 +743,12 @@ def test_tg02_calibration_outputs_expected_files_and_rows(tmp_path) -> None:
             str(st02_path),
             "--st03-split-assignments-path",
             str(st03_path),
+            "--st03-split-protocol-path",
+            str(protocol_path),
             "--output-dir",
             str(output_dir),
+            "--bootstrap-samples",
+            "50",
             "--skip-prerequisites",
         ]
     )
@@ -740,6 +761,8 @@ def test_tg02_calibration_outputs_expected_files_and_rows(tmp_path) -> None:
         prediction_rows = list(csv.DictReader(handle))
     with (output_dir / "tg02_ranked_predictions.csv").open("r", newline="", encoding="utf-8") as handle:
         ranking_rows = list(csv.DictReader(handle))
+    with (output_dir / "tg02_benchmark_summary.json").open("r", encoding="utf-8") as handle:
+        benchmark_summary = json.load(handle)
 
     assert len(summary_rows) == 12
     assert {row["variant"] for row in summary_rows} == {"raw", "isotonic", "platt"}
@@ -749,3 +772,14 @@ def test_tg02_calibration_outputs_expected_files_and_rows(tmp_path) -> None:
     assert prediction_rows[0]["is_strict_trainable"] in {"0", "1"}
     assert len(ranking_rows) == 8
     assert ranking_rows[0]["rank_lightgbm_isotonic"] == "1"
+    assert benchmark_summary["split_protocol"]["split_protocol_id"] == "steel_thread_v0_st03_split_v1"
+    assert set(benchmark_summary["label_slices"]) == {"full_label", "strict_confidence"}
+    assert benchmark_summary["label_slices"]["full_label"]["metrics"]["roc_auc"] is not None
+    assert benchmark_summary["label_slices"]["full_label"]["bootstrap_ci"]["roc_auc"]["bootstrap_samples"] == 50
+    assert (
+        0.0
+        <= benchmark_summary["label_slices"]["strict_confidence"]["bootstrap_ci"]["topk_hit_rate_all_strains"][
+            "ci_low_topk_hit_rate_all_strains"
+        ]
+        <= 1.0
+    )


### PR DESCRIPTION
Lock the ST0.3 split as the canonical v1 evaluation protocol by surfacing a stable split protocol ID in the split artifacts and regression check. Extend the TG02 benchmark summary to report dual-slice point estimates and 1000-strain bootstrap confidence intervals for ROC-AUC, Brier score, ECE, and top-3 hit rate from the calibrated LightGBM outputs.\n\nAlso updated the Track G docs and the benchmark denominator policy note, and added a Track F notebook entry summarizing the protocol lock and evaluation interpretation.

Closes #158