### PR TITLE
[ORCH][TI09] Strict ablation retraining with zero-row guard

### DIFF
--- a/lyzortx/pipeline/track_i/steps/build_strict_ablation_sequence.py
+++ b/lyzortx/pipeline/track_i/steps/build_strict_ablation_sequence.py
@@ -5,13 +5,32 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 from lyzortx.pipeline.steel_thread_v0.io.write_outputs import ensure_directory, write_csv, write_json
 from lyzortx.pipeline.steel_thread_v0.steps._io_helpers import read_csv_rows, safe_round
+from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import (
+    FeatureSpace,
+    build_feature_space,
+    compute_binary_metrics,
+    compute_top3_hit_rate,
+    fit_final_estimator,
+    make_lightgbm_estimator,
+    merge_expanded_feature_rows,
+)
 from lyzortx.pipeline.track_i.steps.build_external_training_cohorts import TRAINING_ARM_INDEX, TRAINING_ARM_ORDER
+from lyzortx.pipeline.track_k.steps.build_source_lift_helpers import (
+    build_locked_feature_space,
+    build_training_rows,
+    load_locked_v1_feature_config,
+    load_source_training_rows,
+    load_tg01_best_params,
+)
+
+LOGGER = logging.getLogger(__name__)
 
 REQUIRED_COHORT_COLUMNS = (
     "pair_id",
@@ -20,6 +39,7 @@ REQUIRED_COHORT_COLUMNS = (
     "first_training_arm_index",
     "effective_training_weight",
 )
+REQUIRED_ST02_COLUMNS = ("pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier")
 
 STRICT_ABLATION_SOURCE_ADDITIONS: Dict[str, Tuple[str, ...]] = {
     "internal_only": ("internal",),
@@ -41,19 +61,65 @@ STRICT_SOURCE_ORDER = (
 )
 STRICT_SOURCE_INDEX = {source: idx for idx, source in enumerate(STRICT_SOURCE_ORDER)}
 
+LOCKED_V1_FEATURE_CONFIG_PATH = Path("lyzortx/pipeline/track_g/v1_feature_configuration.json")
+TG01_SUMMARY_PATH = Path("lyzortx/generated_outputs/track_g/tg01_v1_binary_classifier/tg01_model_summary.json")
+TI08_TRAINING_COHORT_PATH = Path(
+    "lyzortx/generated_outputs/track_i/training_cohort_integration/ti08_training_cohort_rows.csv"
+)
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/track_i/strict_ablation_sequence")
+
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--training-cohort-path",
+        "--st02-pair-table-path",
         type=Path,
-        default=Path("lyzortx/generated_outputs/track_i/training_cohort_integration/ti08_training_cohort_rows.csv"),
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st02_pair_table.csv"),
     )
     parser.add_argument(
-        "--output-dir",
+        "--st03-split-assignments-path",
         type=Path,
-        default=Path("lyzortx/generated_outputs/track_i/strict_ablation_sequence"),
+        default=Path("lyzortx/generated_outputs/steel_thread_v0/intermediate/st03_split_assignments.csv"),
     )
+    parser.add_argument(
+        "--track-c-pair-table-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_c/v1_host_feature_pair_table/pair_table_v1.csv"),
+    )
+    parser.add_argument(
+        "--track-d-genome-kmer-path",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/track_d/phage_genome_kmer_features/phage_genome_kmer_features.csv"),
+    )
+    parser.add_argument(
+        "--track-d-distance-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_d/phage_distance_embedding/phage_distance_embedding_features.csv"
+        ),
+    )
+    parser.add_argument(
+        "--track-e-rbp-compatibility-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_e/rbp_receptor_compatibility_feature_block/"
+            "rbp_receptor_compatibility_features_v1.csv"
+        ),
+    )
+    parser.add_argument(
+        "--track-e-isolation-distance-path",
+        type=Path,
+        default=Path(
+            "lyzortx/generated_outputs/track_e/isolation_host_distance_feature_block/"
+            "isolation_host_distance_features_v1.csv"
+        ),
+    )
+    parser.add_argument("--v1-feature-config-path", type=Path, default=LOCKED_V1_FEATURE_CONFIG_PATH)
+    parser.add_argument("--tg01-summary-path", type=Path, default=TG01_SUMMARY_PATH)
+    parser.add_argument("--training-cohort-path", type=Path, default=TI08_TRAINING_COHORT_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--skip-prerequisites", action="store_true")
     return parser.parse_args(argv)
 
 
@@ -147,6 +213,182 @@ def compute_strict_ablation_summary(rows: Sequence[Mapping[str, str]]) -> List[D
     return summary_rows
 
 
+def _measure_holdout_metrics(
+    training_rows: Sequence[Mapping[str, object]],
+    *,
+    feature_space: FeatureSpace,
+    best_params: Mapping[str, object],
+    random_state: int,
+) -> Tuple[Dict[str, object], Dict[str, object], List[Dict[str, object]]]:
+    estimator_factory = lambda params, seed_offset: make_lightgbm_estimator(  # noqa: E731
+        params,
+        seed_offset,
+        base_random_state=random_state,
+    )
+    _, _, _, eval_rows, probabilities = fit_final_estimator(
+        training_rows,
+        feature_space,
+        estimator_factory=estimator_factory,
+        params=best_params,
+        sample_weight_key="effective_training_weight",
+    )
+    scored_rows: List[Dict[str, object]] = []
+    for row, probability in zip(eval_rows, probabilities):
+        scored = dict(row)
+        scored["probability"] = probability
+        scored_rows.append(scored)
+    holdout_metrics = compute_binary_metrics(
+        [int(str(row["label_hard_any_lysis"])) for row in scored_rows],
+        [float(row["probability"]) for row in scored_rows],
+    )
+    top3_metrics = compute_top3_hit_rate(scored_rows, probability_key="probability")
+    return holdout_metrics, top3_metrics, scored_rows
+
+
+def _delta(value: Optional[float], baseline: Optional[float]) -> Optional[float]:
+    if value is None or baseline is None:
+        return None
+    return safe_round(float(value) - float(baseline))
+
+
+def _paired_count(rows: Sequence[Mapping[str, object]]) -> int:
+    return len({str(row["pair_id"]) for row in rows})
+
+
+def build_strict_ablation_report(
+    *,
+    merged_rows: Sequence[Mapping[str, object]],
+    cohort_rows: Sequence[Mapping[str, str]],
+    feature_space: FeatureSpace,
+    best_params: Mapping[str, object],
+    random_state: int,
+) -> List[Dict[str, object]]:
+    internal_rows = [dict(row, source_system="internal") for row in merged_rows]
+    source_rows_by_system: Dict[str, List[Dict[str, object]]] = {}
+    for source_system in STRICT_SOURCE_ORDER:
+        if source_system == "internal":
+            continue
+        source_rows_by_system[source_system], _ = load_source_training_rows(
+            merged_rows,
+            cohort_rows,
+            source_system,
+        )
+
+    report_rows: List[Dict[str, object]] = []
+    previous_metrics: Optional[Dict[str, object]] = None
+    previous_top3: Optional[Dict[str, object]] = None
+    baseline_metrics: Optional[Dict[str, object]] = None
+    baseline_top3: Optional[Dict[str, object]] = None
+    previous_pair_ids: set[str] = set()
+    previous_observed_pair_ids: set[str] = set()
+    previous_row_count = 0
+
+    for arm in TRAINING_ARM_ORDER:
+        added_sources = _planned_sources_for_arm(arm)
+        added_external_rows = sum(
+            len(source_rows_by_system.get(source_system, []))
+            for source_system in added_sources
+            if source_system != "internal"
+        )
+        if arm != "internal_only" and added_external_rows == 0:
+            raise ValueError(
+                f"TI09 arm {arm} requires >0 external rows from the added source(s): {_join_sources(added_sources)}"
+            )
+
+        cumulative_sources = _cumulative_planned_sources_for_arm(arm)
+        training_rows = build_training_rows(internal_rows, source_rows_by_system, cumulative_sources)
+        holdout_metrics, top3_metrics, scored_rows = _measure_holdout_metrics(
+            training_rows,
+            feature_space=feature_space,
+            best_params=best_params,
+            random_state=random_state,
+        )
+        current_rows = [
+            row for row in cohort_rows if int(str(row["first_training_arm_index"])) == TRAINING_ARM_INDEX[arm]
+        ]
+        current_sources = _sorted_unique_sources([str(row["source_system"]) for row in current_rows])
+        external_rows = [row for row in training_rows if str(row.get("source_system", "internal")) != "internal"]
+        cumulative_pair_ids = {str(row["pair_id"]) for row in training_rows}
+        cumulative_external_pair_ids = {str(row["pair_id"]) for row in external_rows}
+        current_pair_ids = {str(row["pair_id"]) for row in current_rows}
+        added_external_pair_ids = set()
+        for source_system in added_sources:
+            if source_system == "internal":
+                continue
+            added_external_pair_ids.update(str(row["pair_id"]) for row in source_rows_by_system.get(source_system, []))
+
+        if baseline_metrics is None:
+            baseline_metrics = holdout_metrics
+            baseline_top3 = top3_metrics
+
+        row = {
+            "arm": arm,
+            "arm_index": TRAINING_ARM_INDEX[arm],
+            "planned_source_systems_added": _join_sources(added_sources),
+            "observed_source_systems_added": _join_sources(current_sources),
+            "cumulative_source_systems": _join_sources(
+                _sorted_unique_sources([str(row.get("source_system", "internal")) for row in training_rows])
+            ),
+            "cumulative_row_count": len(training_rows),
+            "cumulative_pair_count": len(cumulative_pair_ids),
+            "cumulative_external_row_count": len(external_rows),
+            "cumulative_external_pair_count": len(cumulative_external_pair_ids),
+            "new_rows_vs_previous_arm": len(training_rows) - previous_row_count,
+            "new_pairs_vs_previous_arm": len(cumulative_pair_ids - previous_pair_ids),
+            "new_observed_pairs_vs_previous_arm": len(current_pair_ids - previous_observed_pair_ids),
+            "cumulative_training_weight": safe_round(
+                sum(float(row.get("effective_training_weight", 0.0) or 0.0) for row in training_rows)
+            ),
+            "cumulative_planned_source_count": len(cumulative_sources),
+            "added_external_row_count": added_external_rows,
+            "added_external_pair_count": len(added_external_pair_ids),
+            "holdout_roc_auc": holdout_metrics["roc_auc"],
+            "holdout_top3_hit_rate_all_strains": top3_metrics["top3_hit_rate_all_strains"],
+            "holdout_top3_hit_rate_susceptible_only": top3_metrics["top3_hit_rate_susceptible_only"],
+            "holdout_brier_score": holdout_metrics["brier_score"],
+            "delta_roc_auc_vs_internal_only": (
+                0.0
+                if baseline_metrics is None
+                else _delta(holdout_metrics["roc_auc"], baseline_metrics["roc_auc"])
+                if arm != "internal_only"
+                else 0.0
+            ),
+            "delta_top3_vs_internal_only": (
+                0.0
+                if baseline_top3 is None
+                else _delta(top3_metrics["top3_hit_rate_all_strains"], baseline_top3["top3_hit_rate_all_strains"])
+                if arm != "internal_only"
+                else 0.0
+            ),
+            "delta_brier_vs_internal_only": (
+                0.0
+                if baseline_metrics is None
+                else _delta(holdout_metrics["brier_score"], baseline_metrics["brier_score"])
+                if arm != "internal_only"
+                else 0.0
+            ),
+            "delta_roc_auc_vs_previous_arm": 0.0
+            if previous_metrics is None
+            else _delta(holdout_metrics["roc_auc"], previous_metrics["roc_auc"]),
+            "delta_top3_vs_previous_arm": 0.0
+            if previous_top3 is None
+            else _delta(top3_metrics["top3_hit_rate_all_strains"], previous_top3["top3_hit_rate_all_strains"]),
+            "delta_brier_vs_previous_arm": 0.0
+            if previous_metrics is None
+            else _delta(holdout_metrics["brier_score"], previous_metrics["brier_score"]),
+            "evaluation_rows": len(scored_rows),
+            "training_rows": len(training_rows),
+        }
+        report_rows.append(row)
+        previous_metrics = holdout_metrics
+        previous_top3 = top3_metrics
+        previous_pair_ids = cumulative_pair_ids
+        previous_observed_pair_ids = current_pair_ids
+        previous_row_count = len(training_rows)
+
+    return report_rows
+
+
 def ordered_fieldnames(rows: Sequence[Mapping[str, object]]) -> List[str]:
     fieldnames: List[str] = []
     for row in rows:
@@ -158,10 +400,80 @@ def ordered_fieldnames(rows: Sequence[Mapping[str, object]]) -> List[str]:
 
 def main(argv: Optional[List[str]] = None) -> None:
     args = parse_args(argv)
+    LOGGER.info("Starting TI09 strict ablation sequence")
     ensure_directory(args.output_dir)
 
-    rows = read_csv_rows(args.training_cohort_path, REQUIRED_COHORT_COLUMNS)
-    summary_rows = compute_strict_ablation_summary(rows)
+    if not args.skip_prerequisites:
+        from lyzortx.pipeline.track_g.steps.train_v1_binary_classifier import ensure_prerequisite_outputs
+
+        ensure_prerequisite_outputs(args)
+
+    st02_rows = read_csv_rows(args.st02_pair_table_path, REQUIRED_ST02_COLUMNS)
+    split_rows = read_csv_rows(args.st03_split_assignments_path)
+    track_c_pair_rows = read_csv_rows(args.track_c_pair_table_path)
+    track_d_genome_rows = read_csv_rows(args.track_d_genome_kmer_path)
+    track_d_distance_rows = read_csv_rows(args.track_d_distance_path)
+    track_e_rbp_rows = read_csv_rows(args.track_e_rbp_compatibility_path)
+    track_e_isolation_rows = read_csv_rows(args.track_e_isolation_distance_path)
+    cohort_rows = read_csv_rows(args.training_cohort_path, REQUIRED_COHORT_COLUMNS)
+
+    locked_config = load_locked_v1_feature_config(args.v1_feature_config_path)
+    locked_subset_blocks = tuple(str(block) for block in locked_config["winner_subset_blocks"])
+    tg01_best_params = load_tg01_best_params(args.tg01_summary_path)
+
+    track_d_feature_columns = tuple(
+        dict.fromkeys(
+            [column for column in track_d_genome_rows[0].keys() if column != "phage"]
+            + [column for column in track_d_distance_rows[0].keys() if column != "phage"]
+        )
+    )
+    track_e_feature_columns = tuple(
+        dict.fromkeys(
+            [column for column in track_e_rbp_rows[0].keys() if column not in {"pair_id", "bacteria", "phage"}]
+            + [column for column in track_e_isolation_rows[0].keys() if column not in {"pair_id", "bacteria", "phage"}]
+        )
+    )
+    full_feature_space = build_feature_space(
+        st02_rows,
+        track_c_pair_rows,
+        track_d_feature_columns,
+        track_e_feature_columns,
+    )
+    locked_feature_space = build_locked_feature_space(full_feature_space, locked_subset_blocks)
+
+    merged_rows = merge_expanded_feature_rows(
+        track_c_pair_rows,
+        split_rows,
+        phage_feature_blocks=(track_d_genome_rows, track_d_distance_rows),
+        pair_feature_blocks=(track_e_rbp_rows, track_e_isolation_rows),
+    )
+    report_rows = build_strict_ablation_report(
+        merged_rows=merged_rows,
+        cohort_rows=cohort_rows,
+        feature_space=locked_feature_space,
+        best_params=tg01_best_params,
+        random_state=args.random_state,
+    )
+    summary_rows = compute_strict_ablation_summary(cohort_rows)
+    metrics_by_arm = {row["arm"]: row for row in report_rows}
+    for row in summary_rows:
+        metrics = metrics_by_arm[row["arm"]]
+        row.update(
+            {
+                "added_external_row_count": metrics["added_external_row_count"],
+                "added_external_pair_count": metrics["added_external_pair_count"],
+                "holdout_roc_auc": metrics["holdout_roc_auc"],
+                "holdout_top3_hit_rate_all_strains": metrics["holdout_top3_hit_rate_all_strains"],
+                "holdout_top3_hit_rate_susceptible_only": metrics["holdout_top3_hit_rate_susceptible_only"],
+                "holdout_brier_score": metrics["holdout_brier_score"],
+                "delta_roc_auc_vs_internal_only": metrics["delta_roc_auc_vs_internal_only"],
+                "delta_top3_vs_internal_only": metrics["delta_top3_vs_internal_only"],
+                "delta_brier_vs_internal_only": metrics["delta_brier_vs_internal_only"],
+                "delta_roc_auc_vs_previous_arm": metrics["delta_roc_auc_vs_previous_arm"],
+                "delta_top3_vs_previous_arm": metrics["delta_top3_vs_previous_arm"],
+                "delta_brier_vs_previous_arm": metrics["delta_brier_vs_previous_arm"],
+            }
+        )
 
     summary_output_path = args.output_dir / "ti09_strict_ablation_summary.csv"
     manifest_output_path = args.output_dir / "ti09_strict_ablation_manifest.json"
@@ -173,17 +485,47 @@ def main(argv: Optional[List[str]] = None) -> None:
             "generated_at_utc": datetime.now(tz=timezone.utc).isoformat(),
             "step_name": "build_strict_ablation_sequence",
             "strict_ablation_order": list(TRAINING_ARM_ORDER),
+            "training_arm_source_systems": {
+                arm: list(_cumulative_planned_sources_for_arm(arm)) for arm in TRAINING_ARM_ORDER
+            },
             "input_paths": {
+                "st02_pair_table": str(args.st02_pair_table_path),
+                "st03_split_assignments": str(args.st03_split_assignments_path),
+                "track_c_pair_table": str(args.track_c_pair_table_path),
+                "track_d_genome_kmers": str(args.track_d_genome_kmer_path),
+                "track_d_distance": str(args.track_d_distance_path),
+                "track_e_rbp_receptor_compatibility": str(args.track_e_rbp_compatibility_path),
+                "track_e_isolation_host_distance": str(args.track_e_isolation_distance_path),
                 "training_cohort_rows": str(args.training_cohort_path),
             },
             "input_hashes_sha256": {
+                "st02_pair_table": _hash_path(args.st02_pair_table_path),
+                "st03_split_assignments": _hash_path(args.st03_split_assignments_path),
+                "track_c_pair_table": _hash_path(args.track_c_pair_table_path),
+                "track_d_genome_kmers": _hash_path(args.track_d_genome_kmer_path),
+                "track_d_distance": _hash_path(args.track_d_distance_path),
+                "track_e_rbp_receptor_compatibility": _hash_path(args.track_e_rbp_compatibility_path),
+                "track_e_isolation_host_distance": _hash_path(args.track_e_isolation_distance_path),
                 "training_cohort_rows": _hash_path(args.training_cohort_path),
+                "v1_feature_config": _hash_path(args.v1_feature_config_path),
+                "tg01_summary": _hash_path(args.tg01_summary_path),
             },
             "output_paths": {
                 "summary": str(summary_output_path),
             },
+            "arm_metrics": [
+                {
+                    "arm": row["arm"],
+                    "holdout_roc_auc": row["holdout_roc_auc"],
+                    "holdout_top3_hit_rate_all_strains": row["holdout_top3_hit_rate_all_strains"],
+                    "holdout_brier_score": row["holdout_brier_score"],
+                    "added_external_row_count": row["added_external_row_count"],
+                }
+                for row in summary_rows
+            ],
         },
     )
