### PR TITLE
[ORCH][TF02] Compare v0 and v1 holdout misses

### DIFF
--- a/lyzortx/research_notes/lab_notebooks/track_F.md
+++ b/lyzortx/research_notes/lab_notebooks/track_F.md
@@ -12,3 +12,36 @@ The benchmark summary now records both full-label and strict-confidence results 
   by the recommendation metric, instead of treating pairs as independent samples.
 - The strict-confidence slice remains a materially smaller and harder evaluation set, so the dual-slice reporting is
   still necessary to avoid overstating benchmark performance.
+
+### 2026-03-22: TF02 v0 vs v1 holdout comparison and error buckets
+#### Executive summary
+Compared the v0 metadata logreg baseline from ST0.5/0.7 against the locked v1 genomic GBM winner from TG05
+(`defense + OMP + phage-genomic`). v1 improves every tracked holdout metric and reduces the holdout miss count from
+10 to 8, but it does not eliminate the hard strains.
+
+#### Headline v0 -> v1 comparison
+
+| Metric | v0 (metadata logreg) | v1 (genomic GBM) | Delta |
+|--------|----------------------|------------------|-------|
+| ROC-AUC | 0.826948 | 0.910766 | +0.083818 |
+| Top-3 hit rate (all strains) | 84.615% | 87.692% | +3.077% |
+| Top-3 hit rate (susceptible only) | 87.302% | 90.476% | +3.174% |
+| Brier score | 0.171223 | 0.109543 | -0.061680 |
+
+#### Error bucket analysis
+- **Fixed by v1:** `ECOR-14`, `NILS41`, `NILS70`, `ROAR205`. These were v0 ranking misses where the best true
+  positive was already close to the cutoff; v1 lifts the correct phage to rank 1 in all four cases.
+- **Still unpredictable:** `ECOR-06`, `ECOR-69`, `FN-B4`, `H1-002-0060-C-T`, `H1-003-0088-B-J`, `IAI67`, `NILS24`,
+  `NILS53`.
+- **Why they remain hard:**
+  - `FN-B4` and `NILS24` are abstention failures: zero positives means any top-3 recommendation is wrong.
+  - `ECOR-06` and `H1-002-0060-C-T` are narrow-recall misses: each has one positive, but it stays outside the top 3.
+  - `ECOR-69` and `NILS53` are family-collapse cases: v1 still pushes the wrong phage-family block to the top.
+  - `H1-003-0088-B-J` and `IAI67` are new v1 misses where the best true positive only reaches ranks 4 and 6.
+
+#### Interpretation
+- The v1 feature blocks do fix a real subset of the v0 failures, especially the same-family ordering misses.
+- The remaining misses are not a single bug class; they split cleanly into abstention, narrow-recall, and
+  cross-family-collapse modes.
+- The final model is better overall, but the honest deployment message is still strain-specific: some strains are now
+  solvable, and some remain effectively unpredictable with this feature set.


### PR DESCRIPTION
## Summary
- Added the TF02 notebook entry with a side-by-side v0 vs v1 holdout metric table.
- Documented strain-level error buckets for the final TG05 locked v1 model.
- Listed the remaining unpredictable strains explicitly.

## Verification
- `pytest -q lyzortx/tests/`

Generated by Codex gpt-5.4-mini.

Closes #172