### PR TITLE
Add AUTOMATION_ENABLED feature flag to codex-implement workflow

### DIFF
--- a/.github/workflows/codex-implement.yml
+++ b/.github/workflows/codex-implement.yml
@@ -19,8 +19,11 @@ jobs:
   implement:
     name: Implement Task
     if: >-
-      github.event_name == 'workflow_dispatch'
-      || contains(join(github.event.issue.labels.*.name, ','), 'orchestrator-task')
+      vars.AUTOMATION_ENABLED != 'false'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || contains(join(github.event.issue.labels.*.name, ','), 'orchestrator-task')
+      )
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     # PAT required: github.token can't trigger other workflows (GitHub anti-recursion).


### PR DESCRIPTION
## Summary

- Adds a `vars.AUTOMATION_ENABLED` repository variable check to the `implement` job's `if` condition in `codex-implement.yml`
- When set to `false`, the implement job is skipped entirely; any other value (or unset) allows normal execution
- Existing trigger conditions (workflow_dispatch / orchestrator-task label) are preserved unchanged

## How to use

Set the `AUTOMATION_ENABLED` repository variable in **Settings → Secrets and variables → Actions → Variables**:
- `true` (or leave unset): automation runs normally
- `false`: implementation automation is paused

## Test plan

- [ ] Verify workflow YAML is valid (no syntax errors in CI)
- [ ] Set `AUTOMATION_ENABLED` to `false` and confirm the implement job is skipped when an orchestrator-task issue is opened
- [ ] Unset the variable and confirm the implement job runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)