+    LOGGER.info("Finished TI09 strict ablation sequence with %d arms", len(summary_rows))
 
 
 if __name__ == "__main__":

--- a/lyzortx/research_notes/lab_notebooks/track_I.md
+++ b/lyzortx/research_notes/lab_notebooks/track_I.md
@@ -371,30 +371,31 @@ TI08 is now an actual integration boundary rather than a permissive passthrough.
 internal-only baseline and the external-enhanced arms, but it no longer pretends that an empty or fully excluded
 external feed is an acceptable final artifact.
 
-### 2026-03-22: TI09 Strict ablation sequence
+### 2026-03-24: TI09 Strict ablation sequence
 
 #### Executive summary
 
-TI09 now has a dedicated Track I step that reads the TI08 cohort output and materializes the planned strict ablation
-order `internal-only -> +VHRdb -> +BASEL -> +KlebPhaCol -> +GPB -> +Tier B`. The step writes a reproducible summary
-table and manifest under `lyzortx/generated_outputs/track_i/strict_ablation_sequence/`, making the source-addition
-sequence explicit instead of burying it inside the cohort integration step.
+TI09 now has a dedicated Track I step that loads the TI08 cohort, rebuilds the locked v1 feature space, and retrains
+the model arm by arm in the planned strict order `internal-only -> +VHRdb -> +BASEL -> +KlebPhaCol -> +GPB ->
++Tier B`. The step now computes holdout ROC-AUC, top-3 hit rate, and Brier score per arm and raises `ValueError` as
+soon as an added source contributes zero external training rows.
 
 #### Findings
 
