### PR TITLE
[ORCH][TK02] Add BASEL to training and measure cumulative lift

### DIFF
--- a/lyzortx/pipeline/track_k/steps/build_basel_lift_report.py
+++ b/lyzortx/pipeline/track_k/steps/build_basel_lift_report.py
@@ -141,6 +141,15 @@ def _measure_metrics(
     return scored_rows, holdout_metrics, top3
 
 
+def load_ti08_training_cohort_rows(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing TI08 training cohort artifact: {path}")
+    rows = read_csv_rows(path)
+    if not rows:
+        raise ValueError(f"TI08 training cohort is empty: {path}")
+    return rows
+
+
 def main(argv: Optional[Sequence[str]] = None) -> None:
     args = parse_args(argv)
     logger.info("TK02 starting: measure BASEL lift against the best-so-far Track K cohort")
@@ -188,7 +197,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         phage_feature_blocks=(track_d_genome_rows, track_d_distance_rows),
         pair_feature_blocks=(track_e_rbp_rows, track_e_isolation_rows),
     )
-    cohort_rows = read_csv_rows(args.ti08_training_cohort_path) if args.ti08_training_cohort_path.exists() else []
+    cohort_rows = load_ti08_training_cohort_rows(args.ti08_training_cohort_path)
 
     source_rows_by_system: Dict[str, List[Dict[str, object]]] = {}
     current_source_rows, current_source_counts = load_source_training_rows(
@@ -196,6 +205,13 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         cohort_rows,
         CURRENT_SOURCE_SYSTEM,
     )
+    if int(current_source_counts.get("cohort_rows", 0)) == 0:
+        raise ValueError(f"TI08 cohort contains no BASEL rows: {args.ti08_training_cohort_path}")
+    if int(current_source_counts.get("joined_rows", 0)) == 0:
+        raise ValueError(
+            "TI08 cohort contains no BASEL rows that join into the locked ST03 train split: "
+            f"{args.ti08_training_cohort_path}"
+        )
     source_rows_by_system[CURRENT_SOURCE_SYSTEM] = current_source_rows
     previous_best_source_systems = load_previous_best_source_systems(args.tk01_manifest_path)
     for source_system in previous_best_source_systems:

--- a/lyzortx/research_notes/lab_notebooks/track_K.md
+++ b/lyzortx/research_notes/lab_notebooks/track_K.md
@@ -39,16 +39,17 @@ local production rerun is blocked until that input is restored.
 
 #### Executive summary
 
-Added the TK02 Track K runner to measure BASEL lift on top of the best-so-far TK01 cohort. The real Track G/I
-generated artifacts are not present in this checkout, so the new path was validated on a minimal fixture instead of a
-production rerun. On that fixture, BASEL was neutral: ROC-AUC, top-3, and Brier deltas vs the previous best were all
-`0.0`.
+TK02 now measures BASEL lift on top of the best-so-far TK01 cohort and fails closed if TI08 is missing, empty, or
+contains no BASEL rows that join into the locked ST03 train split. I validated the runner on a minimal fixture with
+one joinable BASEL row. On that fixture, BASEL was neutral: ROC-AUC, top-3, and Brier deltas vs the previous best
+were all `0.0`.
 
 #### What was implemented
 
 - Added shared Track K lift helpers in `lyzortx/pipeline/track_k/steps/build_source_lift_helpers.py`.
 - Added the TK02 runner at `lyzortx/pipeline/track_k/steps/build_basel_lift_report.py`.
 - Updated `lyzortx/pipeline/track_k/run_track_k.py` so `--step all` runs TK01 followed by TK02.
+- Added explicit TI08 BASEL cohort guards so the step raises on a missing file, an empty cohort, or a zero-row join.
 - The TK02 manifest now records the previous-best source systems, cumulative source set, metric deltas, and the lift
   assessment.
 
@@ -56,6 +57,7 @@ production rerun. On that fixture, BASEL was neutral: ROC-AUC, top-3, and Brier 
 
 - On the validation fixture, TK01 kept `internal_plus_vhrdb` as the best-so-far cohort.
 - TK02 evaluated `internal_plus_vhrdb_plus_basel`.
+- The fixture contained `1` BASEL row and `1` joined BASEL training row.
 - Metric deltas vs the previous best were all `0.0`:
   - ROC-AUC `0.0`
   - top-3 `0.0`
@@ -65,8 +67,8 @@ production rerun. On that fixture, BASEL was neutral: ROC-AUC, top-3, and Brier 
 #### Interpretation
 
 - BASEL is now wired as a cumulative add-on after TK01, not as a replacement path.
+- The step now refuses to silently proceed when BASEL data is absent or fails to join.
 - On the available fixture, BASEL is neutral rather than additive or harmful.
-- A production rerun can replace the fixture note once the Track G/I generated artifacts are available locally.
 
 ### 2026-03-24: TK03 KlebPhaCol cumulative lift measurement
 

--- a/lyzortx/tests/test_track_k_basel_lift.py
+++ b/lyzortx/tests/test_track_k_basel_lift.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import csv
 import json
 
+import pytest
+
 from lyzortx.pipeline.track_k.steps.build_basel_lift_report import main
+from lyzortx.pipeline.track_k.steps.build_basel_lift_report import load_ti08_training_cohort_rows
 from lyzortx.pipeline.track_k.steps.build_source_lift_helpers import load_source_training_rows
 
 
@@ -90,6 +93,21 @@ def test_load_source_training_rows_keeps_joinable_basel_rows() -> None:
     assert counts["joined_rows"] == 1
     assert counts["non_training_split_rows"] == 1
     assert counts["excluded_rows"] == 1
+
+
+def test_load_ti08_training_cohort_rows_requires_a_real_file(tmp_path) -> None:
+    cohort_path = tmp_path / "ti08_training_cohort_rows.csv"
+
+    with pytest.raises(FileNotFoundError):
+        load_ti08_training_cohort_rows(cohort_path)
+
+
+def test_load_ti08_training_cohort_rows_rejects_empty_file(tmp_path) -> None:
+    cohort_path = tmp_path / "ti08_training_cohort_rows.csv"
+    cohort_path.write_text("pair_id,source_system\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        load_ti08_training_cohort_rows(cohort_path)
 
 
 def test_main_carries_forward_vhrdb_when_tk01_kept_it(tmp_path) -> None:
@@ -372,3 +390,150 @@ def test_main_carries_forward_vhrdb_when_tk01_kept_it(tmp_path) -> None:
     manifest = json.loads((output_dir / "tk02_basel_lift_manifest.json").read_text(encoding="utf-8"))
     assert manifest["previous_best_source_systems"] == ["vhrdb"]
     assert manifest["lift_assessment"] in {"adds", "hurts", "neutral"}
+
+
+def test_main_rejects_basel_rows_that_do_not_join_into_training(tmp_path) -> None:
+    st02 = tmp_path / "st02_pair_table.csv"
+    st03 = tmp_path / "st03_split_assignments.csv"
+    track_c = tmp_path / "pair_table_v1.csv"
+    track_d_genome = tmp_path / "phage_genome_kmer_features.csv"
+    track_d_distance = tmp_path / "phage_distance_embedding_features.csv"
+    track_e_rbp = tmp_path / "rbp_receptor_compatibility_features_v1.csv"
+    track_e_isolation = tmp_path / "isolation_host_distance_features_v1.csv"
+    v1_config = tmp_path / "v1_feature_configuration.json"
+    tg01_summary = tmp_path / "tg01_model_summary.json"
+    tk01_manifest = tmp_path / "tk01_vhrdb_lift_manifest.json"
+    ti08_cohort = tmp_path / "ti08_training_cohort_rows.csv"
+
+    _write_csv(
+        st02,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            }
+        ],
+    )
+    _write_csv(
+        st03,
+        ["pair_id", "bacteria", "phage", "cv_group", "split_holdout", "split_cv5_fold", "is_hard_trainable"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "cv_group": "g0",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "0",
+                "is_hard_trainable": "1",
+            }
+        ],
+    )
+    _write_csv(
+        track_c,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            }
+        ],
+    )
+    _write_csv(track_d_genome, ["phage", "phage_gc_content"], [{"phage": "p0", "phage_gc_content": "0.4"}])
+    _write_csv(
+        track_d_distance, ["phage", "phage_distance_umap_00"], [{"phage": "p0", "phage_distance_umap_00": "0.05"}]
+    )
+    _write_csv(
+        track_e_rbp,
+        ["pair_id", "bacteria", "phage", "lookup_available"],
+        [{"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "lookup_available": "1"}],
+    )
+    _write_csv(
+        track_e_isolation,
+        ["pair_id", "bacteria", "phage", "isolation_host_distance"],
+        [{"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "isolation_host_distance": "0.25"}],
+    )
+    v1_config.write_text(json.dumps({"winner_subset_blocks": ["defense", "phage_genomic"]}), encoding="utf-8")
+    _write_json(
+        tg01_summary,
+        {
+            "lightgbm": {
+                "best_params": {
+                    "n_estimators": 150,
+                    "learning_rate": 0.03,
+                    "num_leaves": 31,
+                    "min_child_samples": 10,
+                }
+            }
+        },
+    )
+    _write_json(tk01_manifest, {"lift_decision": "keep_vhrdb_for_followup_arms"})
+    _write_csv(
+        ti08_cohort,
+        [
+            "pair_id",
+            "bacteria",
+            "phage",
+            "label_hard_any_lysis",
+            "label_strict_confidence_tier",
+            "source_system",
+            "external_label_include_in_training",
+            "external_label_confidence_tier",
+            "external_label_confidence_score",
+            "external_label_training_weight",
+        ],
+        [
+            {
+                "pair_id": "b1__p999",
+                "bacteria": "b1",
+                "phage": "p999",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "B",
+                "source_system": "basel",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="no BASEL rows that join"):
+        main(
+            [
+                "--st02-pair-table-path",
+                str(st02),
+                "--st03-split-assignments-path",
+                str(st03),
+                "--track-c-pair-table-path",
+                str(track_c),
+                "--track-d-genome-kmer-path",
+                str(track_d_genome),
+                "--track-d-distance-path",
+                str(track_d_distance),
+                "--track-e-rbp-compatibility-path",
+                str(track_e_rbp),
+                "--track-e-isolation-distance-path",
+                str(track_e_isolation),
+                "--v1-feature-config-path",
+                str(v1_config),
+                "--tg01-summary-path",
+                str(tg01_summary),
+                "--tk01-manifest-path",
+                str(tk01_manifest),
+                "--ti08-training-cohort-path",
+                str(ti08_cohort),
+                "--output-dir",
+                str(tmp_path / "out"),
+                "--skip-prerequisites",
+            ]
+        )


### PR DESCRIPTION
Add the TK02 BASEL cumulative-lift path so Track K now fails closed when TI08 is missing, empty, or yields zero joinable BASEL rows.

Changes:
- Add explicit TI08 BASEL cohort loading and zero-row join guards in the TK02 runner.
- Keep BASEL as a cumulative add-on after the TK01 best-so-far cohort.
- Add regression coverage for missing TI08, empty TI08, and non-joining BASEL rows.
- Update the Track K notebook with the TK02 validation notes and neutrality result on the fixture.

Tests:
- `python -m pytest -q lyzortx/tests/`

Generated by Codex gpt-5.4

Closes #242