### PR TITLE
[ORCH][TG07] Retrain and lock the clean Track G model

### DIFF
--- a/lyzortx/pipeline/track_g/v1_feature_configuration.json
+++ b/lyzortx/pipeline/track_g/v1_feature_configuration.json
@@ -13,40 +13,6 @@
   "holdout_brier_score": 0.156534,
   "holdout_top3_hit_rate_all_strains": 0.923077,
   "holdout_top3_hit_rate_susceptible_only": 0.952381,
-  "calibration_metrics": {
-    "full_label": {
-      "isotonic": {
-        "roc_auc": 0.834808,
-        "top3_hit_rate_all_strains": 0.907692,
-        "top3_hit_rate_susceptible_only": 0.936508,
-        "brier_score": 0.138814,
-        "ece": 0.058800
-      },
-      "platt": {
-        "roc_auc": 0.835754,
-        "top3_hit_rate_all_strains": 0.923077,
-        "top3_hit_rate_susceptible_only": 0.952381,
-        "brier_score": 0.139367,
-        "ece": 0.053467
-      }
-    },
-    "strict_confidence": {
-      "isotonic": {
-        "roc_auc": 0.893293,
-        "top3_hit_rate_all_strains": 0.828125,
-        "top3_hit_rate_susceptible_only": 0.898305,
-        "brier_score": 0.104318,
-        "ece": 0.137049
-      },
-      "platt": {
-        "roc_auc": 0.894254,
-        "top3_hit_rate_all_strains": 0.8125,
-        "top3_hit_rate_susceptible_only": 0.881356,
-        "brier_score": 0.103877,
-        "ece": 0.141089
-      }
-    }
-  },
   "tg01_all_features_reference_holdout_roc_auc": 0.835754,
   "tg01_all_features_reference_holdout_brier_score": 0.156187,
   "tg01_all_features_reference_holdout_top3_hit_rate_all_strains": 0.923077,

--- a/lyzortx/research_notes/lab_notebooks/track_G.md
+++ b/lyzortx/research_notes/lab_notebooks/track_G.md
@@ -496,6 +496,7 @@ preserves the expected ranking performance without the leaked features.
 
 #### What was implemented
 
+- Reran Track G through `python lyzortx/pipeline/track_g/run_track_g.py` after the TG06 leak cleanup.
 - Reran the full Track G pipeline after TG06 on the leakage-free feature set with the same TG01 LightGBM
   hyperparameters.
 - Recomputed the clean calibration outputs for isotonic and Platt scaling and captured holdout AUC, top-3, Brier,


### PR DESCRIPTION
## Summary
- Reran TG07 on the leakage-free Track G feature set after the TG06 cleanup.
- Updated the v1 lock artifact to keep only the locked winner metrics plus explicit TG01 reference holdout fields.
- Added the TG07 rerun script path to the Track G notebook entry so the audit trail is explicit.

## Validation
- `pytest -q lyzortx/tests/` (267 passed)

Posted by Codex gpt-5.4

Closes #186