### PR TITLE
fix: retry auto-merge on transient base-branch-modified errors

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -98,8 +98,20 @@ jobs:
 
           if [ "$LATEST_REVIEW" = "APPROVED" ]; then
             echo "Claude approved — enabling auto-merge."
-            gh pr merge "$PR_NUM" --repo "${{ github.repository }}" --squash --auto \
-              --body "Auto-merged after Claude approval and passing CI."
+            MERGE_OK=false
+            for attempt in 1 2 3; do
+              if gh pr merge "$PR_NUM" --repo "${{ github.repository }}" --squash --auto \
+                   --body "Auto-merged after Claude approval and passing CI." 2>&1; then
+                MERGE_OK=true
+                break
+              fi
+              echo "Auto-merge attempt ${attempt} failed, retrying in 10s..."
+              sleep 10
+            done
+            if [ "$MERGE_OK" != "true" ]; then
+              echo "::error::Auto-merge failed after 3 attempts"
+              exit 1
+            fi
           elif [ "$LATEST_REVIEW" = "COMMENTED" ]; then
             echo "Claude left comments — dispatching Codex lifecycle."
             gh workflow run codex-pr-lifecycle.yml \


### PR DESCRIPTION
## Summary
- Adds 3-attempt retry with 10s backoff to the auto-merge step in `claude-pr-review.yml`
- Exits 1 if all attempts fail so the workflow properly reports failure

## Motivation
PR #170 hit `"Base branch was modified. Review and try the merge again."` because main moved
(from PR #169 merging) between the Claude review and the `gh pr merge --auto` call. A retry
handles this transient race.

## Test plan
- [ ] Workflow syntax is valid
- [ ] Next orchestrator PR that gets Claude-approved should auto-merge cleanly

🤖 Generated by Claude Opus 4.6