### PR TITLE
Add TG12, Track K (per-source external data lift), update replan skill

### DIFF
--- a/.agents/skills/replan/SKILL.md
+++ b/.agents/skills/replan/SKILL.md
@@ -146,6 +146,31 @@ After restructuring the plan, make sure everything is consistent:
        print(f"{t.task_id}: model={t.model}, criteria={len(t.acceptance_criteria)} items")
    ```
 
+## Phase 6: Suggest next steps
+
+If the plan has no pending tasks, or the remaining tasks don't address the most important open questions, propose next
+steps. Don't just report "the plan is done" — the user invoked `/replan` because they want direction.
+
+### Harvest future notes
+
+Scan `lyzortx/research_notes/lab_notebooks/project.md` for entries marked "Future:" or containing phrases like
+"consider", "revisit when", "follow-up", "defer". These are seeds planted by previous sessions that may now be
+actionable. Evaluate each:
+- Is the trigger condition met? (e.g., "revisit when external data is wired in")
+- Is it still relevant given what's changed since it was written?
+- Should it become a new plan task, or be deleted as obsolete?
+
+### Propose new tasks
+
+When proposing next steps:
+1. Frame each as a concrete task with a clear acceptance criterion, not a vague direction
+2. Justify why it's the highest-value next step given the current state
+3. Size it (mini vs full model, estimated CI time)
+4. Identify dependencies — can it start now, or does something need to happen first?
+
+Do not suggest presentation or visualization tasks (dashboards, demos, HTML reports). Agents produce bad visual
+artifacts. Presentation work is human-driven.
+
 ## Checklist
 
 Use this as a quick reference when starting a replan:
@@ -164,3 +189,4 @@ Use this as a quick reference when starting a replan:
 - [ ] Re-render PLAN.md and run tests
 - [ ] Write lab notebook + project notebook entries with citations
 - [ ] Verify `load_pending_tasks` succeeds on the updated plan
+- [ ] If no pending tasks remain: harvest "Future:" notes from project.md and propose next steps

--- a/lyzortx/orchestration/AGENTS.md
+++ b/lyzortx/orchestration/AGENTS.md
@@ -16,3 +16,10 @@
 - Every pending task in `plan.yml` must have both a `model` field and non-empty `acceptance_criteria`.
 - Done tasks may omit either — they are historical records, not dispatchable work.
 - The orchestrator validates both fields at load time and raises `ValueError` if either is missing on a pending task.
+
+# Task Status Management
+
+- Never manually set a task's `status` to `done` in `plan.yml`. The orchestrator automatically marks tasks as done when
+  their corresponding GitHub issue is closed as completed (via PR merge with `Closes #N`).
+- Agents should only add new tasks or modify pending task fields (acceptance_criteria, model, title). Status transitions
+  are the orchestrator's responsibility.

--- a/lyzortx/orchestration/plan.yml
+++ b/lyzortx/orchestration/plan.yml
@@ -418,6 +418,23 @@ tracks:
         model (~0.837) and the old leaked model (~0.911) without degrading top-3
       - If no candidate closes the gap, accept the 2-block calibration as the honest
         v1 baseline
+    - id: TG12
+      title: Delete soft-leaky training-label-derived features from Track E code
+      status: pending
+      model: gpt-5.4-mini
+      acceptance_criteria:
+      - 'Delete TE02 defense_evasion_* features: remove build_training_family_defense_profiles
+        and build_feature_rows collaborative-filtering logic from
+        build_defense_evasion_proxy_feature_block.py, or delete the file entirely if
+        no clean features remain'
+      - 'Delete TE01 receptor_variant_seen_in_training_positives: remove the
+        exact_variant_seen computation and the column from OUTPUT_FEATURE_COLUMNS in
+        build_rbp_receptor_compatibility_feature_block.py'
+      - Update downstream tests that assert on removed columns
+      - 'Grep lyzortx/ for defense_evasion_expected_score, defense_evasion_mean_score,
+        defense_evasion_supported_subtype_count, defense_evasion_family_training_pair_count,
+        and receptor_variant_seen_in_training_positives — zero hits outside lab notebooks'
+      - All existing tests pass after deletions
   H:
     name: In-Silico Cocktail Recommendation
     description: Top-k recommendations with SHAP-based explanations. TH01/TH02 are
