### PR TITLE
[ORCH][TK04] Add GPB to training and measure cumulative lift

### DIFF
--- a/lyzortx/pipeline/track_k/run_track_k.py
+++ b/lyzortx/pipeline/track_k/run_track_k.py
@@ -12,6 +12,7 @@ if __package__ in {None, ""}:
 
 from lyzortx.log_config import setup_logging
 from lyzortx.pipeline.track_k.steps import build_basel_lift_report
+from lyzortx.pipeline.track_k.steps import build_gpb_lift_report
 from lyzortx.pipeline.track_k.steps import build_klebphacol_lift_report
 from lyzortx.pipeline.track_k.steps import build_vhrdb_lift_report
 
@@ -20,7 +21,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--step",
-        choices=["vhrdb-lift", "basel-lift", "klebphacol-lift", "all"],
+        choices=["vhrdb-lift", "basel-lift", "klebphacol-lift", "gpb-lift", "all"],
         default="all",
         help="Track K step to run. 'all' runs the implemented lift-measurement steps.",
     )
@@ -36,6 +37,8 @@ def main(argv: list[str] | None = None) -> None:
         build_basel_lift_report.main([])
     if args.step in {"klebphacol-lift", "all"}:
         build_klebphacol_lift_report.main([])
+    if args.step in {"gpb-lift", "all"}:
+        build_gpb_lift_report.main([])
 
 
 if __name__ == "__main__":

--- a/lyzortx/pipeline/track_k/steps/__init__.py
+++ b/lyzortx/pipeline/track_k/steps/__init__.py
@@ -1,5 +1,6 @@
 """Track K step modules."""
 
 from . import build_basel_lift_report as build_basel_lift_report
+from . import build_gpb_lift_report as build_gpb_lift_report
 from . import build_klebphacol_lift_report as build_klebphacol_lift_report
 from . import build_vhrdb_lift_report as build_vhrdb_lift_report

