### PR TITLE
[ORCH][TK02] Add BASEL cumulative lift measurement

### DIFF
--- a/lyzortx/pipeline/track_k/run_track_k.py
+++ b/lyzortx/pipeline/track_k/run_track_k.py
@@ -11,6 +11,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.track_k.steps import build_basel_lift_report
 from lyzortx.pipeline.track_k.steps import build_vhrdb_lift_report
 
 
@@ -18,9 +19,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--step",
-        choices=["vhrdb-lift", "all"],
+        choices=["vhrdb-lift", "basel-lift", "all"],
         default="all",
-        help="Track K step to run. 'all' runs the implemented lift-measurement step.",
+        help="Track K step to run. 'all' runs the implemented lift-measurement steps.",
     )
     return parser.parse_args(argv)
 
@@ -30,6 +31,8 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
     if args.step in {"vhrdb-lift", "all"}:
         build_vhrdb_lift_report.main([])
+    if args.step in {"basel-lift", "all"}:
+        build_basel_lift_report.main([])
 
 
 if __name__ == "__main__":

--- a/lyzortx/pipeline/track_k/steps/__init__.py
+++ b/lyzortx/pipeline/track_k/steps/__init__.py
@@ -1,3 +1,4 @@
 """Track K step modules."""
 
+from . import build_basel_lift_report as build_basel_lift_report
 from . import build_vhrdb_lift_report as build_vhrdb_lift_report