@@ -443,8 +460,8 @@ tracks:
   I:
     name: External Data and Literature Integration
     description: Tier A supervised and Tier B weak-label ingestion with source-fidelity,
-      ablations, and lift tracking. Dead-end track for now — no downstream track depends
-      on I until external data is wired into model training.
+      ablations, and lift tracking. Track K consumes Track I outputs for per-source
+      lift measurement.
     stage: 1
     depends_on:
     - A
@@ -498,6 +515,76 @@ tracks:
         tier
       status: done
       model: gpt-5.4-mini
+  K:
+    name: External Data Lift Measurement
+    description: Incrementally add Track I external sources to the v1 model and measure
+      per-source lift. Each task adds exactly one source, retrains, and reports metrics
+      against the internal-only baseline. This isolates the contribution of each external
+      dataset.
+    stage: 2
+    depends_on:
+    - I
+    - G
+    tasks:
+    - id: TK01
+      title: 'Add VHRdb to training and measure lift vs internal-only baseline'
+      status: pending
+      model: gpt-5.4-mini
+      acceptance_criteria:
+      - Connect TI08 VHRdb cohort rows to Track G training pipeline
+      - Retrain with internal + VHRdb on the locked ST03 holdout split
+      - Report AUC, top-3, Brier delta vs the locked 2-block internal-only baseline
+      - If lift is negative or negligible, document why and do not include VHRdb in
+        subsequent arms
+    - id: TK02
+      title: 'Add BASEL to training and measure cumulative lift'
+      status: pending
+      model: gpt-5.4-mini
+      acceptance_criteria:
+      - Add BASEL rows to the best-so-far cohort (internal-only or internal+VHRdb,
+        depending on TK01 result)
+      - Retrain and report AUC, top-3, Brier delta vs previous best
+      - Document whether BASEL adds, hurts, or is neutral
+    - id: TK03
+      title: 'Add KlebPhaCol to training and measure cumulative lift'
+      status: pending
+      model: gpt-5.4-mini
+      acceptance_criteria:
+      - Add KlebPhaCol rows to the best-so-far cohort
+      - Retrain and report AUC, top-3, Brier delta vs previous best
+      - Document whether KlebPhaCol adds, hurts, or is neutral
+    - id: TK04
+      title: 'Add GPB to training and measure cumulative lift'
+      status: pending
+      model: gpt-5.4-mini
+      acceptance_criteria:
+      - Add GPB rows to the best-so-far cohort
+      - Retrain and report AUC, top-3, Brier delta vs previous best
+      - Document whether GPB adds, hurts, or is neutral
+    - id: TK05
+      title: 'Add Tier B weak labels and measure cumulative lift'
+      status: pending
+      model: gpt-5.4-mini
+      acceptance_criteria:
+      - Add TI07 confidence-weighted Tier B rows to the best-so-far cohort
+      - Retrain and report AUC, top-3, Brier delta vs previous best
+      - Document whether Tier B adds, hurts, or is neutral
+      - If any source combination improved metrics, propose a new locked config;
+        otherwise keep internal-only as the v1 baseline
+    - id: TK06
+      title: Synthesize per-source lift results and lock the external data decision
+      status: pending
+      model: gpt-5.4
+      acceptance_criteria:
+      - Summarize TK01-TK05 results in a single comparison table (source, delta AUC,
+        delta top-3, delta Brier vs internal-only baseline)
+      - Identify the best-performing source combination (may be internal-only if nothing
+        helped)
+      - If external data earned inclusion, update v1_feature_configuration.json with the
+        new locked config and retrain the final model
+      - If no external source improved metrics, document the finding and confirm
+        internal-only remains the v1 baseline
+      - Write a project notebook entry with the final decision and rationale
   J:
     name: Reproducibility and Release Quality
     description: One-command regeneration and environment freezing for v1 pipeline.