--- a/lyzortx/pipeline/track_k/steps/build_gpb_lift_report.py
+++ b/lyzortx/pipeline/track_k/steps/build_gpb_lift_report.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""TK04: Measure the cumulative lift from adding GPB supervision."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence
+
+from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory
+from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
+from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import (
+    IDENTIFIER_COLUMNS,
+    FeatureSpace,
+    build_feature_space,
+    build_top3_ranking_rows,
+    compute_binary_metrics,
+    compute_top3_hit_rate,
+    fit_final_estimator,
+    make_lightgbm_estimator,
+    merge_expanded_feature_rows,
+)
+from lyzortx.pipeline.track_k.steps.build_source_lift_helpers import (
+    arm_name_for_source_systems,
+    build_locked_feature_space,
+    build_training_rows,
+    classify_lift,
+    load_locked_v1_feature_config,
+    load_previous_best_source_systems,
+    load_source_training_rows,
+    load_tg01_best_params,
+    sha256,
+    source_systems_label,
+    write_output_tables,
+)
+
+logger = logging.getLogger(__name__)
+
+LOCKED_V1_FEATURE_CONFIG_PATH = Path("lyzortx/pipeline/track_g/v1_feature_configuration.json")
+TG01_SUMMARY_PATH = Path("lyzortx/generated_outputs/track_g/tg01_v1_binary_classifier/tg01_model_summary.json")
+TK03_MANIFEST_PATH = Path(
+    "lyzortx/generated_outputs/track_k/tk03_klebphacol_lift_measurement/tk03_klebphacol_lift_manifest.json"
+)
+TI08_TRAINING_COHORT_PATH = Path(
+    "lyzortx/generated_outputs/track_i/training_cohort_integration/ti08_training_cohort_rows.csv"
+)
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/track_k/tk04_gpb_lift_measurement")
+CURRENT_SOURCE_SYSTEM = "gpb"
+TRAIN_SPLIT = "train_non_holdout"
+NEGLIGIBLE_DELTA_TOLERANCE = 0.001
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--st02-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st02_pair_table.csv"),
+    )
+    parser.add_argument(
+        "--st03-split-assignments-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_assignments.csv"),
+    )
+    parser.add_argument(
+        "--track-c-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_c/v1_host_feature_pair_table/pair_table_v1.csv"),
+    )
+    parser.add_argument(
+        "--track-d-genome-kmer-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_d/phage_genome_kmer_features/phage_genome_kmer_features.csv"),
+    )
+    parser.add_argument(
+        "--track-d-distance-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_d/phage_distance_embedding/phage_distance_embedding_features.csv"
+        ),
+    )
+    parser.add_argument(
+        "--track-e-rbp-compatibility-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_e/rbp_receptor_compatibility_feature_block/"
+            "rbp_receptor_compatibility_features_v1.csv"
+        ),
+    )
+    parser.add_argument(
+        "--track-e-isolation-distance-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_e/isolation_host_distance_feature_block/"
+            "isolation_host_distance_features_v1.csv"
+        ),
+    )
+    parser.add_argument("--v1-feature-config-path", type=Path, default=LOCKED_V1_FEATURE_CONFIG_PATH)
+    parser.add_argument("--tg01-summary-path", type=Path, default=TG01_SUMMARY_PATH)
+    parser.add_argument("--tk03-manifest-path", type=Path, default=TK03_MANIFEST_PATH)
+    parser.add_argument("--ti08-training-cohort-path", type=Path, default=TI08_TRAINING_COHORT_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--skip-prerequisites", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _delta(value: Optional[float], baseline: Optional[float]) -> Optional[float]:
+    if value is None or baseline is None:
+        return None
+    return safe_round(value - baseline)
+
+
+def _trainable_rows(rows: Sequence[Mapping[str, object]]) -> List[Mapping[str, object]]:
+    return [row for row in rows if row["split_holdout"] == TRAIN_SPLIT and str(row["is_hard_trainable"]) == "1"]
+
+
+def _measure_metrics(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    feature_space: FeatureSpace,
+    estimator_factory,
+    params: Mapping[str, object],
+) -> tuple[List[Dict[str, object]], Dict[str, object], Dict[str, object]]:
+    _, _, _, eval_rows, probabilities = fit_final_estimator(
+        rows,
+        feature_space,
+        estimator_factory=estimator_factory,
+        params=params,
+    )
+    scored_rows: List[Dict[str, object]] = []
+    for row, probability in zip(eval_rows, probabilities):
+        scored = dict(row)
+        scored["probability"] = probability
+        scored_rows.append(scored)
+    holdout_metrics = compute_binary_metrics(
+        [int(str(row["label_hard_any_lysis"])) for row in scored_rows],
+        [float(row["probability"]) for row in scored_rows],
+    )
+    top3 = compute_top3_hit_rate(scored_rows, probability_key="probability")
+    return scored_rows, holdout_metrics, top3
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_args(argv)
+    logger.info("TK04 starting: measure GPB lift against the best-so-far Track K cohort")
+
+    ensure_directory(args.output_dir)
+
+    if not args.skip_prerequisites:
+        from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import ensure_prerequisite_outputs
+
+        ensure_prerequisite_outputs(args)
+
+    st02_rows = read_csv_rows(args.st02_pair_table_path)
+    split_rows = read_csv_rows(args.st03_split_assignments_path)
+    track_c_pair_rows = read_csv_rows(args.track_c_pair_table_path)
+    track_d_genome_rows = read_csv_rows(args.track_d_genome_kmer_path)
+    track_d_distance_rows = read_csv_rows(args.track_d_distance_path)
+    track_e_rbp_rows = read_csv_rows(args.track_e_rbp_compatibility_path)
+    track_e_isolation_rows = read_csv_rows(args.track_e_isolation_distance_path)
+
+    locked_config = load_locked_v1_feature_config(args.v1_feature_config_path)
+    locked_subset_blocks = tuple(str(block) for block in locked_config["winner_subset_blocks"])
+    tg01_best_params = load_tg01_best_params(args.tg01_summary_path)
+    baseline_params_source = "tg01_summary_lock"
+
+    track_d_feature_columns = tuple(
+        dict.fromkeys(
+            [column for column in track_d_genome_rows[0].keys() if column != "phage"]
+            + [column for column in track_d_distance_rows[0].keys() if column != "phage"]
+        )
+    )
+    track_e_feature_columns = tuple(
+        dict.fromkeys(
+            [column for column in track_e_rbp_rows[0].keys() if column not in IDENTIFIER_COLUMNS]
+            + [column for column in track_e_isolation_rows[0].keys() if column not in IDENTIFIER_COLUMNS]
+        )
+    )
+    full_feature_space = build_feature_space(
+        st02_rows, track_c_pair_rows, track_d_feature_columns, track_e_feature_columns
+    )
+    locked_feature_space = build_locked_feature_space(full_feature_space, locked_subset_blocks)
+
+    merged_rows = merge_expanded_feature_rows(
+        track_c_pair_rows,
+        split_rows,
+        phage_feature_blocks=(track_d_genome_rows, track_d_distance_rows),
+        pair_feature_blocks=(track_e_rbp_rows, track_e_isolation_rows),
+    )
+    cohort_rows = read_csv_rows(args.ti08_training_cohort_path) if args.ti08_training_cohort_path.exists() else []
+
+    source_rows_by_system: Dict[str, List[Dict[str, object]]] = {}
+    current_source_rows, current_source_counts = load_source_training_rows(
+        merged_rows,
+        cohort_rows,
+        CURRENT_SOURCE_SYSTEM,
+    )
+    source_rows_by_system[CURRENT_SOURCE_SYSTEM] = current_source_rows
+    previous_best_source_systems = load_previous_best_source_systems(args.tk03_manifest_path)
+    for source_system in previous_best_source_systems:
+        if source_system not in source_rows_by_system:
+            source_rows_by_system[source_system], _ = load_source_training_rows(merged_rows, cohort_rows, source_system)
+
+    base_source_systems = ["internal", *previous_best_source_systems]
+    augmented_source_systems = [*base_source_systems, CURRENT_SOURCE_SYSTEM]
+
+    internal_training_rows = list(merged_rows)
+    base_training_rows = build_training_rows(internal_training_rows, source_rows_by_system, base_source_systems)
+    augmented_training_rows = build_training_rows(
+        internal_training_rows,
+        source_rows_by_system,
+        augmented_source_systems,
+    )
+
+    estimator_factory = lambda params, seed_offset: make_lightgbm_estimator(  # noqa: E731
+        params,
+        seed_offset,
+        base_random_state=args.random_state,
+    )
+
+    baseline_rows, baseline_holdout_metrics, baseline_top3 = _measure_metrics(
+        base_training_rows,
+        feature_space=locked_feature_space,
+        estimator_factory=estimator_factory,
+        params=tg01_best_params,
+    )
+    augmented_rows, augmented_holdout_metrics, augmented_top3 = _measure_metrics(
+        augmented_training_rows,
+        feature_space=locked_feature_space,
+        estimator_factory=estimator_factory,
+        params=tg01_best_params,
+    )
+
+    metric_deltas = {
+        "delta_roc_auc": _delta(augmented_holdout_metrics["roc_auc"], baseline_holdout_metrics["roc_auc"]),
+        "delta_top3_hit_rate_all_strains": _delta(
+            float(augmented_top3["top3_hit_rate_all_strains"]),
+            float(baseline_top3["top3_hit_rate_all_strains"]),
+        ),
+        "delta_brier_score": _delta(augmented_holdout_metrics["brier_score"], baseline_holdout_metrics["brier_score"]),
+    }
+    lift_assessment = classify_lift(
+        delta_roc_auc=metric_deltas["delta_roc_auc"],
+        delta_top3=metric_deltas["delta_top3_hit_rate_all_strains"],
+        delta_brier=metric_deltas["delta_brier_score"],
+        tolerance=NEGLIGIBLE_DELTA_TOLERANCE,
+    )
+
+    summary_rows = [
+        {
+            "arm": arm_name_for_source_systems(base_source_systems),
+            "source_systems": source_systems_label(base_source_systems),
+            "training_row_count": len(_trainable_rows(base_training_rows)),
+            "gpb_row_count": 0,
+            "holdout_roc_auc": baseline_holdout_metrics["roc_auc"],
+            "holdout_top3_hit_rate_all_strains": baseline_top3["top3_hit_rate_all_strains"],
+            "holdout_brier_score": baseline_holdout_metrics["brier_score"],
+            "delta_roc_auc_vs_previous_best": 0.0,
+            "delta_top3_vs_previous_best": 0.0,
+            "delta_brier_vs_previous_best": 0.0,
+        },
+        {
+            "arm": arm_name_for_source_systems(augmented_source_systems),
+            "source_systems": source_systems_label(augmented_source_systems),
+            "training_row_count": len(_trainable_rows(augmented_training_rows)),
+            "gpb_row_count": len(current_source_rows),
+            "holdout_roc_auc": augmented_holdout_metrics["roc_auc"],
+            "holdout_top3_hit_rate_all_strains": augmented_top3["top3_hit_rate_all_strains"],
+            "holdout_brier_score": augmented_holdout_metrics["brier_score"],
+            "delta_roc_auc_vs_previous_best": metric_deltas["delta_roc_auc"],
+            "delta_top3_vs_previous_best": metric_deltas["delta_top3_hit_rate_all_strains"],
+            "delta_brier_vs_previous_best": metric_deltas["delta_brier_score"],
+        },
+    ]
+
+    summary_filename = "tk04_gpb_lift_summary.csv"
+    rankings_filename = "tk04_gpb_holdout_top3_rankings.csv"
+    manifest_path = args.output_dir / "tk04_gpb_lift_manifest.json"
+
+    ranking_rows = [
+        *build_top3_ranking_rows(
+            baseline_rows,
+            probability_key="probability",
+            model_label=arm_name_for_source_systems(base_source_systems),
+        ),
+        *build_top3_ranking_rows(
+            augmented_rows,
+            probability_key="probability",
+            model_label=arm_name_for_source_systems(augmented_source_systems),
+        ),
+    ]
+
+    write_output_tables(
+        output_dir=args.output_dir,
+        summary_rows=summary_rows,
+        summary_fieldnames=[
+            "arm",
+            "source_systems",
+            "training_row_count",
+            "gpb_row_count",
+            "holdout_roc_auc",
+            "holdout_top3_hit_rate_all_strains",
+            "holdout_brier_score",
+            "delta_roc_auc_vs_previous_best",
+            "delta_top3_vs_previous_best",
+            "delta_brier_vs_previous_best",
+        ],
+        ranking_rows=ranking_rows,
+        ranking_fieldnames=[
+            "model_label",
+            "bacteria",
+            "phage",
+            "pair_id",
+            "rank",
+            "predicted_probability",
+            "label_hard_any_lysis",
+        ],
+        manifest_path=manifest_path,
+        manifest_payload={
+            "generated_at_utc": datetime.now(tz=timezone.utc).isoformat(),
+            "step_name": "build_gpb_lift_report",
+            "source_system_added": CURRENT_SOURCE_SYSTEM,
+            "locked_feature_config_path": str(args.v1_feature_config_path),
+            "locked_feature_config_sha256": sha256(args.v1_feature_config_path),
+            "tg01_best_params_source": baseline_params_source,
+            "tg01_best_params": tg01_best_params,
+            "input_paths": {
+                "st02_pair_table": str(args.st02_pair_table_path),
+                "st03_split_assignments": str(args.st03_split_assignments_path),
+                "track_c_pair_table": str(args.track_c_pair_table_path),
+                "track_d_genome_kmers": str(args.track_d_genome_kmer_path),
+                "track_d_distance": str(args.track_d_distance_path),
+                "track_e_rbp_receptor_compatibility": str(args.track_e_rbp_compatibility_path),
+                "track_e_isolation_host_distance": str(args.track_e_isolation_distance_path),
+                "ti08_training_cohort_rows": str(args.ti08_training_cohort_path),
+                "tk03_manifest": str(args.tk03_manifest_path),
+            },
+            "input_hashes_sha256": {
+                "st02_pair_table": sha256(args.st02_pair_table_path),
+                "st03_split_assignments": sha256(args.st03_split_assignments_path),
+                "track_c_pair_table": sha256(args.track_c_pair_table_path),
+                "track_d_genome_kmers": sha256(args.track_d_genome_kmer_path),
+                "track_d_distance": sha256(args.track_d_distance_path),
+                "track_e_rbp_receptor_compatibility": sha256(args.track_e_rbp_compatibility_path),
+                "track_e_isolation_host_distance": sha256(args.track_e_isolation_distance_path),
+                **(
+                    {"ti08_training_cohort_rows": sha256(args.ti08_training_cohort_path)}
+                    if args.ti08_training_cohort_path.exists()
+                    else {}
+                ),
+                **({"tk03_manifest": sha256(args.tk03_manifest_path)} if args.tk03_manifest_path.exists() else {}),
+            },
+            "previous_best_source_systems": previous_best_source_systems,
+            "best_source_systems": (
+                [*previous_best_source_systems, CURRENT_SOURCE_SYSTEM]
+                if lift_assessment == "adds"
+                else previous_best_source_systems
+            ),
+            "base_source_systems": base_source_systems,
+            "augmented_source_systems": augmented_source_systems,
+            "source_rows_by_system": {
+                source_system: len(rows) for source_system, rows in source_rows_by_system.items()
+            },
+            "current_source_counts": current_source_counts,
+            "baseline_metrics": {
+                "roc_auc": baseline_holdout_metrics["roc_auc"],
+                "top3_hit_rate_all_strains": baseline_top3["top3_hit_rate_all_strains"],
+                "brier_score": baseline_holdout_metrics["brier_score"],
+            },
+            "augmented_metrics": {
+                "roc_auc": augmented_holdout_metrics["roc_auc"],
+                "top3_hit_rate_all_strains": augmented_top3["top3_hit_rate_all_strains"],
+                "brier_score": augmented_holdout_metrics["brier_score"],
+            },
+            "metric_deltas": metric_deltas,
+            "lift_assessment": lift_assessment,
+            "output_paths": {
+                "summary": str(args.output_dir / summary_filename),
+                "holdout_rankings": str(args.output_dir / rankings_filename),
+            },
+        },
+        summary_filename=summary_filename,
+        rankings_filename=rankings_filename,
+    )
+
+    logger.info("TK04 completed.")
+    logger.info("- Previous best arm: %s", arm_name_for_source_systems(base_source_systems))
+    logger.info("- Augmented arm: %s", arm_name_for_source_systems(augmented_source_systems))
+    logger.info("- Delta ROC-AUC: %s", metric_deltas["delta_roc_auc"])
+    logger.info("- Delta top-3: %s", metric_deltas["delta_top3_hit_rate_all_strains"])
+    logger.info("- Delta Brier: %s", metric_deltas["delta_brier_score"])
+    logger.info("- GPB rows joined: %s", len(current_source_rows))
+    logger.info("- Lift assessment: %s", lift_assessment)
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_K.md
+++ b/lyzortx/research_notes/lab_notebooks/track_K.md
@@ -100,3 +100,36 @@ previous best were all `0.0`.
 - KlebPhaCol now slots cleanly into the cumulative Track K sequence after BASEL.
 - On the available fixture, KlebPhaCol neither helps nor hurts the current best-so-far cohort, so it should be
   treated as neutral until a production rerun with the real Track I artifacts is available.
+
+### 2026-03-24: TK04 GPB cumulative lift measurement
+
+#### Executive summary
+
+Added the TK04 Track K runner to measure GPB lift on top of the current best-so-far cohort. The local Track I cohort
+artifact is still absent in this checkout, so the new path was validated on the same minimal fixture pattern used for
+TK02/TK03. On that fixture, GPB was neutral: ROC-AUC, top-3, and Brier deltas vs the previous best were all `0.0`.
+
+#### What was implemented
+
+- Added `lyzortx/pipeline/track_k/steps/build_gpb_lift_report.py` and wired it into
+  `lyzortx/pipeline/track_k/run_track_k.py`.
+- Extended the Track K runner so `--step all` now runs TK01 through TK04 in order.
+- Added regression coverage for the TK04 runner and the TK03-to-TK04 cohort handoff.
+
+#### Findings
+
+- On the validation fixture, TK04 carried forward `internal_plus_vhrdb_plus_basel_plus_klebphacol` as the
+  best-so-far cohort.
+- TK04 evaluated `internal_plus_vhrdb_plus_basel_plus_klebphacol_plus_gpb`.
+- On the fixture, both arms scored ROC-AUC `0.5`, top-3 hit rate `1.0`, and Brier score `0.25`.
+- The measured deltas vs the previous best were all `0.0`:
+  - ROC-AUC `0.0`
+  - top-3 `0.0`
+  - Brier `0.0`
+- The TK04 lift assessment was `neutral`.
+
+#### Interpretation
+
+- GPB now fits cleanly after KlebPhaCol in the cumulative Track K sequence.
+- On the available fixture, GPB neither adds nor hurts the current best-so-far cohort, so there is no basis yet for
+  changing the locked external-data chain.

--- a/lyzortx/tests/test_track_k_gpb_lift.py
+++ b/lyzortx/tests/test_track_k_gpb_lift.py
@@ -1,0 +1,326 @@
+"""Unit tests for TK04 GPB lift measurement helpers."""
+
+from __future__ import annotations
+
+import csv
+import json
+
+from lyzortx.pipeline.track_k.steps.build_gpb_lift_report import main
+from lyzortx.pipeline.track_k.steps.build_source_lift_helpers import load_previous_best_source_systems
+
+
+def _write_csv(path, fieldnames, rows) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_json(path, payload) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_load_previous_best_source_systems_reads_tk03_best_cohort(tmp_path) -> None:
+    manifest = tmp_path / "tk03_klebphacol_lift_manifest.json"
+    _write_json(
+        manifest,
+        {
+            "lift_assessment": "neutral",
+            "base_source_systems": ["internal", "vhrdb", "basel"],
+            "augmented_source_systems": ["internal", "vhrdb", "basel", "klebphacol"],
+            "best_source_systems": ["vhrdb", "basel", "klebphacol"],
+        },
+    )
+
+    assert load_previous_best_source_systems(manifest) == ["vhrdb", "basel", "klebphacol"]
+
+
+def test_main_carries_forward_klebphacol_when_tk03_kept_it(tmp_path) -> None:
+    st02 = tmp_path / "st02_pair_table.csv"
+    st03 = tmp_path / "st03_split_assignments.csv"
+    track_c = tmp_path / "pair_table_v1.csv"
+    track_d_genome = tmp_path / "phage_genome_kmer_features.csv"
+    track_d_distance = tmp_path / "phage_distance_embedding_features.csv"
+    track_e_rbp = tmp_path / "rbp_receptor_compatibility_features_v1.csv"
+    track_e_isolation = tmp_path / "isolation_host_distance_features_v1.csv"
+    v1_config = tmp_path / "v1_feature_configuration.json"
+    tg01_summary = tmp_path / "tg01_model_summary.json"
+    tk03_manifest = tmp_path / "tk03_klebphacol_lift_manifest.json"
+
+    _write_csv(
+        st02,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p3",
+                "bacteria": "b1",
+                "phage": "p3",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        st03,
+        ["pair_id", "bacteria", "phage", "cv_group", "split_holdout", "split_cv5_fold", "is_hard_trainable"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "cv_group": "g0",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "1",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "cv_group": "g1",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "0",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "cv_group": "g2",
+                "split_holdout": "holdout_test",
+                "split_cv5_fold": "-1",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p3",
+                "bacteria": "b1",
+                "phage": "p3",
+                "cv_group": "g3",
+                "split_holdout": "holdout_test",
+                "split_cv5_fold": "-1",
+                "is_hard_trainable": "1",
+            },
+        ],
+    )
+    _write_csv(
+        track_c,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p3",
+                "bacteria": "b1",
+                "phage": "p3",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        track_d_genome,
+        ["phage", "phage_gc_content"],
+        [
+            {"phage": "p0", "phage_gc_content": "0.4"},
+            {"phage": "p1", "phage_gc_content": "0.5"},
+            {"phage": "p2", "phage_gc_content": "0.6"},
+            {"phage": "p3", "phage_gc_content": "0.7"},
+        ],
+    )
+    _write_csv(
+        track_d_distance,
+        ["phage", "phage_distance_umap_00"],
+        [
+            {"phage": "p0", "phage_distance_umap_00": "0.05"},
+            {"phage": "p1", "phage_distance_umap_00": "0.1"},
+            {"phage": "p2", "phage_distance_umap_00": "0.2"},
+            {"phage": "p3", "phage_distance_umap_00": "0.3"},
+        ],
+    )
+    _write_csv(
+        track_e_rbp,
+        ["pair_id", "bacteria", "phage", "lookup_available"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "lookup_available": "1"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "lookup_available": "1"},
+            {"pair_id": "b1__p2", "bacteria": "b1", "phage": "p2", "lookup_available": "0"},
+            {"pair_id": "b1__p3", "bacteria": "b1", "phage": "p3", "lookup_available": "1"},
+        ],
+    )
+    _write_csv(
+        track_e_isolation,
+        ["pair_id", "bacteria", "phage", "isolation_host_distance"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "isolation_host_distance": "0.25"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "isolation_host_distance": "0.3"},
+            {"pair_id": "b1__p2", "bacteria": "b1", "phage": "p2", "isolation_host_distance": "0.4"},
+            {"pair_id": "b1__p3", "bacteria": "b1", "phage": "p3", "isolation_host_distance": "0.2"},
+        ],
+    )
+    v1_config.write_text(json.dumps({"winner_subset_blocks": ["defense", "phage_genomic"]}), encoding="utf-8")
+    _write_json(
+        tg01_summary,
+        {
+            "lightgbm": {
+                "best_params": {
+                    "n_estimators": 150,
+                    "learning_rate": 0.03,
+                    "num_leaves": 31,
+                    "min_child_samples": 10,
+                }
+            }
+        },
+    )
+    _write_json(
+        tk03_manifest,
+        {
+            "lift_assessment": "neutral",
+            "base_source_systems": ["internal", "vhrdb", "basel"],
+            "augmented_source_systems": ["internal", "vhrdb", "basel", "klebphacol"],
+            "best_source_systems": ["vhrdb", "basel", "klebphacol"],
+        },
+    )
+    ti08_cohort = tmp_path / "ti08_training_cohort_rows.csv"
+    _write_csv(
+        ti08_cohort,
+        [
+            "pair_id",
+            "bacteria",
+            "phage",
+            "label_hard_any_lysis",
+            "label_strict_confidence_tier",
+            "source_system",
+            "external_label_include_in_training",
+            "external_label_confidence_tier",
+            "external_label_confidence_score",
+            "external_label_training_weight",
+        ],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "B",
+                "source_system": "klebphacol",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "B",
+                "source_system": "gpb",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "B",
+                "source_system": "gpb",
+                "external_label_include_in_training": "0",
+                "external_label_confidence_tier": "exclude",
+                "external_label_confidence_score": "0",
+                "external_label_training_weight": "0.0",
+            },
+        ],
+    )
+
+    output_dir = tmp_path / "out"
+
+    main(
+        [
+            "--st02-pair-table-path",
+            str(st02),
+            "--st03-split-assignments-path",
+            str(st03),
+            "--track-c-pair-table-path",
+            str(track_c),
+            "--track-d-genome-kmer-path",
+            str(track_d_genome),
+            "--track-d-distance-path",
+            str(track_d_distance),
+            "--track-e-rbp-compatibility-path",
+            str(track_e_rbp),
+            "--track-e-isolation-distance-path",
+            str(track_e_isolation),
+            "--v1-feature-config-path",
+            str(v1_config),
+            "--tg01-summary-path",
+            str(tg01_summary),
+            "--tk03-manifest-path",
+            str(tk03_manifest),
+            "--ti08-training-cohort-path",
+            str(ti08_cohort),
+            "--output-dir",
+            str(output_dir),
+            "--skip-prerequisites",
+        ]
+    )
+
+    summary = list(csv.DictReader((output_dir / "tk04_gpb_lift_summary.csv").open("r", encoding="utf-8")))
+    assert summary[0]["arm"] == "internal_plus_vhrdb_plus_basel_plus_klebphacol"
+    assert summary[1]["arm"] == "internal_plus_vhrdb_plus_basel_plus_klebphacol_plus_gpb"
+    assert summary[1]["gpb_row_count"] == "1"
+
+    manifest = json.loads((output_dir / "tk04_gpb_lift_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["previous_best_source_systems"] == ["vhrdb", "basel", "klebphacol"]
+    assert manifest["source_system_added"] == "gpb"
+    assert manifest["lift_assessment"] in {"adds", "hurts", "neutral"}


### PR DESCRIPTION
Add the TK04 Track K step for GPB cumulative lift measurement. This wires GPB into the best-so-far cohort sequence after TK03, adds regression coverage for the TK03-to-TK04 handoff, updates the Track K runner to include `gpb-lift`, and records the measured result in the Track K notebook.

Validation:
- `pytest -q lyzortx/tests/`
- validated the GPB runner on the minimal fixture used by the new test; GPB was neutral on that fixture

Generated by Codex gpt-5.4

Closes #212