-- The strict ablation task is a sequencing problem, not a redefinition of the TI08 cohort contract. Reusing TI08 output
-  keeps the implementation honest: the new step only reasons about the order in which rows become eligible for the
-  cumulative arms.
-- Treating `+Tier B` as a final planned addition works cleanly because the TI08 rows already preserve the underlying
-  source-system provenance for Virus-Host DB and NCBI Virus/BioSample separately.
-- The new summary records both the planned source additions and the observed cumulative source coverage, which makes it
-  easy to spot when a planned arm exists but contributes no rows yet.
+- The live end-to-end run now reaches TI09, but it stops at `+BASEL` because the locked feature grid has no joinable
+  Basel rows for the current TI08 cohort. That is the correct failure mode for this task: the step refuses to invent a
+  Basel ablation result when the added source contributes zero trainable rows.
+- The guard is doing something useful here, not just being conservative. The TI08 cohort does contain Basel rows, but
+  the TI09 join against the locked ST03 feature table leaves no Basel rows eligible for retraining, so a silent pass
+  would have produced a misleading ablation report.
+- The implementation still keeps the planned source order explicit and auditable, so if the Basel seam changes in a
+  later data refresh, the same step will immediately surface it by completing the full metric table instead of failing.
 
 #### Interpretation
 