--- a/lyzortx/research_notes/AGENTS.md
+++ b/lyzortx/research_notes/AGENTS.md
@@ -31,6 +31,10 @@ or restructured, and why). Include source citations (URLs + quotes) for any clai
 - Subsequent sections typically include: problem statement, design decisions, interpretation, and next steps.
 - Entries should reference generated output paths and script paths so findings are traceable.
 - Do not list files changed — that is what git is for.
+- **"Future:" notes** — When an agent discovers something worth revisiting later (a deferred cleanup, a tool adoption
+  trigger, a feature idea), add a section to `project.md` with a heading starting with `#### Future:`. Include the
+  trigger condition ("revisit when...") so the `/replan` skill can evaluate whether the condition is now met. These notes
+  are seeds for future plan tasks — they should be concrete enough to act on, not vague aspirations.
 
 ## Other contents
 

--- a/lyzortx/research_notes/PLAN.md
+++ b/lyzortx/research_notes/PLAN.md
@@ -23,6 +23,7 @@ graph LR
     tf["Track F: Evaluation Protocol"]
     tg["Track G: Modeling Pipeline"]
     th["Track H: In-Silico Cocktail Recommendation"]
+    tk["Track K: External Data Lift Measurement"]
   end
 
   subgraph s3["Stage 3 (Release and Audit)"]
@@ -40,6 +41,8 @@ graph LR
   te --> tg
   tg --> th
   ta --> ti
