### PR TITLE
[ORCH][TK03] Add KlebPhaCol to training and measure cumulative lift

### DIFF
--- a/lyzortx/pipeline/track_k/steps/build_klebphacol_lift_report.py
+++ b/lyzortx/pipeline/track_k/steps/build_klebphacol_lift_report.py
@@ -141,6 +141,15 @@ def _measure_metrics(
     return scored_rows, holdout_metrics, top3
 
 
+def load_ti08_training_cohort_rows(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing TI08 training cohort artifact: {path}")
+    rows = read_csv_rows(path)
+    if not rows:
+        raise ValueError(f"TI08 training cohort is empty: {path}")
+    return rows
+
+
 def main(argv: Optional[Sequence[str]] = None) -> None:
     args = parse_args(argv)
     logger.info("TK03 starting: measure KlebPhaCol lift against the best-so-far Track K cohort")
@@ -188,7 +197,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         phage_feature_blocks=(track_d_genome_rows, track_d_distance_rows),
         pair_feature_blocks=(track_e_rbp_rows, track_e_isolation_rows),
     )
-    cohort_rows = read_csv_rows(args.ti08_training_cohort_path) if args.ti08_training_cohort_path.exists() else []
+    cohort_rows = load_ti08_training_cohort_rows(args.ti08_training_cohort_path)
 
     source_rows_by_system: Dict[str, List[Dict[str, object]]] = {}
     current_source_rows, current_source_counts = load_source_training_rows(
@@ -196,6 +205,13 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         cohort_rows,
         CURRENT_SOURCE_SYSTEM,
     )
+    if int(current_source_counts.get("cohort_rows", 0)) == 0:
+        raise ValueError(f"TI08 cohort contains no KlebPhaCol rows: {args.ti08_training_cohort_path}")
+    if int(current_source_counts.get("joined_rows", 0)) == 0:
+        raise ValueError(
+            "TI08 cohort contains no KlebPhaCol rows that join into the locked ST03 train split: "
+            f"{args.ti08_training_cohort_path}"
+        )
     source_rows_by_system[CURRENT_SOURCE_SYSTEM] = current_source_rows
     previous_best_source_systems = load_previous_best_source_systems(args.tk02_manifest_path)
     for source_system in previous_best_source_systems:

--- a/lyzortx/research_notes/lab_notebooks/track_K.md
+++ b/lyzortx/research_notes/lab_notebooks/track_K.md
@@ -74,10 +74,10 @@ were all `0.0`.
 
 #### Executive summary
 
-Added the TK03 Track K runner to measure KlebPhaCol lift on top of the current best-so-far cohort. The new step
-reads the TK02 manifest to recover the prior external source chain, then retrains the locked v1 model with
-`+KlebPhaCol` appended. On the validation fixture, KlebPhaCol was neutral: ROC-AUC, top-3, and Brier deltas vs the
-previous best were all `0.0`.
+Added the TK03 Track K runner to measure KlebPhaCol lift on top of the current best-so-far cohort. The step now
+fails closed when the TI08 cohort is missing, empty, or yields zero joinable KlebPhaCol rows, then retrains the
+locked v1 model with `+KlebPhaCol` appended. On the validation fixture, KlebPhaCol was neutral: ROC-AUC, top-3,
+and Brier deltas vs the previous best were all `0.0`.
 
 #### What was implemented
 
@@ -85,6 +85,7 @@ previous best were all `0.0`.
   `lyzortx/pipeline/track_k/run_track_k.py`.
 - Extended the shared Track K manifest loader so TK03 can recover the previous best external cohort from TK02
   manifests without duplicating `internal`.
+- Added explicit guards that raise on a missing or empty TI08 cohort, plus a zero-row join check for KlebPhaCol.
 - Added regression coverage for the TK03 runner and the TK02-to-TK03 cohort handoff.
 
 #### Findings
@@ -96,6 +97,8 @@ previous best were all `0.0`.
   - ROC-AUC `0.0`
   - top-3 `0.0`
   - Brier `0.0`
+- The runner now rejects a missing TI08 file or a TI08 cohort with no joinable KlebPhaCol rows instead of silently
+  continuing with an empty add-on.
 - The TK03 lift assessment was `neutral`.
 
 #### Interpretation
@@ -160,7 +163,8 @@ should stay internal-only for v1.
 - The scratch validation run emitted `lyzortx/generated_outputs/track_k/tk05_tier_b_lift_measurement/`-style outputs
   under `.scratch/tk05_demo/out/` for the local fixture.
 - The previous best cohort remained `internal_plus_vhrdb_plus_basel_plus_klebphacol_plus_gpb`.
-- The augmented cohort was `internal_plus_vhrdb_plus_basel_plus_klebphacol_plus_gpb_plus_virus_host_db_plus_ncbi_virus_biosample`.
+- The augmented cohort was
+  `internal_plus_vhrdb_plus_basel_plus_klebphacol_plus_gpb_plus_virus_host_db_plus_ncbi_virus_biosample`.
 - The Tier B rows joined cleanly:
   - `virus_host_db`: `1` joined row
   - `ncbi_virus_biosample`: `1` joined row

--- a/lyzortx/tests/test_track_k_klebphacol_lift.py
+++ b/lyzortx/tests/test_track_k_klebphacol_lift.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import csv
 import json
 
+import pytest
+
 from lyzortx.pipeline.track_k.steps.build_klebphacol_lift_report import main
 from lyzortx.pipeline.track_k.steps.build_source_lift_helpers import load_previous_best_source_systems
 
@@ -322,3 +324,320 @@ def test_main_carries_forward_vhrdb_when_tk02_kept_it(tmp_path) -> None:
     assert manifest["previous_best_source_systems"] == ["vhrdb"]
     assert manifest["source_system_added"] == "klebphacol"
     assert manifest["lift_assessment"] in {"adds", "hurts", "neutral"}
+
+
+def test_main_fails_when_ti08_klebphacol_artifact_is_missing(tmp_path) -> None:
+    st02 = tmp_path / "st02_pair_table.csv"
+    st03 = tmp_path / "st03_split_assignments.csv"
+    track_c = tmp_path / "pair_table_v1.csv"
+    track_d_genome = tmp_path / "phage_genome_kmer_features.csv"
+    track_d_distance = tmp_path / "phage_distance_embedding_features.csv"
+    track_e_rbp = tmp_path / "rbp_receptor_compatibility_features_v1.csv"
+    track_e_isolation = tmp_path / "isolation_host_distance_features_v1.csv"
+    v1_config = tmp_path / "v1_feature_configuration.json"
+    tg01_summary = tmp_path / "tg01_model_summary.json"
+    tk02_manifest = tmp_path / "tk02_basel_lift_manifest.json"
+
+    _write_csv(
+        st02,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        st03,
+        ["pair_id", "bacteria", "phage", "cv_group", "split_holdout", "split_cv5_fold", "is_hard_trainable"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "cv_group": "g0",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "1",
+                "is_hard_trainable": "1",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "cv_group": "g1",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "0",
+                "is_hard_trainable": "1",
+            },
+        ],
+    )
+    _write_csv(
+        track_c,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+            {
+                "pair_id": "b1__p1",
+                "bacteria": "b1",
+                "phage": "p1",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            },
+        ],
+    )
+    _write_csv(
+        track_d_genome,
+        ["phage", "phage_gc_content"],
+        [{"phage": "p0", "phage_gc_content": "0.4"}, {"phage": "p1", "phage_gc_content": "0.5"}],
+    )
+    _write_csv(
+        track_d_distance,
+        ["phage", "phage_distance_umap_00"],
+        [{"phage": "p0", "phage_distance_umap_00": "0.05"}, {"phage": "p1", "phage_distance_umap_00": "0.1"}],
+    )
+    _write_csv(
+        track_e_rbp,
+        ["pair_id", "bacteria", "phage", "lookup_available"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "lookup_available": "1"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "lookup_available": "1"},
+        ],
+    )
+    _write_csv(
+        track_e_isolation,
+        ["pair_id", "bacteria", "phage", "isolation_host_distance"],
+        [
+            {"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "isolation_host_distance": "0.25"},
+            {"pair_id": "b1__p1", "bacteria": "b1", "phage": "p1", "isolation_host_distance": "0.3"},
+        ],
+    )
+    v1_config.write_text(json.dumps({"winner_subset_blocks": ["defense", "phage_genomic"]}), encoding="utf-8")
+    _write_json(
+        tg01_summary,
+        {
+            "lightgbm": {
+                "best_params": {
+                    "n_estimators": 150,
+                    "learning_rate": 0.03,
+                    "num_leaves": 31,
+                    "min_child_samples": 10,
+                }
+            }
+        },
+    )
+    _write_json(
+        tk02_manifest,
+        {
+            "lift_assessment": "neutral",
+            "base_source_systems": ["internal", "vhrdb"],
+            "augmented_source_systems": ["internal", "vhrdb", "basel"],
+        },
+    )
+
+    with pytest.raises(FileNotFoundError, match="Missing TI08 training cohort artifact"):
+        main(
+            [
+                "--st02-pair-table-path",
+                str(st02),
+                "--st03-split-assignments-path",
+                str(st03),
+                "--track-c-pair-table-path",
+                str(track_c),
+                "--track-d-genome-kmer-path",
+                str(track_d_genome),
+                "--track-d-distance-path",
+                str(track_d_distance),
+                "--track-e-rbp-compatibility-path",
+                str(track_e_rbp),
+                "--track-e-isolation-distance-path",
+                str(track_e_isolation),
+                "--v1-feature-config-path",
+                str(v1_config),
+                "--tg01-summary-path",
+                str(tg01_summary),
+                "--tk02-manifest-path",
+                str(tk02_manifest),
+                "--ti08-training-cohort-path",
+                str(tmp_path / "missing_ti08.csv"),
+                "--output-dir",
+                str(tmp_path / "out"),
+                "--skip-prerequisites",
+            ]
+        )
+
+
+def test_main_fails_when_no_klebphacol_rows_join_into_train_split(tmp_path) -> None:
+    st02 = tmp_path / "st02_pair_table.csv"
+    st03 = tmp_path / "st03_split_assignments.csv"
+    track_c = tmp_path / "pair_table_v1.csv"
+    track_d_genome = tmp_path / "phage_genome_kmer_features.csv"
+    track_d_distance = tmp_path / "phage_distance_embedding_features.csv"
+    track_e_rbp = tmp_path / "rbp_receptor_compatibility_features_v1.csv"
+    track_e_isolation = tmp_path / "isolation_host_distance_features_v1.csv"
+    v1_config = tmp_path / "v1_feature_configuration.json"
+    tg01_summary = tmp_path / "tg01_model_summary.json"
+    tk02_manifest = tmp_path / "tk02_basel_lift_manifest.json"
+    ti08_cohort = tmp_path / "ti08_training_cohort_rows.csv"
+
+    _write_csv(
+        st02,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            }
+        ],
+    )
+    _write_csv(
+        st03,
+        ["pair_id", "bacteria", "phage", "cv_group", "split_holdout", "split_cv5_fold", "is_hard_trainable"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "cv_group": "g0",
+                "split_holdout": "holdout_test",
+                "split_cv5_fold": "-1",
+                "is_hard_trainable": "1",
+            }
+        ],
+    )
+    _write_csv(
+        track_c,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            }
+        ],
+    )
+    _write_csv(track_d_genome, ["phage", "phage_gc_content"], [{"phage": "p0", "phage_gc_content": "0.4"}])
+    _write_csv(
+        track_d_distance,
+        ["phage", "phage_distance_umap_00"],
+        [{"phage": "p0", "phage_distance_umap_00": "0.05"}],
+    )
+    _write_csv(
+        track_e_rbp,
+        ["pair_id", "bacteria", "phage", "lookup_available"],
+        [{"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "lookup_available": "1"}],
+    )
+    _write_csv(
+        track_e_isolation,
+        ["pair_id", "bacteria", "phage", "isolation_host_distance"],
+        [{"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "isolation_host_distance": "0.25"}],
+    )
+    v1_config.write_text(json.dumps({"winner_subset_blocks": ["defense", "phage_genomic"]}), encoding="utf-8")
+    _write_json(
+        tg01_summary,
+        {
+            "lightgbm": {
+                "best_params": {
+                    "n_estimators": 150,
+                    "learning_rate": 0.03,
+                    "num_leaves": 31,
+                    "min_child_samples": 10,
+                }
+            }
+        },
+    )
+    _write_json(
+        tk02_manifest,
+        {
+            "lift_assessment": "neutral",
+            "base_source_systems": ["internal", "vhrdb"],
+            "augmented_source_systems": ["internal", "vhrdb", "basel"],
+        },
+    )
+    _write_csv(
+        ti08_cohort,
+        [
+            "pair_id",
+            "bacteria",
+            "phage",
+            "label_hard_any_lysis",
+            "label_strict_confidence_tier",
+            "source_system",
+            "external_label_include_in_training",
+            "external_label_confidence_tier",
+            "external_label_confidence_score",
+            "external_label_training_weight",
+        ],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "B",
+                "source_system": "klebphacol",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="contains no KlebPhaCol rows that join into the locked ST03 train split"):
+        main(
+            [
+                "--st02-pair-table-path",
+                str(st02),
+                "--st03-split-assignments-path",
+                str(st03),
+                "--track-c-pair-table-path",
+                str(track_c),
+                "--track-d-genome-kmer-path",
+                str(track_d_genome),
+                "--track-d-distance-path",
+                str(track_d_distance),
+                "--track-e-rbp-compatibility-path",
+                str(track_e_rbp),
+                "--track-e-isolation-distance-path",
+                str(track_e_isolation),
+                "--v1-feature-config-path",
+                str(v1_config),
+                "--tg01-summary-path",
+                str(tg01_summary),
+                "--tk02-manifest-path",
+                str(tk02_manifest),
+                "--ti08-training-cohort-path",
+                str(ti08_cohort),
+                "--output-dir",
+                str(tmp_path / "out"),
+                "--skip-prerequisites",
+            ]
+        )


### PR DESCRIPTION
Added the TK03 KlebPhaCol lift runner and aligned it with the existing Track K cumulative source chain.

Changes:
- TK03 now fails closed when the TI08 cohort is missing, empty, or has no joinable KlebPhaCol rows.
- The step retrains the locked v1 model with KlebPhaCol appended to the best-so-far cohort.
- Added regression coverage for the success path plus the missing-file and zero-join failure paths.
- Updated the Track K notebook entry with the measured validation-fixture result and the new guardrails.

Validation:
- `pytest -q lyzortx/tests/`

Generated by Codex gpt-5.4-mini

Closes #244