-TI09 is now executable as a standalone, ordered ablation pass. That keeps the Track I pipeline modular: TI08 preserves
-integration trust, and TI09 turns that trusted cohort into a strict source-by-source ablation sequence that TI10 can
-use for lift and failure-mode analysis.
+TI09 is now honest. It retrains the locked model per cumulative arm, but it will not manufacture metrics when an added
+source cannot actually join onto the model feature grid. In this workspace, Basel is the blocker, so the correct
+action is to fail rather than report fake lift.
 
 ### 2026-03-22: TI10 Incremental lift and failure modes
 

--- a/lyzortx/tests/test_strict_ablation_sequence.py
+++ b/lyzortx/tests/test_strict_ablation_sequence.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import csv
 import json
 
+import pytest
+
 from lyzortx.pipeline.track_i import run_track_i
 from lyzortx.pipeline.track_i.steps.build_strict_ablation_sequence import (
     compute_strict_ablation_summary,
@@ -17,6 +19,334 @@ def _write_csv(path, fieldnames, rows) -> None:
         writer = csv.DictWriter(handle, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(rows)
+
+
+def _write_json(path, payload) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_strict_ablation_inputs(tmp_path, *, include_external_rows: bool) -> dict[str, object]:
+    st02 = tmp_path / "st02_pair_table.csv"
+    st03 = tmp_path / "st03_split_assignments.csv"
+    track_c = tmp_path / "pair_table_v1.csv"
+    track_d_genome = tmp_path / "phage_genome_kmer_features.csv"
+    track_d_distance = tmp_path / "phage_distance_embedding_features.csv"
+    track_e_rbp = tmp_path / "rbp_receptor_compatibility_features_v1.csv"
+    track_e_isolation = tmp_path / "isolation_host_distance_features_v1.csv"
+    cohort = tmp_path / "ti08_training_cohort_rows.csv"
+    v1_config = tmp_path / "v1_feature_configuration.json"
+    tg01_summary = tmp_path / "tg01_model_summary.json"
+
+    _write_csv(
+        st02,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p3",
+                "bacteria": "b1",
+                "phage": "p3",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        st03,
+        ["pair_id", "bacteria", "phage", "split_holdout", "split_cv5_fold", "is_hard_trainable"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "0",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "1",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "split_holdout": "holdout_test",
+                "split_cv5_fold": "-1",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p3",
+                "bacteria": "b1",
+                "phage": "p3",
+                "split_holdout": "holdout_test",
+                "split_cv5_fold": "-1",
+                "is_hard_trainable": "1",
+            },
+        ],
+    )
+    _write_csv(
+        track_c,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p2",
+                "bacteria": "b1",
+                "phage": "p2",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p3",
+                "bacteria": "b1",
+                "phage": "p3",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        track_d_genome,
+        ["phage", "phage_gc_content"],
+        [
+            {"phage": "p0", "phage_gc_content": "0.40"},
+            {"phage": "p1", "phage_gc_content": "0.50"},
+            {"phage": "p2", "phage_gc_content": "0.60"},
+            {"phage": "p3", "phage_gc_content": "0.70"},
+        ],
+    )
+    _write_csv(
+        track_d_distance,
+        ["phage", "phage_distance_umap_00"],
+        [
+            {"phage": "p0", "phage_distance_umap_00": "0.05"},
+            {"phage": "p1", "phage_distance_umap_00": "0.10"},
+            {"phage": "p2", "phage_distance_umap_00": "0.20"},
+            {"phage": "p3", "phage_distance_umap_00": "0.30"},
+        ],
+    )
+    _write_csv(
+        track_e_rbp,
+        ["pair_id", "bacteria", "phage", "lookup_available"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "lookup_available": "1"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "lookup_available": "1"},
+            {"pair_id": "b1__p2", "bacteria": "b1", "phage": "p2", "lookup_available": "0"},
+            {"pair_id": "b1__p3", "bacteria": "b1", "phage": "p3", "lookup_available": "1"},
+        ],
+    )
+    _write_csv(
+        track_e_isolation,
+        ["pair_id", "bacteria", "phage", "isolation_host_distance"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "isolation_host_distance": "0.25"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "isolation_host_distance": "0.30"},
+            {"pair_id": "b1__p2", "bacteria": "b1", "phage": "p2", "isolation_host_distance": "0.35"},
+            {"pair_id": "b1__p3", "bacteria": "b1", "phage": "p3", "isolation_host_distance": "0.40"},
+        ],
+    )
+    _write_json(v1_config, {"winner_subset_blocks": ["defense", "phage_genomic"]})
+    _write_json(
+        tg01_summary,
+        {
+            "lightgbm": {
+                "best_params": {
+                    "n_estimators": 10,
+                    "learning_rate": 0.1,
+                    "num_leaves": 7,
+                    "min_child_samples": 1,
+                }
+            }
+        },
+    )
+
+    external_rows = []
+    if include_external_rows:
+        external_rows = [
+            {
+                "pair_id": "b1__p0",
+                "source_system": "vhrdb",
+                "first_training_arm": "plus_vhrdb",
+                "first_training_arm_index": "1",
+                "effective_training_weight": "1.0",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+            },
+            {
+                "pair_id": "b1__p1",
+                "source_system": "basel",
+                "first_training_arm": "plus_basel",
+                "first_training_arm_index": "2",
+                "effective_training_weight": "1.0",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+            },
+            {
+                "pair_id": "b1__p0",
+                "source_system": "klebphacol",
+                "first_training_arm": "plus_klebphacol",
+                "first_training_arm_index": "3",
+                "effective_training_weight": "1.0",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+            },
+            {
+                "pair_id": "b1__p1",
+                "source_system": "gpb",
+                "first_training_arm": "plus_gpb",
+                "first_training_arm_index": "4",
+                "effective_training_weight": "1.0",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+            },
+            {
+                "pair_id": "b1__p0",
+                "source_system": "virus_host_db",
+                "first_training_arm": "plus_tier_b",
+                "first_training_arm_index": "5",
+                "effective_training_weight": "0.5",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "medium",
+                "external_label_confidence_score": "2",
+                "external_label_training_weight": "0.5",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+            },
+            {
+                "pair_id": "b1__p1",
+                "source_system": "ncbi_virus_biosample",
+                "first_training_arm": "plus_tier_b",
+                "first_training_arm_index": "5",
+                "effective_training_weight": "0.5",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "medium",
+                "external_label_confidence_score": "2",
+                "external_label_training_weight": "0.5",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+            },
+        ]
+
+    _write_csv(
+        cohort,
+        [
+            "pair_id",
+            "source_system",
+            "first_training_arm",
+            "first_training_arm_index",
+            "effective_training_weight",
+            "external_label_include_in_training",
+            "external_label_confidence_tier",
+            "external_label_confidence_score",
+            "external_label_training_weight",
+            "label_hard_any_lysis",
+            "label_strict_confidence_tier",
+        ],
+        [
+            {
+                "pair_id": "b1__p0",
+                "source_system": "internal",
+                "first_training_arm": "internal_only",
+                "first_training_arm_index": "0",
+                "effective_training_weight": "1.0",
+                "external_label_include_in_training": "",
+                "external_label_confidence_tier": "",
+                "external_label_confidence_score": "",
+                "external_label_training_weight": "",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+            },
+            {
+                "pair_id": "b1__p1",
+                "source_system": "internal",
+                "first_training_arm": "internal_only",
+                "first_training_arm_index": "0",
+                "effective_training_weight": "1.0",
+                "external_label_include_in_training": "",
+                "external_label_confidence_tier": "",
+                "external_label_confidence_score": "",
+                "external_label_training_weight": "",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+            },
+            *external_rows,
+        ],
+    )
+
+    return {
+        "st02": st02,
+        "st03": st03,
+        "track_c": track_c,
+        "track_d_genome": track_d_genome,
+        "track_d_distance": track_d_distance,
+        "track_e_rbp": track_e_rbp,
+        "track_e_isolation": track_e_isolation,
+        "cohort": cohort,
+        "v1_config": v1_config,
+        "tg01_summary": tg01_summary,
+    }
 
 
 def test_compute_strict_ablation_summary_keeps_the_planned_source_order() -> None:
