### PR TITLE
[ORCH][TK01] Add VHRdb to training and measure lift

### DIFF
--- a/lyzortx/pipeline/track_k/steps/build_vhrdb_lift_report.py
+++ b/lyzortx/pipeline/track_k/steps/build_vhrdb_lift_report.py
@@ -154,6 +154,15 @@ def _normalize_row(row: Mapping[str, str]) -> Dict[str, str]:
     return {key: (value.strip() if isinstance(value, str) else "") for key, value in row.items()}
 
 
+def load_ti08_training_cohort_rows(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing TI08 training cohort artifact: {path}")
+    rows = read_csv_rows(path)
+    if not rows:
+        raise ValueError(f"TI08 training cohort is empty: {path}")
+    return rows
+
+
 def load_vhrdb_training_rows(
     feature_rows: Sequence[Mapping[str, object]],
     cohort_rows: Sequence[Mapping[str, str]],
@@ -255,8 +264,15 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         phage_feature_blocks=(track_d_genome_rows, track_d_distance_rows),
         pair_feature_blocks=(track_e_rbp_rows, track_e_isolation_rows),
     )
-    cohort_rows = read_csv_rows(args.ti08_training_cohort_path) if args.ti08_training_cohort_path.exists() else []
+    cohort_rows = load_ti08_training_cohort_rows(args.ti08_training_cohort_path)
     vhrdb_rows, vhrdb_counts = load_vhrdb_training_rows(merged_rows, cohort_rows)
+    if int(vhrdb_counts.get("cohort_rows", 0)) == 0:
+        raise ValueError(f"TI08 cohort contains no VHRdb rows: {args.ti08_training_cohort_path}")
+    if int(vhrdb_counts.get("joined_rows", 0)) == 0:
+        raise ValueError(
+            "TI08 cohort contains no VHRdb rows that join into the locked ST03 train split: "
+            f"{args.ti08_training_cohort_path}"
+        )
 
     internal_training_rows = list(merged_rows)
     augmented_training_rows = list(merged_rows) + vhrdb_rows
@@ -332,14 +348,16 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         and metric_deltas["delta_brier_score"] >= -NEGLIGIBLE_DELTA_TOLERANCE
     )
 
-    if not cohort_rows:
-        lift_decision = "pending_external_artifact"
-    elif joined_vhrdb_rows == 0:
-        lift_decision = "no_joinable_vhrdb_rows"
-    elif lift_is_negative_or_negligible:
+    if lift_is_negative_or_negligible:
         lift_decision = "do_not_include_vhrdb"
     else:
         lift_decision = "keep_vhrdb_for_followup_arms"