--- a/lyzortx/pipeline/track_k/steps/build_basel_lift_report.py
+++ b/lyzortx/pipeline/track_k/steps/build_basel_lift_report.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""TK02: Measure the cumulative lift from adding BASEL supervision."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
+from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import (
+    IDENTIFIER_COLUMNS,
+    FeatureSpace,
+    build_feature_space,
+    build_top3_ranking_rows,
+    compute_binary_metrics,
+    compute_top3_hit_rate,
+    fit_final_estimator,
+    make_lightgbm_estimator,
+    merge_expanded_feature_rows,
+)
+from lyzortx.pipeline.track_k.steps.build_source_lift_helpers import (
+    arm_name_for_source_systems,
+    build_locked_feature_space,
+    build_training_rows,
+    classify_lift,
+    load_locked_v1_feature_config,
+    load_previous_best_source_systems,
+    load_source_training_rows,
+    load_tg01_best_params,
+    sha256,
+    source_systems_label,
+    write_output_tables,
+)
+
+logger = logging.getLogger(__name__)
+
+LOCKED_V1_FEATURE_CONFIG_PATH = Path("lyzortx/pipeline/track_g/v1_feature_configuration.json")
+TG01_SUMMARY_PATH = Path("lyzortx/generated_outputs/track_g/tg01_v1_binary_classifier/tg01_model_summary.json")
+TK01_MANIFEST_PATH = Path("lyzortx/generated_outputs/track_k/tk01_vhrdb_lift_measurement/tk01_vhrdb_lift_manifest.json")
+TI08_TRAINING_COHORT_PATH = Path(
+    "lyzortx/generated_outputs/track_i/training_cohort_integration/ti08_training_cohort_rows.csv"
+)
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/track_k/tk02_basel_lift_measurement")
+CURRENT_SOURCE_SYSTEM = "basel"
+TRAIN_SPLIT = "train_non_holdout"
+NEGLIGIBLE_DELTA_TOLERANCE = 0.001
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--st02-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st02_pair_table.csv"),
+    )
+    parser.add_argument(
+        "--st03-split-assignments-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_assignments.csv"),
+    )
+    parser.add_argument(
+        "--track-c-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_c/v1_host_feature_pair_table/pair_table_v1.csv"),
+    )
+    parser.add_argument(
+        "--track-d-genome-kmer-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_d/phage_genome_kmer_features/phage_genome_kmer_features.csv"),
+    )
+    parser.add_argument(
+        "--track-d-distance-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_d/phage_distance_embedding/phage_distance_embedding_features.csv"
+        ),
+    )
+    parser.add_argument(
+        "--track-e-rbp-compatibility-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_e/rbp_receptor_compatibility_feature_block/"
+            "rbp_receptor_compatibility_features_v1.csv"
+        ),
+    )
+    parser.add_argument(
+        "--track-e-isolation-distance-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_e/isolation_host_distance_feature_block/"
+            "isolation_host_distance_features_v1.csv"
+        ),
+    )
+    parser.add_argument("--v1-feature-config-path", type=Path, default=LOCKED_V1_FEATURE_CONFIG_PATH)
+    parser.add_argument("--tg01-summary-path", type=Path, default=TG01_SUMMARY_PATH)
+    parser.add_argument("--tk01-manifest-path", type=Path, default=TK01_MANIFEST_PATH)
+    parser.add_argument("--ti08-training-cohort-path", type=Path, default=TI08_TRAINING_COHORT_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--skip-prerequisites", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _delta(value: Optional[float], baseline: Optional[float]) -> Optional[float]:
+    if value is None or baseline is None:
+        return None
+    return safe_round(value - baseline)
+
+
+def _trainable_rows(rows: Sequence[Mapping[str, object]]) -> List[Mapping[str, object]]:
+    return [row for row in rows if row["split_holdout"] == TRAIN_SPLIT and str(row["is_hard_trainable"]) == "1"]
+
+
+def _measure_metrics(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    feature_space: FeatureSpace,
+    estimator_factory,
+    params: Mapping[str, object],
+) -> tuple[List[Dict[str, object]], Dict[str, object], Dict[str, object]]:
+    _, _, _, eval_rows, probabilities = fit_final_estimator(
+        rows,
+        feature_space,
+        estimator_factory=estimator_factory,
+        params=params,
+    )
+    scored_rows: List[Dict[str, object]] = []
+    for row, probability in zip(eval_rows, probabilities):
+        scored = dict(row)
+        scored["probability"] = probability
+        scored_rows.append(scored)
+    holdout_metrics = compute_binary_metrics(
+        [int(str(row["label_hard_any_lysis"])) for row in scored_rows],
+        [float(row["probability"]) for row in scored_rows],
+    )
+    top3 = compute_top3_hit_rate(scored_rows, probability_key="probability")
+    return scored_rows, holdout_metrics, top3
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_args(argv)
+    logger.info("TK02 starting: measure BASEL lift against the best-so-far Track K cohort")
+
+    ensure_directory(args.output_dir)
+
+    if not args.skip_prerequisites:
+        from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import ensure_prerequisite_outputs
+
+        ensure_prerequisite_outputs(args)
+
+    st02_rows = read_csv_rows(args.st02_pair_table_path)
+    split_rows = read_csv_rows(args.st03_split_assignments_path)
+    track_c_pair_rows = read_csv_rows(args.track_c_pair_table_path)
+    track_d_genome_rows = read_csv_rows(args.track_d_genome_kmer_path)
+    track_d_distance_rows = read_csv_rows(args.track_d_distance_path)
+    track_e_rbp_rows = read_csv_rows(args.track_e_rbp_compatibility_path)
+    track_e_isolation_rows = read_csv_rows(args.track_e_isolation_distance_path)
+
+    locked_config = load_locked_v1_feature_config(args.v1_feature_config_path)
+    locked_subset_blocks = tuple(str(block) for block in locked_config["winner_subset_blocks"])
+    tg01_best_params = load_tg01_best_params(args.tg01_summary_path)
+    baseline_params_source = "tg01_summary_lock"
+
+    track_d_feature_columns = tuple(
+        dict.fromkeys(
+            [column for column in track_d_genome_rows[0].keys() if column != "phage"]
+            + [column for column in track_d_distance_rows[0].keys() if column != "phage"]
+        )
+    )
+    track_e_feature_columns = tuple(
+        dict.fromkeys(
+            [column for column in track_e_rbp_rows[0].keys() if column not in IDENTIFIER_COLUMNS]
+            + [column for column in track_e_isolation_rows[0].keys() if column not in IDENTIFIER_COLUMNS]
+        )
+    )
+    full_feature_space = build_feature_space(
+        st02_rows, track_c_pair_rows, track_d_feature_columns, track_e_feature_columns
+    )
+    locked_feature_space = build_locked_feature_space(full_feature_space, locked_subset_blocks)
+
+    merged_rows = merge_expanded_feature_rows(
+        track_c_pair_rows,
+        split_rows,
+        phage_feature_blocks=(track_d_genome_rows, track_d_distance_rows),
+        pair_feature_blocks=(track_e_rbp_rows, track_e_isolation_rows),
+    )
+    cohort_rows = read_csv_rows(args.ti08_training_cohort_path) if args.ti08_training_cohort_path.exists() else []
+
+    source_rows_by_system: Dict[str, List[Dict[str, object]]] = {}
+    current_source_rows, current_source_counts = load_source_training_rows(
+        merged_rows,
+        cohort_rows,
+        CURRENT_SOURCE_SYSTEM,
+    )
+    source_rows_by_system[CURRENT_SOURCE_SYSTEM] = current_source_rows
+    previous_best_source_systems = load_previous_best_source_systems(args.tk01_manifest_path)
+    for source_system in previous_best_source_systems:
+        if source_system not in source_rows_by_system:
+            source_rows_by_system[source_system], _ = load_source_training_rows(merged_rows, cohort_rows, source_system)
+
+    base_source_systems = ["internal", *previous_best_source_systems]
+    augmented_source_systems = [*base_source_systems, CURRENT_SOURCE_SYSTEM]
+
+    internal_training_rows = list(merged_rows)
+    base_training_rows = build_training_rows(internal_training_rows, source_rows_by_system, base_source_systems)
+    augmented_training_rows = build_training_rows(
+        internal_training_rows,
+        source_rows_by_system,
+        augmented_source_systems,
+    )
+
+    estimator_factory = lambda params, seed_offset: make_lightgbm_estimator(  # noqa: E731
+        params,
+        seed_offset,
+        base_random_state=args.random_state,
+    )
+
+    baseline_rows, baseline_holdout_metrics, baseline_top3 = _measure_metrics(
+        base_training_rows,
+        feature_space=locked_feature_space,
+        estimator_factory=estimator_factory,
+        params=tg01_best_params,
+    )
+    augmented_rows, augmented_holdout_metrics, augmented_top3 = _measure_metrics(
+        augmented_training_rows,
+        feature_space=locked_feature_space,
+        estimator_factory=estimator_factory,
+        params=tg01_best_params,
+    )
+
+    metric_deltas = {
+        "delta_roc_auc": _delta(augmented_holdout_metrics["roc_auc"], baseline_holdout_metrics["roc_auc"]),
+        "delta_top3_hit_rate_all_strains": _delta(
+            float(augmented_top3["top3_hit_rate_all_strains"]),
+            float(baseline_top3["top3_hit_rate_all_strains"]),
+        ),
+        "delta_brier_score": _delta(augmented_holdout_metrics["brier_score"], baseline_holdout_metrics["brier_score"]),
+    }
+    lift_assessment = classify_lift(
+        delta_roc_auc=metric_deltas["delta_roc_auc"],
+        delta_top3=metric_deltas["delta_top3_hit_rate_all_strains"],
+        delta_brier=metric_deltas["delta_brier_score"],
+        tolerance=NEGLIGIBLE_DELTA_TOLERANCE,
+    )
+
+    summary_rows = [
+        {
+            "arm": arm_name_for_source_systems(base_source_systems),
+            "source_systems": source_systems_label(base_source_systems),
+            "training_row_count": len(_trainable_rows(base_training_rows)),
+            "basel_row_count": 0,
+            "holdout_roc_auc": baseline_holdout_metrics["roc_auc"],
+            "holdout_top3_hit_rate_all_strains": baseline_top3["top3_hit_rate_all_strains"],
+            "holdout_brier_score": baseline_holdout_metrics["brier_score"],
+            "delta_roc_auc_vs_previous_best": 0.0,
+            "delta_top3_vs_previous_best": 0.0,
+            "delta_brier_vs_previous_best": 0.0,
+        },
+        {
+            "arm": arm_name_for_source_systems(augmented_source_systems),
+            "source_systems": source_systems_label(augmented_source_systems),
+            "training_row_count": len(_trainable_rows(augmented_training_rows)),
+            "basel_row_count": len(current_source_rows),
+            "holdout_roc_auc": augmented_holdout_metrics["roc_auc"],
+            "holdout_top3_hit_rate_all_strains": augmented_top3["top3_hit_rate_all_strains"],
+            "holdout_brier_score": augmented_holdout_metrics["brier_score"],
+            "delta_roc_auc_vs_previous_best": metric_deltas["delta_roc_auc"],
+            "delta_top3_vs_previous_best": metric_deltas["delta_top3_hit_rate_all_strains"],
+            "delta_brier_vs_previous_best": metric_deltas["delta_brier_score"],
+        },
+    ]
+
+    summary_filename = "tk02_basel_lift_summary.csv"
+    rankings_filename = "tk02_basel_holdout_top3_rankings.csv"
+    manifest_path = args.output_dir / "tk02_basel_lift_manifest.json"
+
+    ranking_rows = [
+        *build_top3_ranking_rows(
+            baseline_rows,
+            probability_key="probability",
+            model_label=arm_name_for_source_systems(base_source_systems),
+        ),
+        *build_top3_ranking_rows(
+            augmented_rows,
+            probability_key="probability",
+            model_label=arm_name_for_source_systems(augmented_source_systems),
+        ),
+    ]
+
+    write_output_tables(
+        output_dir=args.output_dir,
+        summary_rows=summary_rows,
+        summary_fieldnames=[
+            "arm",
+            "source_systems",
+            "training_row_count",
+            "basel_row_count",
+            "holdout_roc_auc",
+            "holdout_top3_hit_rate_all_strains",
+            "holdout_brier_score",
+            "delta_roc_auc_vs_previous_best",
+            "delta_top3_vs_previous_best",
+            "delta_brier_vs_previous_best",
+        ],
+        ranking_rows=ranking_rows,
+        ranking_fieldnames=[
+            "model_label",
+            "bacteria",
+            "phage",
+            "pair_id",
+            "rank",
+            "predicted_probability",
+            "label_hard_any_lysis",
+        ],
+        manifest_path=manifest_path,
+        manifest_payload={
+            "generated_at_utc": datetime.now(tz=timezone.utc).isoformat(),
+            "step_name": "build_basel_lift_report",
+            "source_system_added": CURRENT_SOURCE_SYSTEM,
+            "locked_feature_config_path": str(args.v1_feature_config_path),
+            "locked_feature_config_sha256": sha256(args.v1_feature_config_path),
+            "tg01_best_params_source": baseline_params_source,
+            "tg01_best_params": tg01_best_params,
+            "input_paths": {
+                "st02_pair_table": str(args.st02_pair_table_path),
+                "st03_split_assignments": str(args.st03_split_assignments_path),
+                "track_c_pair_table": str(args.track_c_pair_table_path),
+                "track_d_genome_kmers": str(args.track_d_genome_kmer_path),
+                "track_d_distance": str(args.track_d_distance_path),
+                "track_e_rbp_receptor_compatibility": str(args.track_e_rbp_compatibility_path),
+                "track_e_isolation_host_distance": str(args.track_e_isolation_distance_path),
+                "ti08_training_cohort_rows": str(args.ti08_training_cohort_path),
+                "tk01_manifest": str(args.tk01_manifest_path),
+            },
+            "input_hashes_sha256": {
+                "st02_pair_table": sha256(args.st02_pair_table_path),
+                "st03_split_assignments": sha256(args.st03_split_assignments_path),
+                "track_c_pair_table": sha256(args.track_c_pair_table_path),
+                "track_d_genome_kmers": sha256(args.track_d_genome_kmer_path),
+                "track_d_distance": sha256(args.track_d_distance_path),
+                "track_e_rbp_receptor_compatibility": sha256(args.track_e_rbp_compatibility_path),
+                "track_e_isolation_host_distance": sha256(args.track_e_isolation_distance_path),
+                **(
+                    {"ti08_training_cohort_rows": sha256(args.ti08_training_cohort_path)}
+                    if args.ti08_training_cohort_path.exists()
+                    else {}
+                ),
+                **({"tk01_manifest": sha256(args.tk01_manifest_path)} if args.tk01_manifest_path.exists() else {}),
+            },
+            "previous_best_source_systems": previous_best_source_systems,
+            "base_source_systems": base_source_systems,
+            "augmented_source_systems": augmented_source_systems,
+            "source_rows_by_system": {
+                source_system: len(rows) for source_system, rows in source_rows_by_system.items()
+            },
+            "current_source_counts": current_source_counts,
+            "baseline_metrics": {
+                "roc_auc": baseline_holdout_metrics["roc_auc"],
+                "top3_hit_rate_all_strains": baseline_top3["top3_hit_rate_all_strains"],
+                "brier_score": baseline_holdout_metrics["brier_score"],
+            },
+            "augmented_metrics": {
+                "roc_auc": augmented_holdout_metrics["roc_auc"],
+                "top3_hit_rate_all_strains": augmented_top3["top3_hit_rate_all_strains"],
+                "brier_score": augmented_holdout_metrics["brier_score"],
+            },
+            "metric_deltas": metric_deltas,
+            "lift_assessment": lift_assessment,
+            "output_paths": {
+                "summary": str(args.output_dir / summary_filename),
+                "holdout_rankings": str(args.output_dir / rankings_filename),
+            },
+        },
+        summary_filename=summary_filename,
+        rankings_filename=rankings_filename,
+    )
+
+    logger.info("TK02 completed.")
+    logger.info("- Previous best arm: %s", arm_name_for_source_systems(base_source_systems))
+    logger.info("- Augmented arm: %s", arm_name_for_source_systems(augmented_source_systems))
+    logger.info("- Delta ROC-AUC: %s", metric_deltas["delta_roc_auc"])
+    logger.info("- Delta top-3: %s", metric_deltas["delta_top3_hit_rate_all_strains"])
+    logger.info("- Delta Brier: %s", metric_deltas["delta_brier_score"])
+    logger.info("- BASEL rows joined: %s", len(current_source_rows))
+    logger.info("- Lift assessment: %s", lift_assessment)

--- a/lyzortx/pipeline/track_k/steps/build_source_lift_helpers.py
+++ b/lyzortx/pipeline/track_k/steps/build_source_lift_helpers.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Shared helpers for Track K cumulative lift measurements."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
+from lyzortx.pipeline.steel_thread_v0.steps.st04_train_baselines import (
+    CATEGORICAL_FEATURE_COLUMNS as V0_CATEGORICAL_FEATURE_COLUMNS,
+)
+from lyzortx.pipeline.steel_thread_v0.steps.st04_train_baselines import (
+    NUMERIC_FEATURE_COLUMNS as V0_NUMERIC_FEATURE_COLUMNS,
+)
+from lyzortx.pipeline.track_g.steps.run_feature_subset_sweep import build_feature_blocks
+from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import FeatureSpace
+from lyzortx.pipeline.track_i.steps.build_external_training_cohorts import (
+    TRAINING_ARM_INDEX,
+    first_training_arm_for_source,
+    source_family_for_source,
+)
+
+
+def _normalize_row(row: Mapping[str, str]) -> Dict[str, str]:
+    return {key: (value.strip() if isinstance(value, str) else "") for key, value in row.items()}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_locked_v1_feature_config(path: Path) -> Dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_tg01_best_params(path: Path) -> Dict[str, object]:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing locked TG01 summary artifact: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        summary = json.load(handle)
+    return dict(summary["lightgbm"]["best_params"])
+
+
+def build_locked_feature_space(feature_space: FeatureSpace, locked_subset_blocks: Sequence[str]) -> FeatureSpace:
+    blocks = build_feature_blocks(feature_space)
+    categorical_columns = list(V0_CATEGORICAL_FEATURE_COLUMNS)
+    numeric_columns = list(V0_NUMERIC_FEATURE_COLUMNS)
+    for block_id in locked_subset_blocks:
+        block = blocks[block_id]
+        categorical_columns.extend(block.categorical_columns)
+        numeric_columns.extend(block.numeric_columns)
+    return FeatureSpace(
+        categorical_columns=tuple(dict.fromkeys(categorical_columns)),
+        numeric_columns=tuple(dict.fromkeys(numeric_columns)),
+        track_c_additional_columns=tuple(feature_space.track_c_additional_columns),
+        track_d_columns=tuple(feature_space.track_d_columns),
+        track_e_columns=tuple(feature_space.track_e_columns),
+    )
+
+
+def load_source_training_rows(
+    feature_rows: Sequence[Mapping[str, object]],
+    cohort_rows: Sequence[Mapping[str, str]],
+    source_system: str,
+) -> Tuple[List[Dict[str, object]], Dict[str, int]]:
+    feature_rows_by_pair = {str(row["pair_id"]): dict(row) for row in feature_rows}
+    augmented_rows: List[Dict[str, object]] = []
+    counts = Counter(
+        {
+            "cohort_rows": 0,
+            "joined_rows": 0,
+            "missing_feature_rows": 0,
+            "excluded_rows": 0,
+            "non_training_split_rows": 0,
+        }
+    )
+
+    for row in cohort_rows:
+        normalized = _normalize_row(row)
+        if normalized.get("source_system") != source_system:
+            continue
+        counts["cohort_rows"] += 1
+        if normalized.get("external_label_include_in_training") != "1":
+            counts["excluded_rows"] += 1
+            continue
+
+        feature_row = feature_rows_by_pair.get(normalized["pair_id"])
+        if feature_row is None:
+            counts["missing_feature_rows"] += 1
+            continue
+        if (
+            feature_row.get("split_holdout") != "train_non_holdout"
+            or str(feature_row.get("is_hard_trainable", "")) != "1"
+        ):
+            counts["non_training_split_rows"] += 1
+            continue
+
+        merged = dict(feature_row)
+        merged.update(
+            {
+                "source_system": source_system,
+                "source_family": source_family_for_source(source_system),
+                "external_label_confidence_tier": normalized.get("external_label_confidence_tier", ""),
+                "external_label_confidence_score": normalized.get("external_label_confidence_score", ""),
+                "external_label_training_weight": normalized.get("external_label_training_weight", ""),
+                "external_label_include_in_training": normalized.get("external_label_include_in_training", ""),
+                "integration_status": "external_enhancer",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": -1,
+                "is_hard_trainable": "1",
+                "training_origin": source_system,
+                "first_training_arm": first_training_arm_for_source(source_system),
+                "first_training_arm_index": TRAINING_ARM_INDEX[first_training_arm_for_source(source_system)],
+                "effective_training_weight": float(normalized.get("external_label_training_weight", "0") or 0.0),
+            }
+        )
+        if normalized.get("label_hard_any_lysis", ""):
+            merged["label_hard_any_lysis"] = normalized["label_hard_any_lysis"]
+        if normalized.get("label_strict_confidence_tier", ""):
+            merged["label_strict_confidence_tier"] = normalized["label_strict_confidence_tier"]
+        augmented_rows.append(merged)
+        counts["joined_rows"] += 1
+
+    return augmented_rows, dict(counts)
+
+
+def canonical_source_systems(source_systems: Sequence[str]) -> Tuple[str, ...]:
+    ordered: List[str] = []
+    for source_system in source_systems:
+        if source_system not in ordered:
+            ordered.append(source_system)
+    return tuple(ordered)
+
+
+def source_systems_label(source_systems: Sequence[str]) -> str:
+    return "|".join(canonical_source_systems(source_systems))
+
+
+def arm_name_for_source_systems(source_systems: Sequence[str]) -> str:
+    canonical = canonical_source_systems(source_systems)
+    if canonical == ("internal",):
+        return "internal_only"
+    if canonical and canonical[0] == "internal":
+        return "internal_plus_" + "_plus_".join(canonical[1:])
+    return "_plus_".join(canonical)
+
+
+def build_training_rows(
+    merged_rows: Sequence[Mapping[str, object]],
+    source_rows_by_system: Mapping[str, Sequence[Mapping[str, object]]],
+    source_systems: Sequence[str],
+) -> List[Mapping[str, object]]:
+    training_rows = list(merged_rows)
+    for source_system in canonical_source_systems(source_systems):
+        if source_system == "internal":
+            continue
+        training_rows.extend(source_rows_by_system.get(source_system, []))
+    return training_rows
+
+
+def classify_lift(
+    *,
+    delta_roc_auc: Optional[float],
+    delta_top3: Optional[float],
+    delta_brier: Optional[float],
+    tolerance: float,
+) -> str:
+    if delta_roc_auc is None or delta_top3 is None or delta_brier is None:
+        return "pending"
+
+    improved = delta_roc_auc > tolerance or delta_top3 > tolerance or delta_brier < -tolerance
+    worsened = delta_roc_auc < -tolerance or delta_top3 < -tolerance or delta_brier > tolerance
+    if improved and not worsened:
+        return "adds"
+    if worsened and not improved:
+        return "hurts"
+    return "neutral"
+
+
+def load_previous_best_source_systems(previous_manifest_path: Path) -> List[str]:
+    if not previous_manifest_path.exists():
+        return []
+
+    with previous_manifest_path.open("r", encoding="utf-8") as handle:
+        manifest = json.load(handle)
+
+    if manifest.get("lift_decision") == "keep_vhrdb_for_followup_arms":
+        return ["vhrdb"]
+    return []
+
+
+def write_output_tables(
+    *,
+    output_dir: Path,
+    summary_rows: Sequence[Mapping[str, object]],
+    summary_fieldnames: Sequence[str],
+    ranking_rows: Sequence[Mapping[str, object]],
+    ranking_fieldnames: Sequence[str],
+    manifest_path: Path,
+    manifest_payload: Mapping[str, object],
+    summary_filename: str,
+    rankings_filename: str,
+) -> None:
+    ensure_directory(output_dir)
+    write_csv(output_dir / summary_filename, fieldnames=summary_fieldnames, rows=summary_rows)
+    write_csv(output_dir / rankings_filename, fieldnames=ranking_fieldnames, rows=ranking_rows)
+    write_json(manifest_path, manifest_payload)

--- a/lyzortx/research_notes/lab_notebooks/track_K.md
+++ b/lyzortx/research_notes/lab_notebooks/track_K.md
@@ -33,3 +33,36 @@ defaults, so the baseline comparison stays comparable to the Track G lock.
   locked ST03-safe path.
 - For this repository state, VHRdb should not be added to later arms yet. The code path is ready, but the local
   artifact set does not contain joinable VHRdb training rows, so there is no empirical lift to carry forward.
+
+### 2026-03-24: TK02 BASEL cumulative lift measurement
+
+#### Executive summary
+
+Added the TK02 Track K runner to measure BASEL lift on top of the best-so-far TK01 cohort. The real Track G/I
+generated artifacts are not present in this checkout, so the new path was validated on a minimal fixture instead of a
+production rerun. On that fixture, BASEL was neutral: ROC-AUC, top-3, and Brier deltas vs the previous best were all
+`0.0`.
+
+#### What was implemented
+
+- Added shared Track K lift helpers in `lyzortx/pipeline/track_k/steps/build_source_lift_helpers.py`.
+- Added the TK02 runner at `lyzortx/pipeline/track_k/steps/build_basel_lift_report.py`.
+- Updated `lyzortx/pipeline/track_k/run_track_k.py` so `--step all` runs TK01 followed by TK02.
+- The TK02 manifest now records the previous-best source systems, cumulative source set, metric deltas, and the lift
+  assessment.
+
+#### Findings
+
+- On the validation fixture, TK01 kept `internal_plus_vhrdb` as the best-so-far cohort.
+- TK02 evaluated `internal_plus_vhrdb_plus_basel`.
+- Metric deltas vs the previous best were all `0.0`:
+  - ROC-AUC `0.0`
+  - top-3 `0.0`
+  - Brier `0.0`
+- The TK02 lift assessment was `neutral`.
+
+#### Interpretation
+
+- BASEL is now wired as a cumulative add-on after TK01, not as a replacement path.
+- On the available fixture, BASEL is neutral rather than additive or harmful.
+- A production rerun can replace the fixture note once the Track G/I generated artifacts are available locally.

--- a/lyzortx/tests/test_track_k_basel_lift.py
+++ b/lyzortx/tests/test_track_k_basel_lift.py
@@ -1,0 +1,374 @@
+"""Unit tests for TK02 BASEL lift measurement helpers."""
+
+from __future__ import annotations
+
+import csv
+import json
+
+from lyzortx.pipeline.track_k.steps.build_basel_lift_report import main
+from lyzortx.pipeline.track_k.steps.build_source_lift_helpers import load_source_training_rows
+
+
+def _write_csv(path, fieldnames, rows) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_json(path, payload) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_load_source_training_rows_keeps_joinable_basel_rows() -> None:
+    feature_rows = [
+        {
+            "pair_id": "b1__p1",
+            "bacteria": "b1",
+            "phage": "p1",
+            "split_holdout": "train_non_holdout",
+            "split_cv5_fold": "0",
+            "is_hard_trainable": "1",
+            "label_hard_any_lysis": "1",
+            "label_strict_confidence_tier": "A",
+        },
+        {
+            "pair_id": "b2__p2",
+            "bacteria": "b2",
+            "phage": "p2",
+            "split_holdout": "holdout_test",
+            "split_cv5_fold": "-1",
+            "is_hard_trainable": "1",
+            "label_hard_any_lysis": "0",
+            "label_strict_confidence_tier": "A",
+        },
+    ]
+    cohort_rows = [
+        {
+            "pair_id": "b1__p1",
+            "bacteria": "b1",
+            "phage": "p1",
+            "source_system": "basel",
+            "external_label_include_in_training": "1",
+            "external_label_confidence_tier": "high",
+            "external_label_confidence_score": "3",
+            "external_label_training_weight": "1.0",
+            "label_hard_any_lysis": "0",
+            "label_strict_confidence_tier": "B",
+        },
+        {
+            "pair_id": "b2__p2",
+            "bacteria": "b2",
+            "phage": "p2",
+            "source_system": "basel",
+            "external_label_include_in_training": "1",
+            "external_label_confidence_tier": "high",
+            "external_label_confidence_score": "3",
+            "external_label_training_weight": "1.0",
+            "label_hard_any_lysis": "1",
+            "label_strict_confidence_tier": "B",
+        },
+        {
+            "pair_id": "b3__p3",
+            "bacteria": "b3",
+            "phage": "p3",
+            "source_system": "basel",
+            "external_label_include_in_training": "0",
+            "external_label_confidence_tier": "exclude",
+            "external_label_confidence_score": "0",
+            "external_label_training_weight": "0.0",
+            "label_hard_any_lysis": "1",
+            "label_strict_confidence_tier": "B",
+        },
+    ]
+
+    augmented_rows, counts = load_source_training_rows(feature_rows, cohort_rows, "basel")
+
+    assert len(augmented_rows) == 1
+    assert augmented_rows[0]["pair_id"] == "b1__p1"
+    assert augmented_rows[0]["training_origin"] == "basel"
+    assert counts["joined_rows"] == 1
+    assert counts["non_training_split_rows"] == 1
+    assert counts["excluded_rows"] == 1
+
+
+def test_main_carries_forward_vhrdb_when_tk01_kept_it(tmp_path) -> None:
+    st02 = tmp_path / "st02_pair_table.csv"
+    st03 = tmp_path / "st03_split_assignments.csv"
+    track_c = tmp_path / "pair_table_v1.csv"
+    track_d_genome = tmp_path / "phage_genome_kmer_features.csv"
+    track_d_distance = tmp_path / "phage_distance_embedding_features.csv"
+    track_e_rbp = tmp_path / "rbp_receptor_compatibility_features_v1.csv"
+    track_e_isolation = tmp_path / "isolation_host_distance_features_v1.csv"
+    v1_config = tmp_path / "v1_feature_configuration.json"
+    tg01_summary = tmp_path / "tg01_model_summary.json"
+    tk01_manifest = tmp_path / "tk01_vhrdb_lift_manifest.json"
+
+    _write_csv(
+        st02,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p3",
+                "bacteria": "b1",
+                "phage": "p3",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        st03,
+        ["pair_id", "bacteria", "phage", "cv_group", "split_holdout", "split_cv5_fold", "is_hard_trainable"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "cv_group": "g0",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "1",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "cv_group": "g1",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "0",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "cv_group": "g2",
+                "split_holdout": "holdout_test",
+                "split_cv5_fold": "-1",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p3",
+                "bacteria": "b1",
+                "phage": "p3",
+                "cv_group": "g3",
+                "split_holdout": "holdout_test",
+                "split_cv5_fold": "-1",
+                "is_hard_trainable": "1",
+            },
+        ],
+    )
+    _write_csv(
+        track_c,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p3",
+                "bacteria": "b1",
+                "phage": "p3",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        track_d_genome,
+        ["phage", "phage_gc_content"],
+        [
+            {"phage": "p0", "phage_gc_content": "0.4"},
+            {"phage": "p1", "phage_gc_content": "0.5"},
+            {"phage": "p2", "phage_gc_content": "0.6"},
+            {"phage": "p3", "phage_gc_content": "0.7"},
+        ],
+    )
+    _write_csv(
+        track_d_distance,
+        ["phage", "phage_distance_umap_00"],
+        [
+            {"phage": "p0", "phage_distance_umap_00": "0.05"},
+            {"phage": "p1", "phage_distance_umap_00": "0.1"},
+            {"phage": "p2", "phage_distance_umap_00": "0.2"},
+            {"phage": "p3", "phage_distance_umap_00": "0.3"},
+        ],
+    )
+    _write_csv(
+        track_e_rbp,
+        ["pair_id", "bacteria", "phage", "lookup_available"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "lookup_available": "1"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "lookup_available": "1"},
+            {"pair_id": "b1__p2", "bacteria": "b1", "phage": "p2", "lookup_available": "0"},
+            {"pair_id": "b1__p3", "bacteria": "b1", "phage": "p3", "lookup_available": "1"},
+        ],
+    )
+    _write_csv(
+        track_e_isolation,
+        ["pair_id", "bacteria", "phage", "isolation_host_distance"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "isolation_host_distance": "0.25"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "isolation_host_distance": "0.3"},
+            {"pair_id": "b1__p2", "bacteria": "b1", "phage": "p2", "isolation_host_distance": "0.4"},
+            {"pair_id": "b1__p3", "bacteria": "b1", "phage": "p3", "isolation_host_distance": "0.2"},
+        ],
+    )
+    v1_config.write_text(json.dumps({"winner_subset_blocks": ["defense", "phage_genomic"]}), encoding="utf-8")
+    _write_json(
+        tg01_summary,
+        {
+            "lightgbm": {
+                "best_params": {
+                    "n_estimators": 150,
+                    "learning_rate": 0.03,
+                    "num_leaves": 31,
+                    "min_child_samples": 10,
+                }
+            }
+        },
+    )
+    _write_json(tk01_manifest, {"lift_decision": "keep_vhrdb_for_followup_arms"})
+    ti08_cohort = tmp_path / "ti08_training_cohort_rows.csv"
+    _write_csv(
+        ti08_cohort,
+        [
+            "pair_id",
+            "bacteria",
+            "phage",
+            "label_hard_any_lysis",
+            "label_strict_confidence_tier",
+            "source_system",
+            "external_label_include_in_training",
+            "external_label_confidence_tier",
+            "external_label_confidence_score",
+            "external_label_training_weight",
+        ],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "B",
+                "source_system": "vhrdb",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "B",
+                "source_system": "basel",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "B",
+                "source_system": "basel",
+                "external_label_include_in_training": "0",
+                "external_label_confidence_tier": "exclude",
+                "external_label_confidence_score": "0",
+                "external_label_training_weight": "0.0",
+            },
+        ],
+    )
+
+    output_dir = tmp_path / "out"
+
+    main(
+        [
+            "--st02-pair-table-path",
+            str(st02),
+            "--st03-split-assignments-path",
+            str(st03),
+            "--track-c-pair-table-path",
+            str(track_c),
+            "--track-d-genome-kmer-path",
+            str(track_d_genome),
+            "--track-d-distance-path",
+            str(track_d_distance),
+            "--track-e-rbp-compatibility-path",
+            str(track_e_rbp),
+            "--track-e-isolation-distance-path",
+            str(track_e_isolation),
+            "--v1-feature-config-path",
+            str(v1_config),
+            "--tg01-summary-path",
+            str(tg01_summary),
+            "--tk01-manifest-path",
+            str(tk01_manifest),
+            "--ti08-training-cohort-path",
+            str(ti08_cohort),
+            "--output-dir",
+            str(output_dir),
+            "--skip-prerequisites",
+        ]
+    )
+
+    summary = list(csv.DictReader((output_dir / "tk02_basel_lift_summary.csv").open("r", encoding="utf-8")))
+    assert summary[0]["arm"] == "internal_plus_vhrdb"
+    assert summary[1]["arm"] == "internal_plus_vhrdb_plus_basel"
+    assert summary[1]["basel_row_count"] == "1"
+
+    manifest = json.loads((output_dir / "tk02_basel_lift_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["previous_best_source_systems"] == ["vhrdb"]
+    assert manifest["lift_assessment"] in {"adds", "hurts", "neutral"}


### PR DESCRIPTION
Add a Track K cumulative lift path for BASEL on top of the best-so-far cohort selected from TK01.

Changes:
- Added shared Track K lift helpers for source-specific row joins, cumulative source labels, arm naming, and lift classification.
- Added the TK02 BASEL runner and wired it into `run_track_k.py` and the Track K step package.
- Added tests for BASEL row joining and the cumulative TK02 path when TK01 keeps VHRdb in the best-so-far cohort.
- Recorded the TK02 findings in `lyzortx/research_notes/lab_notebooks/track_K.md`.

Validation:
- `pytest -q lyzortx/tests/`
- Fixture-level TK02 run: neutral deltas vs previous best (`delta AUC = 0.0`, `delta top-3 = 0.0`, `delta Brier = 0.0`).

Closes #208

Posted by Codex gpt-5.4