+  ti --> tk
+  tg --> tk
   tg --> tj
 ```
 
@@ -274,6 +277,17 @@ graph LR
   - Report whether any candidate recovers >50% of the AUC gap between the 2-block model (~0.837) and the old leaked
     model (~0.911) without degrading top-3
   - If no candidate closes the gap, accept the 2-block calibration as the honest v1 baseline
+- [ ] **TG12** Delete soft-leaky training-label-derived features from Track E code. Model: `gpt-5.4-mini`.
+  - Delete TE02 defense_evasion_* features: remove build_training_family_defense_profiles and build_feature_rows
+    collaborative-filtering logic from build_defense_evasion_proxy_feature_block.py, or delete the file entirely if no
+    clean features remain
+  - Delete TE01 receptor_variant_seen_in_training_positives: remove the exact_variant_seen computation and the column
+    from OUTPUT_FEATURE_COLUMNS in build_rbp_receptor_compatibility_feature_block.py
+  - Update downstream tests that assert on removed columns
+  - Grep lyzortx/ for defense_evasion_expected_score, defense_evasion_mean_score,
+    defense_evasion_supported_subtype_count, defense_evasion_family_training_pair_count, and
+    receptor_variant_seen_in_training_positives — zero hits outside lab notebooks
+  - All existing tests pass after deletions
 
 ## Track H: In-Silico Cocktail Recommendation
 
@@ -288,7 +302,7 @@ graph LR
 ## Track I: External Data and Literature Integration
 
 - **Guiding Principle:** Tier A supervised and Tier B weak-label ingestion with source-fidelity, ablations, and lift
-  tracking. Dead-end track for now — no downstream track depends on I until external data is wired into model training.
+  tracking. Track K consumes Track I outputs for per-source lift measurement.
 - [x] **TI01** Create a curated reading list of closely related phage-host prediction papers. Implemented in
       `lyzortx/research_notes/LITERATURE.md`.
 - [x] **TI02** Build source_registry.csv for all external sources. Implemented in
@@ -306,6 +320,43 @@ graph LR
 - [x] **TI09** Run strict ablations in sequence: internal-only -> +VHRdb -> +BASEL -> +KlebPhaCol -> +GPB -> +Tier B.
       Model: `gpt-5.4-mini`.
 - [x] **TI10** Track incremental lift and failure modes by datasource and confidence tier. Model: `gpt-5.4-mini`.
+
+## Track K: External Data Lift Measurement
+
+- **Guiding Principle:** Incrementally add Track I external sources to the v1 model and measure per-source lift. Each
+  task adds exactly one source, retrains, and reports metrics against the internal-only baseline. This isolates the
+  contribution of each external dataset.
+- [ ] **TK01** Add VHRdb to training and measure lift vs internal-only baseline. Model: `gpt-5.4-mini`.
+  - Connect TI08 VHRdb cohort rows to Track G training pipeline
+  - Retrain with internal + VHRdb on the locked ST03 holdout split
+  - Report AUC, top-3, Brier delta vs the locked 2-block internal-only baseline
+  - If lift is negative or negligible, document why and do not include VHRdb in subsequent arms
+- [ ] **TK02** Add BASEL to training and measure cumulative lift. Model: `gpt-5.4-mini`.
+  - Add BASEL rows to the best-so-far cohort (internal-only or internal+VHRdb, depending on TK01 result)
+  - Retrain and report AUC, top-3, Brier delta vs previous best
+  - Document whether BASEL adds, hurts, or is neutral
+- [ ] **TK03** Add KlebPhaCol to training and measure cumulative lift. Model: `gpt-5.4-mini`.
+  - Add KlebPhaCol rows to the best-so-far cohort
+  - Retrain and report AUC, top-3, Brier delta vs previous best
+  - Document whether KlebPhaCol adds, hurts, or is neutral
+- [ ] **TK04** Add GPB to training and measure cumulative lift. Model: `gpt-5.4-mini`.
+  - Add GPB rows to the best-so-far cohort
+  - Retrain and report AUC, top-3, Brier delta vs previous best
+  - Document whether GPB adds, hurts, or is neutral
+- [ ] **TK05** Add Tier B weak labels and measure cumulative lift. Model: `gpt-5.4-mini`.
+  - Add TI07 confidence-weighted Tier B rows to the best-so-far cohort
+  - Retrain and report AUC, top-3, Brier delta vs previous best
+  - Document whether Tier B adds, hurts, or is neutral
+  - If any source combination improved metrics, propose a new locked config; otherwise keep internal-only as the v1
+    baseline
+- [ ] **TK06** Synthesize per-source lift results and lock the external data decision. Model: `gpt-5.4`.
+  - Summarize TK01-TK05 results in a single comparison table (source, delta AUC, delta top-3, delta Brier vs
+    internal-only baseline)
+  - Identify the best-performing source combination (may be internal-only if nothing helped)
+  - If external data earned inclusion, update v1_feature_configuration.json with the new locked config and retrain the
+    final model
+  - If no external source improved metrics, document the finding and confirm internal-only remains the v1 baseline
+  - Write a project notebook entry with the final decision and rationale
 
 ## Track J: Reproducibility and Release Quality
 


### PR DESCRIPTION
## Summary

- **TG12**: Delete soft-leaky TE02/TE01 training-label-derived features from Track E code (gpt-5.4-mini)
- **Track K** (new): Incrementally add each Track I external source to training and measure per-source lift
  - TK01-TK05: Add VHRdb, BASEL, KlebPhaCol, GPB, Tier B one at a time, retrain, report delta vs internal-only baseline
  - TK06: Synthesize results, lock the external data decision (gpt-5.4)
- Track I no longer a dead end — Track K consumes its outputs
- Replan skill: add Phase 6 (suggest next steps, harvest future notes), no presentation task suggestions
- orchestration/AGENTS.md: never manually set task status to done — orchestrator owns status transitions
- research_notes/AGENTS.md: add "Future:" note convention for project.md

## Test plan

- [x] 275 tests pass
- [x] `load_pending_tasks` loads all 7 pending tasks (TG12, TK01-TK06)
- [x] PLAN.md re-rendered
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)