### PR TITLE
[ORCH][TI08] Build training cohorts from internal + external rows

### DIFF
--- a/lyzortx/pipeline/track_i/steps/build_external_training_cohorts.py
+++ b/lyzortx/pipeline/track_i/steps/build_external_training_cohorts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""TI08: Build internal-only and external-enhanced training cohorts without blocking the baseline."""
+"""TI08: Build internal-only and external-enhanced training cohorts from TI07 rows."""
 
 from __future__ import annotations
 
@@ -20,6 +20,8 @@ REQUIRED_EXTERNAL_COLUMNS = (
     "label_hard_any_lysis",
     "label_strict_confidence_tier",
     "source_system",
+    "confidence_tier",
+    "training_weight",
     "external_label_confidence_tier",
     "external_label_confidence_score",
     "external_label_training_weight",
@@ -46,6 +48,8 @@ OUTPUT_APPEND_COLUMNS = [
     "source_family",
     "first_training_arm",
     "first_training_arm_index",
+    "confidence_tier",
+    "training_weight",
     "effective_training_weight",
     "integration_status",
 ]
@@ -105,7 +109,7 @@ def source_family_for_source(source_system: str) -> str:
 
 def load_external_rows(path: Path) -> List[Dict[str, str]]:
     if not path.exists():
-        return []
+        raise FileNotFoundError(f"Missing TI07 external confidence cohort: {path}")
     return [_normalize_row(row) for row in read_csv_rows(path, REQUIRED_EXTERNAL_COLUMNS)]
 
 
@@ -123,6 +127,8 @@ def build_integrated_training_rows(
                 "source_family": "internal",
                 "first_training_arm": "internal_only",
                 "first_training_arm_index": TRAINING_ARM_INDEX["internal_only"],
+                "confidence_tier": "",
+                "training_weight": "",
                 "effective_training_weight": 1.0,
                 "integration_status": "baseline_internal",
             }
@@ -139,6 +145,10 @@ def build_integrated_training_rows(
                 "source_family": source_family_for_source(source_system),
                 "first_training_arm": first_arm if include_in_training else "excluded",
                 "first_training_arm_index": TRAINING_ARM_INDEX[first_arm] if include_in_training else -1,
+                "confidence_tier": normalized.get("confidence_tier", "")
+                or normalized.get("external_label_confidence_tier", ""),
+                "training_weight": normalized.get("training_weight", "")
+                or normalized.get("external_label_training_weight", ""),
                 "effective_training_weight": (
                     float(normalized.get("external_label_training_weight", "0") or 0.0) if include_in_training else 0.0
                 ),
@@ -235,6 +245,13 @@ def main(argv: Optional[List[str]] = None) -> None:
     external_rows = load_external_rows(args.external_confidence_path)
 
     integrated_rows = build_integrated_training_rows(internal_rows, external_rows)
+    included_external_rows = [
+        row
+        for row in integrated_rows
+        if str(row["source_system"]) != "internal" and int(row["first_training_arm_index"]) >= 0
+    ]
+    if not included_external_rows:
+        raise ValueError("TI08 requires >0 external rows with external_label_include_in_training=1")
     arm_summary_rows = compute_training_arm_summary(integrated_rows)
     integration_status_rows = compute_integration_status_summary(integrated_rows)
 

--- a/lyzortx/research_notes/lab_notebooks/track_I.md
+++ b/lyzortx/research_notes/lab_notebooks/track_I.md
@@ -337,6 +337,40 @@ produces a runnable internal-only cohort plus zero-lift summaries for the future
 - This is the correct amount of implementation for TI08. It makes the enhancement path executable and testable without
   prematurely claiming that the current model trainers should already consume every external row.
 
+### 2026-03-24: TI08 Build training cohorts from internal + external rows
+
+#### Executive summary
+
+TI08 now emits a single cohort file that contains the internal ST0.2 rows plus the TI07 external rows, and it fails
+fast if the external side is missing or if every external row is excluded by the confidence policy. The updated
+`lyzortx/pipeline/track_i/steps/build_external_training_cohorts.py` contract preserves the legacy
+`external_label_*` fields for Track K while also surfacing the generic `confidence_tier` and `training_weight`
+columns required by the plan.
+
+#### What changed
+
+- Required TI08 external inputs now include the real TI07 CSV columns, not an optional empty fallback.
+- Internal rows are still emitted with `first_training_arm=internal_only`, so the baseline arm remains extractable from
+  the same file.
+- External rows now carry both the generic and legacy confidence/weight fields in the TI08 cohort output.
+- TI08 raises `ValueError` when no external row survives `external_label_include_in_training=1`.
+- Added regression coverage for the happy path and the all-excluded failure case.
+
+#### Findings
+
+- The old missing-external shortcut was incompatible with the task acceptance criteria because it allowed a valid TI08
+  run to produce an internal-only file.
+- The legacy `external_label_*` fields still need to remain in the cohort file because Track K and TI10 already consume
+  them directly.
+- The new generic `confidence_tier` and `training_weight` columns can coexist with those aliases without changing the
+  downstream join contract.
+
+#### Interpretation
+
+TI08 is now an actual integration boundary rather than a permissive passthrough. The cohort file can support both the
+internal-only baseline and the external-enhanced arms, but it no longer pretends that an empty or fully excluded
+external feed is an acceptable final artifact.
+
 ### 2026-03-22: TI09 Strict ablation sequence
 
 #### Executive summary

--- a/lyzortx/tests/test_external_training_cohorts.py
+++ b/lyzortx/tests/test_external_training_cohorts.py
@@ -64,6 +64,8 @@ def test_build_integrated_training_rows_assigns_planned_training_arms() -> None:
     assert by_source["internal"]["effective_training_weight"] == 1.0
     assert by_source["vhrdb"]["first_training_arm"] == "plus_vhrdb"
     assert by_source["vhrdb"]["integration_status"] == "external_enhancer"
+    assert by_source["vhrdb"]["confidence_tier"] == "high"
+    assert by_source["vhrdb"]["training_weight"] == "1.0"
     assert by_source["virus_host_db"]["first_training_arm"] == "excluded"
     assert by_source["virus_host_db"]["first_training_arm_index"] == -1
     assert by_source["virus_host_db"]["integration_status"] == "excluded_by_confidence"
@@ -99,8 +101,9 @@ def test_compute_training_arm_summary_keeps_internal_only_runnable() -> None:
     assert all(row["cumulative_pair_count"] == 2 for row in summary)
 
 
-def test_main_emits_internal_only_outputs_when_external_confidence_is_missing(tmp_path) -> None:
+def test_main_emits_internal_and_external_outputs(tmp_path) -> None:
     internal_pair_table = tmp_path / "st02_pair_table.csv"
+    external_confidence = tmp_path / "ti07_external_label_confidence_pairs.csv"
     _write_csv(
         internal_pair_table,
         ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier"],
@@ -114,6 +117,39 @@ def test_main_emits_internal_only_outputs_when_external_confidence_is_missing(tm
             }
         ],
     )
+    _write_csv(
+        external_confidence,
+        [
+            "pair_id",
+            "bacteria",
+            "phage",
+            "label_hard_any_lysis",
+            "label_strict_confidence_tier",
+            "source_system",
+            "confidence_tier",
+            "training_weight",
+            "external_label_confidence_tier",
+            "external_label_confidence_score",
+            "external_label_training_weight",
+            "external_label_include_in_training",
+        ],
+        [
+            {
+                "pair_id": "b2__p2",
+                "bacteria": "b2",
+                "phage": "p2",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "source_system": "vhrdb",
+                "confidence_tier": "high",
+                "training_weight": "1.0",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+                "external_label_include_in_training": "1",
+            }
+        ],
+    )
     output_dir = tmp_path / "out"
 
     main(
@@ -121,7 +157,7 @@ def test_main_emits_internal_only_outputs_when_external_confidence_is_missing(tm
             "--internal-pair-table-path",
             str(internal_pair_table),
             "--external-confidence-path",
-            str(tmp_path / "missing.csv"),
+            str(external_confidence),
             "--output-dir",
             str(output_dir),
         ]
@@ -129,13 +165,87 @@ def test_main_emits_internal_only_outputs_when_external_confidence_is_missing(tm
 
     with (output_dir / "ti08_training_cohort_rows.csv").open("r", encoding="utf-8") as handle:
         rows = list(csv.DictReader(handle))
-    assert len(rows) == 1
-    assert rows[0]["source_system"] == "internal"
-    assert rows[0]["first_training_arm"] == "internal_only"
+    assert len(rows) == 2
+    internal_row = next(row for row in rows if row["source_system"] == "internal")
+    external_row = next(row for row in rows if row["source_system"] == "vhrdb")
+    assert internal_row["first_training_arm"] == "internal_only"
+    assert external_row["first_training_arm"] == "plus_vhrdb"
+    assert external_row["confidence_tier"] == "high"
+    assert external_row["training_weight"] == "1.0"
+    assert external_row["external_label_confidence_tier"] == "high"
+    assert external_row["external_label_training_weight"] == "1.0"
 
     manifest = json.loads((output_dir / "ti08_training_cohort_manifest.json").read_text(encoding="utf-8"))
     assert manifest["step_name"] == "build_external_training_cohorts"
-    assert manifest["external_confidence_input_present"] is False
+    assert manifest["external_confidence_input_present"] is True
+
+
+def test_main_raises_when_all_external_rows_are_excluded(tmp_path) -> None:
+    internal_pair_table = tmp_path / "st02_pair_table.csv"
+    external_confidence = tmp_path / "ti07_external_label_confidence_pairs.csv"
+    _write_csv(
+        internal_pair_table,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier"],
+        [
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+            }
+        ],
+    )
+    _write_csv(
+        external_confidence,
+        [
+            "pair_id",
+            "bacteria",
+            "phage",
+            "label_hard_any_lysis",
+            "label_strict_confidence_tier",
+            "source_system",
+            "confidence_tier",
+            "training_weight",
+            "external_label_confidence_tier",
+            "external_label_confidence_score",
+            "external_label_training_weight",
+            "external_label_include_in_training",
+        ],
+        [
+            {
+                "pair_id": "b2__p2",
+                "bacteria": "b2",
+                "phage": "p2",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "source_system": "vhrdb",
+                "confidence_tier": "high",
+                "training_weight": "1.0",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+                "external_label_include_in_training": "0",
+            }
+        ],
+    )
+    output_dir = tmp_path / "out"
+
+    try:
+        main(
+            [
+                "--internal-pair-table-path",
+                str(internal_pair_table),
+                "--external-confidence-path",
+                str(external_confidence),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+    except ValueError as exc:
+        assert "requires >0 external rows" in str(exc)
+    else:
+        raise AssertionError("TI08 should fail when every external row is excluded")
 
 
 def test_run_track_i_dispatches_ti08_step(monkeypatch) -> None:


### PR DESCRIPTION
Build the TI08 training cohort as a single cohort file that keeps the internal baseline rows and integrates the TI07 external rows in the same artifact.

Changes:
- Require a real TI07 external-confidence CSV instead of silently falling back to an internal-only cohort.
- Emit `ti08_training_cohort_rows.csv` with internal rows plus external rows, preserving the legacy `external_label_*` fields for downstream Track K consumers.
- Add the generic `confidence_tier` and `training_weight` columns to the cohort output for the plan contract.
- Fail fast when every external row is excluded by the TI07 policy.
- Update TI08 tests to cover the happy path and the all-excluded failure case.
- Record the TI08 contract change in the Track I lab notebook.

Validation:
- `pytest -q lyzortx/tests/`

Generated by Codex gpt-5.4-mini

Closes #233