### PR TITLE
[ORCH][TG09] Lock deterministic TG01 release path

### DIFF
--- a/lyzortx/pipeline/track_g/steps/train_v1_binary_classifier.py
+++ b/lyzortx/pipeline/track_g/steps/train_v1_binary_classifier.py
@@ -9,7 +9,6 @@ import json
 import logging
 import warnings
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
@@ -549,7 +548,7 @@ def make_lightgbm_estimator(params: Mapping[str, object], seed_offset: int, *, b
         objective="binary",
         class_weight="balanced",
         random_state=base_random_state + seed_offset,
-        n_jobs=1,
+        deterministic=True,
         verbosity=-1,
         force_col_wise=True,
         colsample_bytree=0.8,
@@ -807,7 +806,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     top3_ranking_rows.sort(key=lambda row: (str(row["model_label"]), str(row["bacteria"]), int(row["rank"])))
 
     summary = {
-        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
         "task_id": "TG01",
         "feature_space": {
             "categorical_columns": list(feature_space.categorical_columns),

--- a/lyzortx/pipeline/track_g/v1_feature_configuration.json
+++ b/lyzortx/pipeline/track_g/v1_feature_configuration.json
@@ -1,17 +1,16 @@
 {
-  "task_id": "TG07",
+  "task_id": "TG09",
   "source_lock_task_id": "TG05",
-  "selection_policy": "Among 2-block and 3-block panel-evaluation subsets, keep arms with holdout ROC-AUC >= TG01 all-features holdout ROC-AUC, then choose the highest holdout top-3 hit rate. Ties break on higher ROC-AUC, then lower Brier score, then arm_id.",
-  "winner_arm_id": "subset_defense__phage_genomic__pairwise",
-  "winner_label": "defense + phage-genomic + pairwise",
+  "selection_policy": "Human-locked decision after reviewing TG07-TG08 instability: keep the 2-block defense + phage-genomic arm and exclude the pairwise block because 5 of 13 pairwise features are training-label-derived.",
+  "winner_arm_id": "subset_defense__phage_genomic",
+  "winner_label": "defense + phage-genomic",
   "winner_subset_blocks": [
     "defense",
-    "phage_genomic",
-    "pairwise"
+    "phage_genomic"
   ],
-  "holdout_roc_auc": 0.835975,
-  "holdout_brier_score": 0.156534,
-  "holdout_top3_hit_rate_all_strains": 0.923077,
+  "holdout_roc_auc": 0.8372,
+  "holdout_brier_score": 0.159559,
+  "holdout_top3_hit_rate_all_strains": 0.907692,
   "holdout_top3_hit_rate_susceptible_only": 0.952381,
   "tg01_all_features_reference_holdout_roc_auc": 0.835754,
   "tg01_all_features_reference_holdout_brier_score": 0.156187,

--- a/lyzortx/pipeline/track_j/run_track_j.py
+++ b/lyzortx/pipeline/track_j/run_track_j.py
@@ -66,7 +66,10 @@ def _runners_for_step(step: str) -> Iterable[StepRunner]:
     rest: Tuple[StepRunner, ...] = (
         ("track-d", lambda: run_track_d.main(["--step", "all"])),
         ("track-e", lambda: run_track_e.main(["--step", "all"])),
-        ("track-g", lambda: run_track_g.main(["--step", "all"])),
+        ("track-g-train-v1-binary", lambda: run_track_g.train_v1_binary_classifier.main([])),
+        ("track-g-calibrate-gbm", lambda: run_track_g.calibrate_gbm_outputs.main([])),
+        ("track-g-feature-block-ablation", lambda: run_track_g.run_feature_block_ablation_suite.main([])),
+        ("track-g-compute-shap", lambda: run_track_g.compute_shap_explanations.main([])),
         ("track-h", lambda: run_track_h.main(["--step", "all"])),
     )
     if step == "foundation":
@@ -74,9 +77,9 @@ def _runners_for_step(step: str) -> Iterable[StepRunner]:
     if step == "feature-blocks":
         return features
     if step == "modeling":
-        return rest[:3]
+        return rest[:6]
     if step == "recommendations":
-        return rest[3:]
+        return rest[6:]
     if step == "all":
         return (*foundation, *features, *rest)
     raise ValueError(f"Unsupported step: {step}")

--- a/lyzortx/research_notes/lab_notebooks/track_G.md
+++ b/lyzortx/research_notes/lab_notebooks/track_G.md
@@ -644,3 +644,29 @@ Lock `defense + phage_genomic` (without pairwise). Reasons:
 3. Half the pairwise block is label-derived — adding it is inconsistent with the leakage cleanup
 4. The clean pairwise features (TE03 distances, TE01 curated lookups) should be evaluated individually in a future task,
    not bundled with the label-derived ones
+
+### 2026-03-24: TG09 implemented (deterministic TG01 training and human-locked v1 feature config)
+
+#### What was implemented
+
+- Updated `lyzortx/pipeline/track_g/steps/train_v1_binary_classifier.py` so `make_lightgbm_estimator` now sets
+  `deterministic=True` and no longer forces `n_jobs=1`.
+- Removed the run timestamp from the TG01 summary artifact so consecutive training runs produce byte-identical output
+  trees.
+- Updated `lyzortx/pipeline/track_g/v1_feature_configuration.json` to lock `defense + phage-genomic` as the v1 winner
+  and exclude the pairwise block from the human-approved lock.
+- Updated `lyzortx/pipeline/track_j/run_track_j.py` so Track J calls the Track G modeling steps explicitly and no
+  longer regenerates the feature-subset sweep during release runs.
+- Added tests covering the LightGBM factory flags and the new Track J release ordering.
+
+#### What was verified
+
+- `pytest -q lyzortx/tests/` passed.
+- Two consecutive runs of `python -m lyzortx.pipeline.track_g.steps.train_v1_binary_classifier --output-dir ...`
+  produced identical artifacts under `.scratch/tg01_run1b` and `.scratch/tg01_run2b`.
+
+#### Interpretation
+
+1. TG01 is now reproducible at the artifact level, not just at the metric level.
+2. Track J now treats the v1 feature lock as a human decision instead of regenerating it from the sweep.
+3. The locked v1 winner is aligned with the leak cleanup: `defense + phage-genomic` only.

--- a/lyzortx/tests/test_track_g_v1_binary_classifier.py
+++ b/lyzortx/tests/test_track_g_v1_binary_classifier.py
@@ -1,5 +1,7 @@
-import json
 import csv
+import json
+import sys
+import types
 
 import numpy as np
 
@@ -24,6 +26,7 @@ from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import (
     build_feature_space,
     compute_top3_hit_rate,
     merge_expanded_feature_rows,
+    make_lightgbm_estimator,
     select_best_candidate,
 )
 
@@ -144,6 +147,27 @@ def test_select_best_candidate_prefers_auc_then_top3_then_brier() -> None:
     )
 
     assert best["params"]["name"] == "b"
+
+
+def test_make_lightgbm_estimator_enables_determinism_without_forcing_single_thread(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeLGBMClassifier:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    fake_lightgbm = types.SimpleNamespace(LGBMClassifier=FakeLGBMClassifier)
+    monkeypatch.setitem(sys.modules, "lightgbm", fake_lightgbm)
+
+    estimator = make_lightgbm_estimator({"num_leaves": 31}, 2, base_random_state=17)
+
+    assert estimator.__class__.__name__ == "FakeLGBMClassifier"
+    assert captured["objective"] == "binary"
+    assert captured["class_weight"] == "balanced"
+    assert captured["random_state"] == 19
+    assert captured["deterministic"] is True
+    assert captured["force_col_wise"] is True
+    assert "n_jobs" not in captured
 
 
 def test_partition_track_c_columns_splits_defense_from_remaining_host_genomic() -> None:

--- a/lyzortx/tests/test_track_j_release_pipeline.py
+++ b/lyzortx/tests/test_track_j_release_pipeline.py
@@ -30,7 +30,26 @@ def test_run_track_j_dispatches_release_sequence_in_dependency_order(monkeypatch
     )
     monkeypatch.setattr(run_track_j.run_track_d, "main", lambda argv: calls.append("track-d"))
     monkeypatch.setattr(run_track_j.run_track_e, "main", lambda argv: calls.append("track-e"))
-    monkeypatch.setattr(run_track_j.run_track_g, "main", lambda argv: calls.append("track-g"))
+    monkeypatch.setattr(
+        run_track_j.run_track_g.train_v1_binary_classifier,
+        "main",
+        lambda argv: calls.append("track-g-train-v1-binary"),
+    )
+    monkeypatch.setattr(
+        run_track_j.run_track_g.calibrate_gbm_outputs,
+        "main",
+        lambda argv: calls.append("track-g-calibrate-gbm"),
+    )
+    monkeypatch.setattr(
+        run_track_j.run_track_g.run_feature_block_ablation_suite,
+        "main",
+        lambda argv: calls.append("track-g-feature-block-ablation"),
+    )
+    monkeypatch.setattr(
+        run_track_j.run_track_g.compute_shap_explanations,
+        "main",
+        lambda argv: calls.append("track-g-compute-shap"),
+    )
     monkeypatch.setattr(run_track_j.run_track_h, "main", lambda argv: calls.append("track-h"))
 
     run_track_j.main([])
@@ -46,7 +65,10 @@ def test_run_track_j_dispatches_release_sequence_in_dependency_order(monkeypatch
         "track-c-v1-pair-table",
         "track-d",
         "track-e",
-        "track-g",
+        "track-g-train-v1-binary",
+        "track-g-calibrate-gbm",
+        "track-g-feature-block-ablation",
+        "track-g-compute-shap",
         "track-h",
     ]
 
@@ -71,7 +93,26 @@ def test_run_track_j_uses_dynamic_runner_boundaries_and_logs_steps(monkeypatch, 
     )
     monkeypatch.setattr(run_track_j.run_track_d, "main", lambda argv: release_calls.append("track-d"))
     monkeypatch.setattr(run_track_j.run_track_e, "main", lambda argv: release_calls.append("track-e"))
-    monkeypatch.setattr(run_track_j.run_track_g, "main", lambda argv: release_calls.append("track-g"))
+    monkeypatch.setattr(
+        run_track_j.run_track_g.train_v1_binary_classifier,
+        "main",
+        lambda argv: release_calls.append("track-g-train-v1-binary"),
+    )
+    monkeypatch.setattr(
+        run_track_j.run_track_g.calibrate_gbm_outputs,
+        "main",
+        lambda argv: release_calls.append("track-g-calibrate-gbm"),
+    )
+    monkeypatch.setattr(
+        run_track_j.run_track_g.run_feature_block_ablation_suite,
+        "main",
+        lambda argv: release_calls.append("track-g-feature-block-ablation"),
+    )
+    monkeypatch.setattr(
+        run_track_j.run_track_g.compute_shap_explanations,
+        "main",
+        lambda argv: release_calls.append("track-g-compute-shap"),
+    )
     monkeypatch.setattr(run_track_j.run_track_h, "main", lambda argv: release_calls.append("track-h"))
 
     foundation_runners = tuple(run_track_j._runners_for_step("foundation"))
@@ -81,7 +122,14 @@ def test_run_track_j_uses_dynamic_runner_boundaries_and_logs_steps(monkeypatch, 
 
     assert [name for name, _ in foundation_runners] == ["foundation-a", "foundation-b"]
     assert [name for name, _ in feature_runners] == ["feature-a"]
-    assert [name for name, _ in modeling_runners] == ["track-d", "track-e", "track-g"]
+    assert [name for name, _ in modeling_runners] == [
+        "track-d",
+        "track-e",
+        "track-g-train-v1-binary",
+        "track-g-calibrate-gbm",
+        "track-g-feature-block-ablation",
+        "track-g-compute-shap",
+    ]
     assert [name for name, _ in recommendation_runners] == ["track-h"]
 
     with caplog.at_level("INFO", logger="lyzortx.pipeline.track_j.run_track_j"):
@@ -89,7 +137,15 @@ def test_run_track_j_uses_dynamic_runner_boundaries_and_logs_steps(monkeypatch, 
 
     assert foundation_calls == ["foundation-a", "foundation-b"]
     assert feature_calls == ["feature-a"]
-    assert release_calls == ["track-d", "track-e", "track-g", "track-h"]
+    assert release_calls == [
+        "track-d",
+        "track-e",
+        "track-g-train-v1-binary",
+        "track-g-calibrate-gbm",
+        "track-g-feature-block-ablation",
+        "track-g-compute-shap",
+        "track-h",
+    ]
     step_messages = [r.message for r in caplog.records if r.message.startswith("[track-j]")]
     assert step_messages == [
         "[track-j] foundation-a",
@@ -97,7 +153,10 @@ def test_run_track_j_uses_dynamic_runner_boundaries_and_logs_steps(monkeypatch, 
         "[track-j] feature-a",
         "[track-j] track-d",
         "[track-j] track-e",
-        "[track-j] track-g",
+        "[track-j] track-g-train-v1-binary",
+        "[track-j] track-g-calibrate-gbm",
+        "[track-j] track-g-feature-block-ablation",
+        "[track-j] track-g-compute-shap",
         "[track-j] track-h",
     ]
 
@@ -131,7 +190,26 @@ def test_run_track_j_can_limit_to_feature_blocks(monkeypatch) -> None:
     )
     monkeypatch.setattr(run_track_j.run_track_d, "main", lambda argv: calls.append("track-d"))
     monkeypatch.setattr(run_track_j.run_track_e, "main", lambda argv: calls.append("track-e"))
-    monkeypatch.setattr(run_track_j.run_track_g, "main", lambda argv: calls.append("track-g"))
+    monkeypatch.setattr(
+        run_track_j.run_track_g.train_v1_binary_classifier,
+        "main",
+        lambda argv: calls.append("track-g-train-v1-binary"),
+    )
+    monkeypatch.setattr(
+        run_track_j.run_track_g.calibrate_gbm_outputs,
+        "main",
+        lambda argv: calls.append("track-g-calibrate-gbm"),
+    )
+    monkeypatch.setattr(
+        run_track_j.run_track_g.run_feature_block_ablation_suite,
+        "main",
+        lambda argv: calls.append("track-g-feature-block-ablation"),
+    )
+    monkeypatch.setattr(
+        run_track_j.run_track_g.compute_shap_explanations,
+        "main",
+        lambda argv: calls.append("track-g-compute-shap"),
+    )
     monkeypatch.setattr(run_track_j.run_track_h, "main", lambda argv: calls.append("track-h"))
 
     run_track_j.main(["--step", "feature-blocks"])


### PR DESCRIPTION
This updates the TG01 release path to be deterministic and keeps the v1 lock human-approved.

Changes:
- add `deterministic=True` to the LightGBM factory and remove `n_jobs=1`
- remove the TG01 summary timestamp so consecutive runs are byte-identical
- lock `v1_feature_configuration.json` to `defense + phage-genomic`
- make Track J call the Track G modeling steps explicitly so it no longer regenerates the sweep
- add regression coverage for the factory flags and release ordering

Verification:
- `pytest -q lyzortx/tests/`
- two consecutive TG01 runs into `.scratch/tg01_run1b` and `.scratch/tg01_run2b` produced identical trees

Posted by Codex gpt-5.4

Closes #195