@@ -93,39 +423,32 @@ def test_compute_strict_ablation_summary_keeps_the_planned_source_order() -> Non
 
 
 def test_main_emits_strict_ablation_outputs(tmp_path) -> None:
-    cohort_rows = tmp_path / "ti08_training_cohort_rows.csv"
-    _write_csv(
-        cohort_rows,
-        [
-            "pair_id",
-            "source_system",
-            "first_training_arm",
-            "first_training_arm_index",
-            "effective_training_weight",
-        ],
-        [
-            {
-                "pair_id": "b1__p1",
-                "source_system": "internal",
-                "first_training_arm": "internal_only",
-                "first_training_arm_index": "0",
-                "effective_training_weight": "1.0",
-            },
-            {
-                "pair_id": "b2__p2",
-                "source_system": "vhrdb",
-                "first_training_arm": "plus_vhrdb",
-                "first_training_arm_index": "1",
-                "effective_training_weight": "1.0",
-            },
-        ],
-    )
+    paths = _write_strict_ablation_inputs(tmp_path, include_external_rows=True)
     output_dir = tmp_path / "out"
 
     main(
         [
+            "--skip-prerequisites",
+            "--st02-pair-table-path",
+            str(paths["st02"]),
+            "--st03-split-assignments-path",
+            str(paths["st03"]),
+            "--track-c-pair-table-path",
+            str(paths["track_c"]),
+            "--track-d-genome-kmer-path",
+            str(paths["track_d_genome"]),
+            "--track-d-distance-path",
+            str(paths["track_d_distance"]),
+            "--track-e-rbp-compatibility-path",
+            str(paths["track_e_rbp"]),
+            "--track-e-isolation-distance-path",
+            str(paths["track_e_isolation"]),
+            "--v1-feature-config-path",
+            str(paths["v1_config"]),
+            "--tg01-summary-path",
+            str(paths["tg01_summary"]),
             "--training-cohort-path",
-            str(cohort_rows),
+            str(paths["cohort"]),
             "--output-dir",
             str(output_dir),
         ]
@@ -142,11 +465,49 @@ def test_main_emits_strict_ablation_outputs(tmp_path) -> None:
         "plus_tier_b",
     ]
     assert rows[1]["planned_source_systems_added"] == "vhrdb"
