### PR TITLE
[ORCH][TI07] Assign confidence tiers to ingested external labels

### DIFF
--- a/lyzortx/pipeline/track_i/steps/build_external_label_confidence_tiers.py
+++ b/lyzortx/pipeline/track_i/steps/build_external_label_confidence_tiers.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import csv
 import hashlib
+import logging
 from collections import Counter
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -14,6 +15,8 @@ from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
 from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows
+
+LOGGER = logging.getLogger(__name__)
 
 REQUIRED_SOURCE_REGISTRY_COLUMNS = (
     "source_id",
@@ -24,8 +27,16 @@ REQUIRED_SOURCE_REGISTRY_COLUMNS = (
     "notes",
 )
 REQUIRED_EXTERNAL_COLUMNS = ("pair_id", "source_system")
+EXPECTED_TIER_A_SOURCES = ("vhrdb", "basel", "klebphacol", "gpb")
+EXPECTED_TIER_B_SOURCES = ("virus_host_db", "ncbi_virus_biosample")
+EXPECTED_EXTERNAL_SOURCES = EXPECTED_TIER_A_SOURCES + EXPECTED_TIER_B_SOURCES
 
 OUTPUT_APPEND_COLUMNS = [
+    "confidence_tier",
+    "confidence_score",
+    "training_weight",
+    "confidence_reason",
+    "include_in_training",
     "external_label_confidence_tier",
     "external_label_confidence_score",
     "external_label_training_weight",
@@ -145,11 +156,17 @@ def assign_external_confidence(
     adjusted_score = max(base_score - len(penalties), 0)
     confidence_tier, training_weight, include_in_training = score_to_tier(adjusted_score, config)
     reason_parts = [f"base_{base_reason}", *penalties]
+    confidence_reason = "|".join(reason_parts)
     return {
+        "confidence_tier": confidence_tier,
+        "confidence_score": adjusted_score,
+        "training_weight": training_weight,
+        "confidence_reason": confidence_reason,
+        "include_in_training": include_in_training,
         "external_label_confidence_tier": confidence_tier,
         "external_label_confidence_score": adjusted_score,
         "external_label_training_weight": training_weight,
-        "external_label_confidence_reason": "|".join(reason_parts),
+        "external_label_confidence_reason": confidence_reason,
         "external_label_include_in_training": include_in_training,
     }
 
@@ -182,9 +199,9 @@ def compute_summary_rows(rows: Sequence[Mapping[str, object]]) -> List[Dict[str,
     by_include: Counter[str] = Counter()
 
     for row in rows:
-        tier = str(row["external_label_confidence_tier"])
+        tier = str(row["confidence_tier"])
         source_system = str(row.get("source_system", ""))
-        include = str(row["external_label_include_in_training"])
+        include = str(row["include_in_training"])
         by_tier[tier] += 1
         by_source[(source_system, tier)] += 1
         by_include[include] += 1
@@ -208,7 +225,7 @@ def compute_summary_rows(rows: Sequence[Mapping[str, object]]) -> List[Dict[str,
 def build_policy_definition(config: ExternalConfidenceConfig) -> Dict[str, object]:
     return {
         "policy_name": "track_i_external_label_confidence_tiers",
-        "policy_version": "v1",
+        "policy_version": "v2",
         "base_score_rules": {
             "3": "Tier A direct assay-backed external sources from source_registry confidence_tier=A",
             "2": "Curated metadata knowledgebases such as Virus-Host DB",
@@ -255,28 +272,70 @@ def ordered_fieldnames(rows: List[Dict[str, object]]) -> List[str]:
     return fieldnames
 
 
+def validate_required_sources_in_registry(source_registry_rows: Mapping[str, Mapping[str, str]]) -> None:
+    missing_sources = [source_id for source_id in EXPECTED_EXTERNAL_SOURCES if source_id not in source_registry_rows]
+    if missing_sources:
+        raise ValueError("TI07 source registry is missing required sources: " + ", ".join(sorted(missing_sources)))
+
+
+def require_existing_inputs(input_paths: Mapping[str, Path]) -> None:
+    missing_inputs = [f"{name}={path}" for name, path in input_paths.items() if not path.exists()]
+    if missing_inputs:
+        raise FileNotFoundError(
+            "TI07 requires the TI05 Tier A harmonization output and TI06 Tier B ingest output. Missing: "
+            + ", ".join(missing_inputs)
+        )
+
+
+def validate_source_row_counts(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    expected_sources: Sequence[str],
+    context: str,
+) -> Dict[str, int]:
+    counts = Counter(str(row.get("source_system", "")) for row in rows)
+    missing_sources = [source_id for source_id in expected_sources if counts.get(source_id, 0) == 0]
+    if missing_sources:
+        raise ValueError(f"{context} produced zero tiered rows for source(s): {', '.join(sorted(missing_sources))}")
+    return {source_id: counts[source_id] for source_id in expected_sources}
+
+
 def main(argv: Optional[List[str]] = None) -> None:
     args = parse_args(argv)
     ensure_directory(args.output_dir)
     config = ExternalConfidenceConfig()
     source_registry_rows = load_source_registry(args.source_registry_path)
+    validate_required_sources_in_registry(source_registry_rows)
+    input_paths = {
+        "tier_a_ingest": args.tier_a_ingest_path,
+        "tier_b_ingest": args.tier_b_ingest_path,
+    }
+    require_existing_inputs(input_paths)
+    LOGGER.info("Starting TI07 external-label confidence tiering")
 
-    input_paths: Dict[str, Path] = {}
-    input_rows: List[Dict[str, str]] = []
-    if args.tier_a_ingest_path.exists():
-        input_paths["tier_a_ingest"] = args.tier_a_ingest_path
-        input_rows.extend(read_external_rows(args.tier_a_ingest_path))
-    if args.tier_b_ingest_path.exists():
-        input_paths["tier_b_ingest"] = args.tier_b_ingest_path
-        input_rows.extend(read_external_rows(args.tier_b_ingest_path))
-
-    if not input_rows:
-        raise ValueError("No external label inputs were found. Expected Tier A and/or Tier B ingest outputs.")
+    tier_a_rows = read_external_rows(args.tier_a_ingest_path)
+    validate_source_row_counts(
+        tier_a_rows,
+        expected_sources=EXPECTED_TIER_A_SOURCES,
+        context="TI07 Tier A input",
+    )
+    tier_b_rows = read_external_rows(args.tier_b_ingest_path)
+    validate_source_row_counts(
+        tier_b_rows,
+        expected_sources=EXPECTED_TIER_B_SOURCES,
+        context="TI07 Tier B input",
+    )
+    input_rows = [*tier_a_rows, *tier_b_rows]
 
     output_rows = apply_external_confidence_policy(
         input_rows,
         source_registry_rows=source_registry_rows,
         config=config,
+    )
+    source_row_counts = validate_source_row_counts(
+        output_rows,
+        expected_sources=EXPECTED_EXTERNAL_SOURCES,
+        context="TI07 output",
     )
     summary_rows = compute_summary_rows(output_rows)
     policy_definition = build_policy_definition(config)
@@ -317,8 +376,10 @@ def main(argv: Optional[List[str]] = None) -> None:
                 "summary": str(summary_output_path),
                 "policy": str(policy_output_path),
             },
+            "source_row_counts": source_row_counts,
         },
     )
+    LOGGER.info("Finished TI07 external-label confidence tiering with %s rows", len(output_rows))
 
 
 if __name__ == "__main__":

--- a/lyzortx/research_notes/lab_notebooks/track_I.md
+++ b/lyzortx/research_notes/lab_notebooks/track_I.md
@@ -261,36 +261,53 @@ and the code preserves the uncertainty that downstream TI07 needs instead of fla
 context away. The bounded Entrez query is the right tradeoff for now: it produces real rows reproducibly and leaves the
 door open to broader retrieval later without hard-coding a fragile full-database crawl into the default Track I path.
 
-### 2026-03-22: TI07 External-label confidence tiers
+### 2026-03-24: TI07 Assign confidence tiers to all ingested external labels
 
 #### What was implemented
 
-- Added `lyzortx/pipeline/track_i/steps/build_external_label_confidence_tiers.py`, a dedicated TI07 policy step that
-  reads external ingest outputs and assigns a unified `external_label_confidence_tier`, numeric confidence score, and
-  training weight per record.
-- Kept the policy deliberately small and executable instead of inventing many bespoke bins: base confidence comes from
-  source family (`A` assay-backed external sources > curated metadata knowledgebases > repository/submitter metadata),
-  and row-level degradations apply for disagreement, non-`ok` QC flags, and unresolved entity mapping.
-- Updated `lyzortx/pipeline/track_i/run_track_i.py` so Track I can run the new confidence-tier step directly or as part
-  of `--step all`.
-- Added unit tests covering the intended source-family ordering, downgrade behavior for unresolved mappings, and
-  end-to-end artifact emission for mixed Tier A and Tier B inputs.
+- Updated `lyzortx/pipeline/track_i/steps/build_external_label_confidence_tiers.py` so TI07 now requires the real TI05
+  and TI06 outputs instead of treating external inputs as optional. The step raises `FileNotFoundError` when either
+  upstream artifact is missing and raises `ValueError` if any of the six expected sources (`vhrdb`, `basel`,
+  `klebphacol`, `gpb`, `virus_host_db`, `ncbi_virus_biosample`) contributes zero tiered rows.
+- Kept the four-bin policy small and executable: base confidence still comes from source family
+  (`A` assay-backed sources > curated metadata knowledgebase > repository metadata), and row-level degradations still
+  come from disagreement, non-`ok` QC flags, and unresolved canonical mapping.
+- Expanded the output contract so the TI07 CSV now includes the generic columns required by the plan
+  (`confidence_tier`, `training_weight`) while preserving the existing `external_label_*` aliases for downstream Track I
+  consumers.
+- Added TI07 regression coverage for the new happy path and for the fail-fast case where one expected source is absent
+  from the tiered output.
 
 #### Findings
 
-- A four-bin policy (`high`, `medium`, `low`, `exclude`) is enough for the current external landscape; adding finer
-  subclasses now would create unstable distinctions before TI08/TI09 provide empirical feedback.
-- The most important row-level degradations are provenance-quality failures rather than subtle biological heuristics:
-  disagreement, bad QC states, and unresolved canonical mapping are strong enough to demote or exclude a record without
-  pretending we can rescue it by hand-crafted weighting.
-- This design gives TI08 a concrete interface now: every external row can be filtered or down-weighted mechanically
-  without coupling integration logic to source-specific if/else blocks.
+- A live rerun on 2026-03-24 after regenerating Track A plus TI03-TI06 produced
+  `lyzortx/generated_outputs/track_i/external_label_confidence_tiers/ti07_external_label_confidence_pairs.csv` with
+  `126,402` tiered rows. Overall tier counts were `26,029` `high`, `41,647` `medium`, `58,458` `low`, and `268`
+  `exclude`.
+- Tier distribution by source on that run:
+  - `vhrdb`: `26,029` `high`, `30,643` `medium`, `0` `low`, `0` `exclude`
+  - `basel`: `0` `high`, `468` `medium`, `0` `low`, `0` `exclude`
+  - `klebphacol`: `0` `high`, `6,576` `medium`, `1,121` `low`, `0` `exclude`
+  - `gpb`: `0` `high`, `3,960` `medium`, `0` `low`, `0` `exclude`
+  - `virus_host_db`: `0` `high`, `0` `medium`, `57,337` `low`, `0` `exclude`
+  - `ncbi_virus_biosample`: `0` `high`, `0` `medium`, `0` `low`, `268` `exclude`
+- Unresolved canonical mapping is the dominant downgrade path. All `BASEL`, `GPB`, and `Virus-Host DB` rows were
+  penalized by `unresolved_entity_mapping`, and `30,643` of `56,672` `VHRdb` rows were also demoted from `high` to
+  `medium` for the same reason.
+- `KlebPhaCol` is the only source that currently lands in both `medium` and `low`: `6,576` rows were downgraded only by
+  unresolved mapping, while `1,121` rows were pushed further down by the combination of unresolved mapping and
+  `source_disagreement`.
+- The only `exclude` rows came from `NCBI Virus/BioSample`. Those rows were already weak metadata labels, and the extra
+  QC penalties (`host_conflict` or `biosample_missing`) were enough to drive all `268` rows to zero weight.
 
 #### Interpretation
 
-- TI07 is now an explicit policy boundary between ingestion and training. That is the right abstraction: TI06 preserves
-  raw provenance, TI07 translates provenance into training trust, and TI08 can stay focused on optional integration
-  rather than re-litigating confidence semantics inside the model pipeline.
+- TI07 is now an honest policy boundary rather than a permissive pass-through. It consumes the real TI03-TI06 outputs,
+  proves that every expected source contributed rows, and emits a training-ready table with explicit keep/down-weight/
+  exclude semantics.
+- The current confidence distribution also exposes the main structural bottleneck for Track I: canonical mapping, not
+  assay provenance, is what suppresses trust for most external rows. That means TI08 should treat the external-weighting
+  contract as real signal, not as a cosmetic annotation layered on top of uniformly trustworthy data.
 
 ### 2026-03-22: TI08 External data as a non-blocking enhancer
 

--- a/lyzortx/tests/test_external_label_confidence_tiers.py
+++ b/lyzortx/tests/test_external_label_confidence_tiers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import csv
 import json
 
+import pytest
+
 from lyzortx.pipeline.track_i.steps.build_external_label_confidence_tiers import (
     ExternalConfidenceConfig,
     apply_external_confidence_policy,
@@ -133,6 +135,30 @@ def test_main_emits_external_confidence_outputs(tmp_path) -> None:
                 "notes": "",
             },
             {
+                "source_id": "basel",
+                "source_type": "publication_dataset",
+                "confidence_tier": "A",
+                "confidence_basis": "direct_experimental_screening",
+                "host_resolution": "strain",
+                "notes": "",
+            },
+            {
+                "source_id": "klebphacol",
+                "source_type": "curated_database",
+                "confidence_tier": "A",
+                "confidence_basis": "curated_experimental_records",
+                "host_resolution": "strain",
+                "notes": "",
+            },
+            {
+                "source_id": "gpb",
+                "source_type": "curated_database",
+                "confidence_tier": "A",
+                "confidence_basis": "assay_backed_records_from_bank_workflows",
+                "host_resolution": "strain",
+                "notes": "",
+            },
+            {
                 "source_id": "virus_host_db",
                 "source_type": "metadata_knowledgebase",
                 "confidence_tier": "B",
@@ -171,7 +197,34 @@ def test_main_emits_external_confidence_outputs(tmp_path) -> None:
                 "label_strict_confidence_tier": "A",
                 "source_system": "vhrdb",
                 "source_disagreement_flag": "0",
-            }
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "source_system": "basel",
+                "source_disagreement_flag": "0",
+            },
+            {
+                "pair_id": "b1__p3",
+                "bacteria": "b1",
+                "phage": "p3",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "source_system": "klebphacol",
+                "source_disagreement_flag": "1",
+            },
+            {
+                "pair_id": "b1__p4",
+                "bacteria": "b1",
+                "phage": "p4",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "source_system": "gpb",
+                "source_disagreement_flag": "0",
+            },
         ],
     )
     tier_b_ingest = tmp_path / "ti06_weak_label_ingested_pairs.csv"
@@ -230,8 +283,11 @@ def test_main_emits_external_confidence_outputs(tmp_path) -> None:
 
     with (output_dir / "ti07_external_label_confidence_pairs.csv").open("r", encoding="utf-8") as handle:
         rows = list(csv.DictReader(handle))
-    assert len(rows) == 3
+    assert len(rows) == 6
     assert {row["external_label_confidence_tier"] for row in rows} == {"high", "medium", "exclude"}
+    assert {row["confidence_tier"] for row in rows} == {"high", "medium", "exclude"}
+    assert {row["training_weight"] for row in rows} == {"1.0", "0.5", "0.0"}
+    assert {row["include_in_training"] for row in rows} == {"1", "0"}
 
     with (output_dir / "ti07_external_label_confidence_summary.csv").open("r", encoding="utf-8") as handle:
         summary_rows = list(csv.DictReader(handle))
@@ -243,6 +299,126 @@ def test_main_emits_external_confidence_outputs(tmp_path) -> None:
 
     policy = json.loads((output_dir / "ti07_external_label_confidence_policy.json").read_text(encoding="utf-8"))
     assert policy["policy_name"] == "track_i_external_label_confidence_tiers"
+    assert policy["policy_version"] == "v2"
 
     manifest = json.loads((output_dir / "ti07_external_label_confidence_manifest.json").read_text(encoding="utf-8"))
     assert manifest["step_name"] == "build_external_label_confidence_tiers"
+    assert manifest["source_row_counts"] == {
+        "vhrdb": 1,
+        "basel": 1,
+        "klebphacol": 1,
+        "gpb": 1,
+        "virus_host_db": 1,
+        "ncbi_virus_biosample": 1,
+    }
+
+
+def test_main_raises_when_expected_source_has_zero_rows(tmp_path) -> None:
+    source_registry = tmp_path / "source_registry.csv"
+    _write_csv(
+        source_registry,
+        [
+            "source_id",
+            "source_type",
+            "confidence_tier",
+            "confidence_basis",
+            "host_resolution",
+            "notes",
+        ],
+        [
+            {
+                "source_id": "vhrdb",
+                "source_type": "curated_database",
+                "confidence_tier": "A",
+                "confidence_basis": "direct_experimental_screening",
+                "host_resolution": "strain",
+                "notes": "",
+            },
+            {
+                "source_id": "basel",
+                "source_type": "publication_dataset",
+                "confidence_tier": "A",
+                "confidence_basis": "direct_experimental_screening",
+                "host_resolution": "strain",
+                "notes": "",
+            },
+            {
+                "source_id": "klebphacol",
+                "source_type": "curated_database",
+                "confidence_tier": "A",
+                "confidence_basis": "curated_experimental_records",
+                "host_resolution": "strain",
+                "notes": "",
+            },
+            {
+                "source_id": "gpb",
+                "source_type": "curated_database",
+                "confidence_tier": "A",
+                "confidence_basis": "assay_backed_records_from_bank_workflows",
+                "host_resolution": "strain",
+                "notes": "",
+            },
+            {
+                "source_id": "virus_host_db",
+                "source_type": "metadata_knowledgebase",
+                "confidence_tier": "B",
+                "confidence_basis": "metadata_inferred_without_uniform_wet_lab_assay",
+                "host_resolution": "species_or_higher_taxonomy",
+                "notes": "",
+            },
+            {
+                "source_id": "ncbi_virus_biosample",
+                "source_type": "metadata_repository",
+                "confidence_tier": "B",
+                "confidence_basis": "submitter_metadata_with_variable_validation",
+                "host_resolution": "species_or_higher_taxonomy",
+                "notes": "",
+            },
+        ],
+    )
+    tier_a_ingest = tmp_path / "ti05_tier_a_harmonized_pairs.csv"
+    _write_csv(
+        tier_a_ingest,
+        [
+            "pair_id",
+            "source_system",
+        ],
+        [
+            {
+                "pair_id": "b1__p1",
+                "source_system": "vhrdb",
+            }
+        ],
+    )
+    tier_b_ingest = tmp_path / "ti06_weak_label_ingested_pairs.csv"
+    _write_csv(
+        tier_b_ingest,
+        [
+            "pair_id",
+            "source_system",
+        ],
+        [
+            {
+                "pair_id": "b2__p2",
+                "source_system": "virus_host_db",
+            },
+            {
+                "pair_id": "b3__p3",
+                "source_system": "ncbi_virus_biosample",
+            },
+        ],
+    )
+
+    with pytest.raises(ValueError, match="basel, gpb, klebphacol"):
+        main(
+            [
+                "--source-registry-path",
+                str(source_registry),
+                "--tier-a-ingest-path",
+                str(tier_a_ingest),
+                "--tier-b-ingest-path",
+                str(tier_b_ingest),
+                "--output-dir",
+                str(tmp_path / "out"),
+            ]
+        )


### PR DESCRIPTION
## Summary
- tighten TI07 so it requires the real TI05 and TI06 artifacts, validates that all six expected external sources contribute rows, and fails fast when any source produces zero tiered rows
- emit the plan-required `confidence_tier` and `training_weight` columns while preserving the existing `external_label_*` aliases used by downstream Track I steps
- add TI07 regression coverage and replace the outdated notebook entry with the 2026-03-24 live source-by-tier distribution from a regenerated TI03-TI07 run

## Validation
- `pytest -q lyzortx/tests/`
- `python -m lyzortx.pipeline.track_a.run_track_a --step build`
- `python -m lyzortx.pipeline.track_i.run_track_i --step tier-a-ingest`
- `python -m lyzortx.pipeline.track_i.run_track_i --step tier-a-harmonization`
- `python -m lyzortx.pipeline.track_i.run_track_i --step weak-label-ingest`
- `python -m lyzortx.pipeline.track_i.run_track_i --step external-confidence-tiers`

Generated by Codex gpt-5.4

Closes #231