### PR TITLE
Restore done-task criteria modified by TG12, add immutability rule

### DIFF
--- a/.agents/skills/gh/SKILL.md
+++ b/.agents/skills/gh/SKILL.md
@@ -181,6 +181,17 @@ reports, or abandoned review workflows when checks are simply still running.
 **How to handle:** When exit code is 8, report the status honestly ("checks still running" or "some checks skipped")
 and move on. Do not retry or treat it as a blocker unless you specifically need all checks green.
 
+## 9. `gh pr view --json` field names
+
+**The rule:** The `--json` flag on `gh pr view` only accepts specific field names. Common mistakes:
+
+- `diffStat` does not exist — use `additions` and `deletions` separately
+- `diff` does not exist — use `gh pr diff <number>` instead (separate command)
+- `files` returns the list of changed files with patch data
+
+**How to discover valid fields:** Run `gh pr view --json invalid` and read the error message — it lists all available
+fields.
+
 ## Quick self-check before running
 
 Before executing any `gh` command that sets `--body`:

--- a/lyzortx/orchestration/AGENTS.md
+++ b/lyzortx/orchestration/AGENTS.md
@@ -23,3 +23,11 @@
   their corresponding GitHub issue is closed as completed (via PR merge with `Closes #N`).
 - Agents should only add new tasks or modify pending task fields (acceptance_criteria, model, title). Status transitions
   are the orchestrator's responsibility.
+
+# Done Task Immutability
+
+- Never modify the title, acceptance_criteria, or any other field on a done task. Done tasks are historical records —
+  they document what was originally required, not the current state of the code.
+- If a later task changes the codebase in ways that make a done task's criteria look stale (e.g., deleting features that
+  a done task created), that is expected. The done task records what was true when it was completed; the later task
+  records what changed. Git history tells the full story.

--- a/lyzortx/orchestration/plan.yml
+++ b/lyzortx/orchestration/plan.yml
@@ -227,15 +227,19 @@ tracks:
       status: done
       acceptance_criteria:
       - Curated lookup mapping phage genus/subfamily to known primary receptor targets
-      - Per-pair features include target_receptor_present and receptor_cluster_matches
-      - Output CSV joinable on bacteria+phage pair with ~4-5 features
+      - Per-pair features include target_receptor_present, receptor_cluster_matches,
+        receptor_variant_seen_in_training_positives
+      - Output CSV joinable on bacteria+phage pair with ~5-8 features
     - id: TE02
-      title: Legacy soft-leaky pairwise block removed from the Track E code path
+      title: Build defense evasion proxy features from training-fold collaborative
+        filtering
       status: done
       acceptance_criteria:
-      - Legacy training-label-derived pairwise features removed from the codebase
-      - No Track E step emits the removed defense-family proxy block
-      - Downstream consumers and tests use the remaining clean pairwise features
+      - For each phage family, compute average lysis rate against each defense subtype
+        from training data only
+      - Per-pair expected evasion score computed as sum of phage family success rates
+        against host defense systems
+      - Leakage verified by computing on training fold only, never holdout
     - id: TE03
       title: Build phylogenetic distance to isolation host features
       status: done
@@ -402,9 +406,9 @@ tracks:
       status: done
       model: gpt-5.4
       acceptance_criteria:
-      - 'Pairwise soft leakage context: legacy family-by-defense features and the
-        exact-variant flag are training-label-derived via collaborative filtering.
-        Do not include these in candidate features.'
+      - 'Pairwise soft leakage context: TE02 defense_evasion_* features (4) and TE01
+        receptor_variant_seen_in_training_positives (1) are training-label-derived
+        via collaborative filtering. Do not include these in candidate features.'
       - 'Clean pairwise candidates to evaluate individually: TE03 isolation_host distances
         (2 features) and TE01 curated lookup features (lookup_available, target_receptor_present,
         protein_target_present, surface_target_present, receptor_cluster_matches)'

--- a/lyzortx/research_notes/PLAN.md
+++ b/lyzortx/research_notes/PLAN.md
@@ -165,12 +165,13 @@ graph LR
   break the popular-phage bias.
 - [x] **TE01** Build RBP-receptor compatibility features from curated genus-receptor lookup
   - Curated lookup mapping phage genus/subfamily to known primary receptor targets
-  - Per-pair features include target_receptor_present and receptor_cluster_matches
-  - Output CSV joinable on bacteria+phage pair with ~4-5 features
-- [x] **TE02** Legacy soft-leaky pairwise block removed from the Track E code path
-  - Legacy training-label-derived pairwise features removed from the codebase
-  - No Track E step emits the removed defense-family proxy block
-  - Downstream consumers and tests use the remaining clean pairwise features
+  - Per-pair features include target_receptor_present, receptor_cluster_matches,
+    receptor_variant_seen_in_training_positives
+  - Output CSV joinable on bacteria+phage pair with ~5-8 features
+- [x] **TE02** Build defense evasion proxy features from training-fold collaborative filtering
+  - For each phage family, compute average lysis rate against each defense subtype from training data only
+  - Per-pair expected evasion score computed as sum of phage family success rates against host defense systems
+  - Leakage verified by computing on training fold only, never holdout
 - [x] **TE03** Build phylogenetic distance to isolation host features
   - UMAP Euclidean distance between target host and phage isolation host
   - Defense Jaccard distance between target host and phage isolation host
@@ -265,8 +266,9 @@ graph LR
   - Run python -m lyzortx.pipeline.track_j.run_track_j end-to-end and verify it completes without error
   - Verify v1_feature_configuration.json is unchanged after the Track J run (sweep no longer regenerates it)
 - [x] **TG11** Investigate non-leaky features that close the calibration gap. Model: `gpt-5.4`.
-  - Pairwise soft leakage context: legacy family-by-defense features and the exact-variant flag are
-    training-label-derived via collaborative filtering. Do not include these in candidate features.
+  - Pairwise soft leakage context: TE02 defense_evasion_* features (4) and TE01
+    receptor_variant_seen_in_training_positives (1) are training-label-derived via collaborative filtering. Do not
+    include these in candidate features.
   - Clean pairwise candidates to evaluate individually: TE03 isolation_host distances (2 features) and TE01 curated
     lookup features (lookup_available, target_receptor_present, protein_target_present, surface_target_present,
     receptor_cluster_matches)


### PR DESCRIPTION
## Summary

- Restore original acceptance criteria on TE01, TE02, and TG11 that were retroactively rewritten by TG12 (PR #204)
- Done tasks are historical records — they document what was originally required, not the current code state
- Add "Done Task Immutability" rule to `lyzortx/orchestration/AGENTS.md`
- Add `gh pr view --json` field name guidance to gh skill (`diffStat` doesn't exist, use `additions`/`deletions`)

## Test plan

- [x] 273 tests pass
- [x] PLAN.md re-rendered
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)