### PR TITLE
Add fail-fast, CI environment, and substance-over-plumbing rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,22 @@
 - **How to detect CI:** Check for the `CI` environment variable (`[ -n "$CI" ]`). If set, skip micromamba activation.
 - **Git identity in CI:** Git `user.name` and `user.email` are pre-configured before the agent runs. Do not attempt to
   set them yourself.
+- **Generated outputs do not exist in CI.** This repo runs in GitHub Actions (Codex). A fresh checkout contains only
+  source code and committed data — no `lyzortx/generated_outputs/` artifacts. If a task depends on generated outputs
+  from a previous track, it must either regenerate them (by running the prerequisite steps) or fail loudly. It must
+  **never** silently produce empty results, zero-row outputs, or "pending" placeholders and call itself done.
+
+# Fail-Fast on Missing Data
+
+- Pipeline and analysis code must raise an exception when required input data is missing. Never silently fall back to
+  empty DataFrames, zero rows, or default values when the real data is absent — that is not graceful, it is a bug that
+  hides failure.
+- If a pipeline step's input file does not exist, raise `FileNotFoundError`. If a join produces zero rows when rows are
+  expected, raise `ValueError`. If an external API returns no data, raise an error.
+- A task that runs to completion on empty inputs and reports zero deltas has **failed**, not succeeded. The acceptance
+  criteria were not met. Do not mark it done.
+- This applies equally to tests: a test that passes because it operates on empty fixtures instead of real data is not
+  testing anything.
 
 # Dependency Selection Policy
 
@@ -126,6 +142,18 @@
   overcomplicated, or low-value rather than blindly implementing every suggestion.
 - Before raising an issue, check existing review threads and replies on the PR. Do not re-raise concerns that have
   already been addressed with a code fix or explicitly pushed back on with a reasoned explanation.
+
+## Substance over plumbing
+
+Before approving a PR or marking a task done, ask: **did this task produce real results, or just scaffolding?**
+
+- Code that builds a pipeline step but produces zero rows, zero deltas, or "pending" placeholders has not met its
+  acceptance criteria. It built plumbing, not substance.
+- A notebook entry that says "0 joinable rows" or "validated on a minimal fixture" is documenting a failure, not a
+  finding. The task is not done.
+- If the implementing agent cannot produce real results (e.g., required data doesn't exist in CI), the agent should
+  fail — no PR, no commit. Leave the issue open so the orchestrator knows the task is still pending. Do not produce
+  a PR with empty results and call it done.
 
 ## Review focus areas
 

--- a/lyzortx/orchestration/AGENTS.md
+++ b/lyzortx/orchestration/AGENTS.md
@@ -31,3 +31,11 @@
 - If a later task changes the codebase in ways that make a done task's criteria look stale (e.g., deleting features that
   a done task created), that is expected. The done task records what was true when it was completed; the later task
   records what changed. Git history tells the full story.
+
+# Orchestration Robustness vs Fail-Fast
+
+- The root AGENTS.md fail-fast rule applies to pipeline code. Orchestration code is different: the orchestrator should
+  be robust against transient failures (GitHub API errors, network timeouts, race conditions) via retries.
+- But robustness means retrying on transient errors, not tolerating missing data or silently skipping work. If the
+  orchestrator cannot dispatch a task because its inputs are missing, that is an error to surface, not a condition to
+  swallow.


### PR DESCRIPTION
## Summary

Track I (TI03-TI10) and Track K (TK01-TK05) all completed on empty data — zero external rows joined, zero deltas
reported, tasks marked done anyway. This happened because code silently tolerated missing inputs and review accepted
empty results.

New AGENTS.md rules:
- **Fail-fast on missing data:** Pipeline code must raise on missing inputs. Zero-row results are failures, not findings.
- **CI starts empty:** No generated outputs exist in a fresh checkout. Tasks must regenerate prerequisites or fail.
- **Substance over plumbing:** If a task can't produce real results, fail — no PR, leave the issue open.
- **Orchestration exception:** Orchestrator retries on transient errors, but does not tolerate missing data.

## Test plan

- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)