+
+    lift_reason = (
+        "delta metrics were within the negligible tolerance"
+        if lift_decision == "do_not_include_vhrdb"
+        else "VHRdb improved at least one tracked metric without harming the others"
+    )
 
     summary_rows = [
         {
@@ -449,6 +467,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
             },
             "vhrdb_counts": vhrdb_counts,
             "joined_vhrdb_rows": joined_vhrdb_rows,
+            "lift_reason": lift_reason,
             "baseline_metrics": {
                 "roc_auc": baseline_holdout_metrics["roc_auc"],
                 "top3_hit_rate_all_strains": baseline_top3["top3_hit_rate_all_strains"],

--- a/lyzortx/research_notes/lab_notebooks/track_K.md
+++ b/lyzortx/research_notes/lab_notebooks/track_K.md
@@ -3,36 +3,37 @@
 #### Executive summary
 
 Added the TK01 Track K runner to measure VHRdb lift against the locked v1 baseline and record the result in a
-manifest plus summary tables under `lyzortx/generated_outputs/track_k/tk01_vhrdb_lift_measurement/`. The first local
-run found no joinable TI08 VHRdb rows, so the lift deltas were all `0.0` and the decision remained
-`pending_external_artifact`. The step now requires the locked TG01 summary artifact rather than silently substituting
-defaults, so the baseline comparison stays comparable to the Track G lock.
+manifest plus summary tables under `lyzortx/generated_outputs/track_k/tk01_vhrdb_lift_measurement/`. The step now
+fails closed if the TI08 cohort is missing, empty, or yields zero joinable VHRdb rows, so it no longer emits a fake
+`pending_external_artifact` placeholder. This checkout still does not contain the real TI08 generated artifact, so the
+local production rerun is blocked until that input is restored.
 
 #### What was implemented
 
 - Added a new Track K runner at `lyzortx/pipeline/track_k/run_track_k.py` and a TK01 lift-measurement step at
   `lyzortx/pipeline/track_k/steps/build_vhrdb_lift_report.py`.
 - The step reuses the locked `defense + phage-genomic` v1 feature contract, trains the baseline internal-only model,
-  then attempts to add TI08 VHRdb rows only when they join safely into the ST03 train split.
+  then adds TI08 VHRdb rows only when they join safely into the ST03 train split.
+- Added explicit guards that raise `FileNotFoundError` for a missing TI08 cohort and `ValueError` when the cohort is
+  empty or no VHRdb rows survive the join.
 - Emitted a TK01 summary CSV, top-3 ranking CSV, and manifest under
   `lyzortx/generated_outputs/track_k/tk01_vhrdb_lift_measurement/`.
 
 #### Findings
 
-- In this checkout, the run completed with `0` joinable VHRdb rows from the TI08 cohort artifact.
-- Baseline internal-only holdout metrics were:
-  - ROC-AUC `0.831075`
-  - top-3 hit rate `0.876923`
-  - Brier score `0.166377`
-- The VHRdb-augmented arm was identical because no cohort rows joined into the training split, so all deltas were `0.0`.
-- The TK01 manifest marked the decision as `pending_external_artifact`.
+- The repository snapshot used for this run does not include the TI08 cohort artifact, so the real TK01 measurement
+  cannot be reproduced here without regenerating that input.
+- The new contract now prevents a silent fallback to an internal-only placeholder when TI08 is absent.
+- On the unit-test fixture, the VHRdb arm can be joined into the locked ST03 train split and the manifest records the
+  resulting baseline-versus-augmented metrics plus a `do_not_include_vhrdb` or `keep_vhrdb_for_followup_arms`
+  decision.
 
 #### Interpretation
 
 - The Track K seam is now wired correctly: if TI08 VHRdb rows appear later, they will enter training only through the
-  locked ST03-safe path.
-- For this repository state, VHRdb should not be added to later arms yet. The code path is ready, but the local
-  artifact set does not contain joinable VHRdb training rows, so there is no empirical lift to carry forward.
+  locked ST03-safe path and the step will fail if that path produces no real VHRdb rows.
+- Because the required TI08 artifact is absent in this checkout, there is no honest basis to promote VHRdb to later
+  arms from this run alone.
 
 ### 2026-03-24: TK02 BASEL cumulative lift measurement
 

--- a/lyzortx/tests/test_track_k_vhrdb_lift.py
+++ b/lyzortx/tests/test_track_k_vhrdb_lift.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import csv
 import json
 
+import pytest
+
 from lyzortx.pipeline.track_k.steps.build_vhrdb_lift_report import load_vhrdb_training_rows
 from lyzortx.pipeline.track_k.steps.build_vhrdb_lift_report import main
 
@@ -93,7 +95,7 @@ def test_load_vhrdb_training_rows_only_keeps_joinable_train_split_rows() -> None
     assert counts["missing_feature_rows"] == 1
 
 
-def test_main_emits_internal_only_summary_when_vhrdb_cohort_is_missing(tmp_path) -> None:
+def test_main_emits_vhrdb_augmented_summary_when_ti08_rows_join(tmp_path) -> None:
     st02 = tmp_path / "st02_pair_table.csv"
     st03 = tmp_path / "st03_split_assignments.csv"
     track_c = tmp_path / "pair_table_v1.csv"
@@ -290,6 +292,36 @@ def test_main_emits_internal_only_summary_when_vhrdb_cohort_is_missing(tmp_path)
             }
         },
     )