-    assert rows[2]["new_rows_vs_previous_arm"] == "0"
+    assert rows[1]["holdout_roc_auc"] != ""
+    assert rows[-1]["added_external_row_count"] == "2"
+    assert rows[-1]["holdout_top3_hit_rate_all_strains"] != ""
+    assert rows[-1]["holdout_brier_score"] != ""
 
     manifest = json.loads((output_dir / "ti09_strict_ablation_manifest.json").read_text(encoding="utf-8"))
     assert manifest["step_name"] == "build_strict_ablation_sequence"
     assert manifest["strict_ablation_order"][-1] == "plus_tier_b"
+    assert manifest["training_arm_source_systems"]["plus_tier_b"][-1] == "ncbi_virus_biosample"
+
+
+def test_main_raises_when_an_added_source_has_zero_rows(tmp_path) -> None:
+    paths = _write_strict_ablation_inputs(tmp_path, include_external_rows=False)
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(ValueError, match="requires >0 external rows"):
+        main(
+            [
+                "--skip-prerequisites",
+                "--st02-pair-table-path",
+                str(paths["st02"]),
+                "--st03-split-assignments-path",
+                str(paths["st03"]),
+                "--track-c-pair-table-path",
+                str(paths["track_c"]),
+                "--track-d-genome-kmer-path",
+                str(paths["track_d_genome"]),
+                "--track-d-distance-path",
+                str(paths["track_d_distance"]),
+                "--track-e-rbp-compatibility-path",
+                str(paths["track_e_rbp"]),
+                "--track-e-isolation-distance-path",
+                str(paths["track_e_isolation"]),
+                "--v1-feature-config-path",
+                str(paths["v1_config"]),
+                "--tg01-summary-path",
+                str(paths["tg01_summary"]),
+                "--training-cohort-path",
+                str(paths["cohort"]),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
 
 
 def test_run_track_i_dispatches_ti09_step(monkeypatch) -> None:


### PR DESCRIPTION
Adds a real TI09 runner that:
- loads TI08 plus the locked TG01 v1 artifacts
- rebuilds the locked v1 feature space
- retrains the locked model arm by arm across the strict source order
- reports holdout ROC-AUC, top-3 hit rate, and Brier per arm
- raises ValueError when an added source contributes zero external rows

Validation:
- `pytest -q lyzortx/tests/`

Live run:
- `python -m lyzortx.pipeline.track_i.run_track_i --step all` now reaches TI09, but the current workspace aborts at `+BASEL` because that source contributes zero joinable external rows to the locked feature grid. That is the intended fail-fast behavior, not a silent pass.

Generated by Codex gpt-5.4-mini

Closes #235