+    ti08 = tmp_path / "ti08_training_cohort_rows.csv"
+    _write_csv(
+        ti08,
+        [
+            "pair_id",
+            "bacteria",
+            "phage",
+            "source_system",
+            "external_label_include_in_training",
+            "external_label_confidence_tier",
+            "external_label_confidence_score",
+            "external_label_training_weight",
+            "label_hard_any_lysis",
+            "label_strict_confidence_tier",
+        ],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "source_system": "vhrdb",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+            }
+        ],
+    )
     output_dir = tmp_path / "out"
 
     main(
@@ -313,7 +345,7 @@ def test_main_emits_internal_only_summary_when_vhrdb_cohort_is_missing(tmp_path)
             "--tg01-summary-path",
             str(tg01_summary),
             "--ti08-training-cohort-path",
-            str(tmp_path / "missing_ti08.csv"),
+            str(ti08),
             "--output-dir",
             str(output_dir),
             "--skip-prerequisites",
@@ -323,11 +355,319 @@ def test_main_emits_internal_only_summary_when_vhrdb_cohort_is_missing(tmp_path)
     summary = list(csv.DictReader((output_dir / "tk01_vhrdb_lift_summary.csv").open("r", encoding="utf-8")))
     assert summary[0]["arm"] == "internal_only"
     assert summary[1]["arm"] == "internal_plus_vhrdb"
-    assert summary[1]["vhrdb_row_count"] == "0"
+    assert summary[1]["vhrdb_row_count"] == "1"
 
     manifest = json.loads((output_dir / "tk01_vhrdb_lift_manifest.json").read_text(encoding="utf-8"))
-    assert manifest["lift_decision"] == "pending_external_artifact"
-    assert manifest["vhrdb_counts"]["joined_rows"] == 0
+    assert manifest["vhrdb_counts"]["cohort_rows"] == 1
+    assert manifest["vhrdb_counts"]["joined_rows"] == 1
+    assert manifest["lift_decision"] in {"do_not_include_vhrdb", "keep_vhrdb_for_followup_arms"}
+    assert manifest["lift_reason"]
+
+
+def test_main_requires_ti08_training_cohort_file(tmp_path) -> None:
+    st02 = tmp_path / "st02_pair_table.csv"
+    st03 = tmp_path / "st03_split_assignments.csv"
+    track_c = tmp_path / "pair_table_v1.csv"
+    track_d_genome = tmp_path / "phage_genome_kmer_features.csv"
+    track_d_distance = tmp_path / "phage_distance_embedding_features.csv"
+    track_e_rbp = tmp_path / "rbp_receptor_compatibility_features_v1.csv"
+    track_e_isolation = tmp_path / "isolation_host_distance_features_v1.csv"
+    v1_config = tmp_path / "v1_feature_configuration.json"
+
+    _write_csv(
+        st02,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        st03,
+        ["pair_id", "bacteria", "phage", "cv_group", "split_holdout", "split_cv5_fold", "is_hard_trainable"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "cv_group": "g0",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "1",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "cv_group": "g1",
+                "split_holdout": "holdout_test",
+                "split_cv5_fold": "-1",
+                "is_hard_trainable": "1",
+            },
+        ],
+    )
+    _write_csv(
+        track_c,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        track_d_genome,
+        ["phage", "phage_gc_content"],
+        [{"phage": "p0", "phage_gc_content": "0.4"}, {"phage": "p1", "phage_gc_content": "0.5"}],
+    )
+    _write_csv(
+        track_d_distance,
+        ["phage", "phage_distance_umap_00"],
+        [{"phage": "p0", "phage_distance_umap_00": "0.05"}, {"phage": "p1", "phage_distance_umap_00": "0.1"}],
+    )
+    _write_csv(
+        track_e_rbp,
+        ["pair_id", "bacteria", "phage", "lookup_available"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "lookup_available": "1"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "lookup_available": "1"},
+        ],
+    )
+    _write_csv(
+        track_e_isolation,
+        ["pair_id", "bacteria", "phage", "isolation_host_distance"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "isolation_host_distance": "0.25"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "isolation_host_distance": "0.3"},
+        ],
+    )
+    v1_config.write_text(json.dumps({"winner_subset_blocks": ["defense", "phage_genomic"]}), encoding="utf-8")
+    tg01_summary = tmp_path / "tg01_model_summary.json"
+    _write_json(
+        tg01_summary,
+        {
+            "lightgbm": {
+                "best_params": {
+                    "n_estimators": 150,
+                    "learning_rate": 0.03,
+                    "num_leaves": 31,
+                    "min_child_samples": 10,
+                }
+            }
+        },
+    )
+
+    with pytest.raises(FileNotFoundError, match="Missing TI08 training cohort artifact"):
+        main(
+            [
+                "--st02-pair-table-path",
+                str(st02),
+                "--st03-split-assignments-path",
+                str(st03),
+                "--track-c-pair-table-path",
+                str(track_c),
+                "--track-d-genome-kmer-path",
+                str(track_d_genome),
+                "--track-d-distance-path",
+                str(track_d_distance),
+                "--track-e-rbp-compatibility-path",
+                str(track_e_rbp),
+                "--track-e-isolation-distance-path",
+                str(track_e_isolation),
+                "--v1-feature-config-path",
+                str(v1_config),
+                "--tg01-summary-path",
+                str(tg01_summary),
+                "--ti08-training-cohort-path",
+                str(tmp_path / "missing_ti08.csv"),
+                "--output-dir",
+                str(tmp_path / "out"),
+                "--skip-prerequisites",
+            ]
+        )
+
+
+def test_main_rejects_empty_ti08_training_cohort_file(tmp_path) -> None:
+    st02 = tmp_path / "st02_pair_table.csv"
+    st03 = tmp_path / "st03_split_assignments.csv"
+    track_c = tmp_path / "pair_table_v1.csv"
+    track_d_genome = tmp_path / "phage_genome_kmer_features.csv"
+    track_d_distance = tmp_path / "phage_distance_embedding_features.csv"
+    track_e_rbp = tmp_path / "rbp_receptor_compatibility_features_v1.csv"
+    track_e_isolation = tmp_path / "isolation_host_distance_features_v1.csv"
+    v1_config = tmp_path / "v1_feature_configuration.json"
+    ti08 = tmp_path / "ti08_training_cohort_rows.csv"
+
+    _write_csv(
+        st02,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        st03,
+        ["pair_id", "bacteria", "phage", "cv_group", "split_holdout", "split_cv5_fold", "is_hard_trainable"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "cv_group": "g0",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "1",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "cv_group": "g1",
+                "split_holdout": "holdout_test",
+                "split_cv5_fold": "-1",
+                "is_hard_trainable": "1",
+            },
+        ],
+    )
+    _write_csv(
+        track_c,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        track_d_genome,
+        ["phage", "phage_gc_content"],
+        [{"phage": "p0", "phage_gc_content": "0.4"}, {"phage": "p1", "phage_gc_content": "0.5"}],
+    )
+    _write_csv(
+        track_d_distance,
+        ["phage", "phage_distance_umap_00"],
+        [{"phage": "p0", "phage_distance_umap_00": "0.05"}, {"phage": "p1", "phage_distance_umap_00": "0.1"}],
+    )
+    _write_csv(
+        track_e_rbp,
+        ["pair_id", "bacteria", "phage", "lookup_available"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "lookup_available": "1"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "lookup_available": "1"},
+        ],
+    )
+    _write_csv(
+        track_e_isolation,
+        ["pair_id", "bacteria", "phage", "isolation_host_distance"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "isolation_host_distance": "0.25"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "isolation_host_distance": "0.3"},
+        ],
+    )
+    ti08.write_text(
+        "pair_id,bacteria,phage,source_system,external_label_include_in_training,external_label_confidence_tier,"
+        "external_label_confidence_score,external_label_training_weight,label_hard_any_lysis,label_strict_confidence_tier\n",
+        encoding="utf-8",
+    )
+    v1_config.write_text(json.dumps({"winner_subset_blocks": ["defense", "phage_genomic"]}), encoding="utf-8")
+    tg01_summary = tmp_path / "tg01_model_summary.json"
+    _write_json(
+        tg01_summary,
+        {
+            "lightgbm": {
+                "best_params": {
+                    "n_estimators": 150,
+                    "learning_rate": 0.03,
+                    "num_leaves": 31,
+                    "min_child_samples": 10,
+                }
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="TI08 training cohort is empty"):
+        main(
+            [
+                "--st02-pair-table-path",
+                str(st02),
+                "--st03-split-assignments-path",
+                str(st03),
+                "--track-c-pair-table-path",
+                str(track_c),
+                "--track-d-genome-kmer-path",
+                str(track_d_genome),
+                "--track-d-distance-path",
+                str(track_d_distance),
+                "--track-e-rbp-compatibility-path",
+                str(track_e_rbp),
+                "--track-e-isolation-distance-path",
+                str(track_e_isolation),
+                "--v1-feature-config-path",
+                str(v1_config),
+                "--tg01-summary-path",
+                str(tg01_summary),
+                "--ti08-training-cohort-path",
+                str(ti08),
+                "--output-dir",
+                str(tmp_path / "out"),
+                "--skip-prerequisites",
+            ]
+        )
 
 
 def test_main_requires_locked_tg01_summary_when_skip_prerequisites_is_used(tmp_path) -> None:


### PR DESCRIPTION
TK01 now fails closed on missing or empty TI08 inputs, and it also raises when TI08 contains no joinable VHRdb rows in the locked ST03 train split. When VHRdb rows do join, the step retrains the locked v1 model against the internal-only baseline, writes the summary/ranking/manifest artifacts, and records whether the lift is negligible enough to exclude VHRdb from later arms.

I also updated the TK01 notebook entry to reflect the new contract and the fact that this checkout does not contain the real TI08 generated artifact.

Tests: `pytest -q lyzortx/tests/`

Agent: Codex gpt-5.4

Closes #239