### PR TITLE
[ORCH][TK04] Add GPB to training and measure cumulative lift

### DIFF
--- a/lyzortx/pipeline/track_k/steps/build_gpb_lift_report.py
+++ b/lyzortx/pipeline/track_k/steps/build_gpb_lift_report.py
@@ -143,6 +143,15 @@ def _measure_metrics(
     return scored_rows, holdout_metrics, top3
 
 
+def load_ti08_training_cohort_rows(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing TI08 training cohort artifact: {path}")
+    rows = read_csv_rows(path)
+    if not rows:
+        raise ValueError(f"TI08 training cohort is empty: {path}")
+    return rows
+
+
 def main(argv: Optional[Sequence[str]] = None) -> None:
     args = parse_args(argv)
     logger.info("TK04 starting: measure GPB lift against the best-so-far Track K cohort")
@@ -190,7 +199,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         phage_feature_blocks=(track_d_genome_rows, track_d_distance_rows),
         pair_feature_blocks=(track_e_rbp_rows, track_e_isolation_rows),
     )
-    cohort_rows = read_csv_rows(args.ti08_training_cohort_path) if args.ti08_training_cohort_path.exists() else []
+    cohort_rows = load_ti08_training_cohort_rows(args.ti08_training_cohort_path)
 
     source_rows_by_system: Dict[str, List[Dict[str, object]]] = {}
     current_source_rows, current_source_counts = load_source_training_rows(
@@ -198,6 +207,13 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         cohort_rows,
         CURRENT_SOURCE_SYSTEM,
     )
+    if int(current_source_counts.get("cohort_rows", 0)) == 0:
+        raise ValueError(f"TI08 cohort contains no GPB rows: {args.ti08_training_cohort_path}")
+    if int(current_source_counts.get("joined_rows", 0)) == 0:
+        raise ValueError(
+            "TI08 cohort contains no GPB rows that join into the locked ST03 train split: "
+            f"{args.ti08_training_cohort_path}"
+        )
     source_rows_by_system[CURRENT_SOURCE_SYSTEM] = current_source_rows
     previous_best_source_systems = load_previous_best_source_systems(args.tk03_manifest_path)
     for source_system in previous_best_source_systems:

--- a/lyzortx/research_notes/lab_notebooks/track_K.md
+++ b/lyzortx/research_notes/lab_notebooks/track_K.md
@@ -111,9 +111,10 @@ and Brier deltas vs the previous best were all `0.0`.
 
 #### Executive summary
 
-Added the TK04 Track K runner to measure GPB lift on top of the current best-so-far cohort. The local Track I cohort
-artifact is still absent in this checkout, so the new path was validated on the same minimal fixture pattern used for
-TK02/TK03. On that fixture, GPB was neutral: ROC-AUC, top-3, and Brier deltas vs the previous best were all `0.0`.
+Added the TK04 Track K runner to measure GPB lift on top of the current best-so-far cohort. TK04 now fails closed if
+the TI08 cohort is missing or empty, and it also fails if no GPB rows survive the ST03 join. The new path was
+validated on the same minimal fixture pattern used for TK02/TK03. On that fixture, GPB was neutral: ROC-AUC, top-3,
+and Brier deltas vs the previous best were all `0.0`.
 
 #### What was implemented
 
@@ -127,6 +128,8 @@ TK02/TK03. On that fixture, GPB was neutral: ROC-AUC, top-3, and Brier deltas vs
 - On the validation fixture, TK04 carried forward `internal_plus_vhrdb_plus_basel_plus_klebphacol` as the
   best-so-far cohort.
 - TK04 evaluated `internal_plus_vhrdb_plus_basel_plus_klebphacol_plus_gpb`.
+- The GPB cohort checks now fail on missing or empty TI08 input, and they fail if the GPB rows do not join into the
+  locked ST03 train split.
 - On the fixture, both arms scored ROC-AUC `0.5`, top-3 hit rate `1.0`, and Brier score `0.25`.
 - The measured deltas vs the previous best were all `0.0`:
   - ROC-AUC `0.0`

--- a/lyzortx/tests/test_track_k_gpb_lift.py
+++ b/lyzortx/tests/test_track_k_gpb_lift.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import csv
 import json
 
+import pytest
+
 from lyzortx.pipeline.track_k.steps.build_gpb_lift_report import main
 from lyzortx.pipeline.track_k.steps.build_source_lift_helpers import load_previous_best_source_systems
 
@@ -324,3 +326,291 @@ def test_main_carries_forward_klebphacol_when_tk03_kept_it(tmp_path) -> None:
     assert manifest["previous_best_source_systems"] == ["vhrdb", "basel", "klebphacol"]
     assert manifest["source_system_added"] == "gpb"
     assert manifest["lift_assessment"] in {"adds", "hurts", "neutral"}
+
+
+def test_main_fails_when_ti08_cohort_is_missing(tmp_path) -> None:
+    st02 = tmp_path / "st02_pair_table.csv"
+    st03 = tmp_path / "st03_split_assignments.csv"
+    track_c = tmp_path / "pair_table_v1.csv"
+    track_d_genome = tmp_path / "phage_genome_kmer_features.csv"
+    track_d_distance = tmp_path / "phage_distance_embedding_features.csv"
+    track_e_rbp = tmp_path / "rbp_receptor_compatibility_features_v1.csv"
+    track_e_isolation = tmp_path / "isolation_host_distance_features_v1.csv"
+    v1_config = tmp_path / "v1_feature_configuration.json"
+    tg01_summary = tmp_path / "tg01_model_summary.json"
+    tk03_manifest = tmp_path / "tk03_klebphacol_lift_manifest.json"
+
+    _write_csv(
+        st02,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            }
+        ],
+    )
+    _write_csv(
+        st03,
+        ["pair_id", "bacteria", "phage", "cv_group", "split_holdout", "split_cv5_fold", "is_hard_trainable"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "cv_group": "g0",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "0",
+                "is_hard_trainable": "1",
+            }
+        ],
+    )
+    _write_csv(
+        track_c,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            }
+        ],
+    )
+    _write_csv(track_d_genome, ["phage", "phage_gc_content"], [{"phage": "p0", "phage_gc_content": "0.4"}])
+    _write_csv(
+        track_d_distance,
+        ["phage", "phage_distance_umap_00"],
+        [{"phage": "p0", "phage_distance_umap_00": "0.05"}],
+    )
+    _write_csv(
+        track_e_rbp,
+        ["pair_id", "bacteria", "phage", "lookup_available"],
+        [{"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "lookup_available": "1"}],
+    )
+    _write_csv(
+        track_e_isolation,
+        ["pair_id", "bacteria", "phage", "isolation_host_distance"],
+        [{"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "isolation_host_distance": "0.25"}],
+    )
+    v1_config.write_text(json.dumps({"winner_subset_blocks": ["defense", "phage_genomic"]}), encoding="utf-8")
+    _write_json(
+        tg01_summary,
+        {
+            "lightgbm": {
+                "best_params": {
+                    "n_estimators": 150,
+                    "learning_rate": 0.03,
+                    "num_leaves": 31,
+                    "min_child_samples": 10,
+                }
+            }
+        },
+    )
+    _write_json(
+        tk03_manifest,
+        {
+            "lift_assessment": "neutral",
+            "base_source_systems": ["internal", "vhrdb", "basel"],
+            "augmented_source_systems": ["internal", "vhrdb", "basel", "klebphacol"],
+            "best_source_systems": ["vhrdb", "basel", "klebphacol"],
+        },
+    )
+
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(FileNotFoundError, match="Missing TI08 training cohort artifact"):
+        main(
+            [
+                "--st02-pair-table-path",
+                str(st02),
+                "--st03-split-assignments-path",
+                str(st03),
+                "--track-c-pair-table-path",
+                str(track_c),
+                "--track-d-genome-kmer-path",
+                str(track_d_genome),
+                "--track-d-distance-path",
+                str(track_d_distance),
+                "--track-e-rbp-compatibility-path",
+                str(track_e_rbp),
+                "--track-e-isolation-distance-path",
+                str(track_e_isolation),
+                "--v1-feature-config-path",
+                str(v1_config),
+                "--tg01-summary-path",
+                str(tg01_summary),
+                "--tk03-manifest-path",
+                str(tk03_manifest),
+                "--ti08-training-cohort-path",
+                str(tmp_path / "missing_ti08.csv"),
+                "--output-dir",
+                str(output_dir),
+                "--skip-prerequisites",
+            ]
+        )
+
+
+def test_main_fails_when_ti08_has_no_joinable_gpb_rows(tmp_path) -> None:
+    st02 = tmp_path / "st02_pair_table.csv"
+    st03 = tmp_path / "st03_split_assignments.csv"
+    track_c = tmp_path / "pair_table_v1.csv"
+    track_d_genome = tmp_path / "phage_genome_kmer_features.csv"
+    track_d_distance = tmp_path / "phage_distance_embedding_features.csv"
+    track_e_rbp = tmp_path / "rbp_receptor_compatibility_features_v1.csv"
+    track_e_isolation = tmp_path / "isolation_host_distance_features_v1.csv"
+    v1_config = tmp_path / "v1_feature_configuration.json"
+    tg01_summary = tmp_path / "tg01_model_summary.json"
+    tk03_manifest = tmp_path / "tk03_klebphacol_lift_manifest.json"
+    ti08_cohort = tmp_path / "ti08_training_cohort_rows.csv"
+
+    _write_csv(
+        st02,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            }
+        ],
+    )
+    _write_csv(
+        st03,
+        ["pair_id", "bacteria", "phage", "cv_group", "split_holdout", "split_cv5_fold", "is_hard_trainable"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "cv_group": "g0",
+                "split_holdout": "train_non_holdout",
+                "split_cv5_fold": "0",
+                "is_hard_trainable": "1",
+            }
+        ],
+    )
+    _write_csv(
+        track_c,
+        ["pair_id", "bacteria", "phage", "label_hard_any_lysis", "label_strict_confidence_tier", "host_pathotype"],
+        [
+            {
+                "pair_id": "b1__p0",
+                "bacteria": "b1",
+                "phage": "p0",
+                "label_hard_any_lysis": "0",
+                "label_strict_confidence_tier": "A",
+                "host_pathotype": "pt",
+            }
+        ],
+    )
+    _write_csv(track_d_genome, ["phage", "phage_gc_content"], [{"phage": "p0", "phage_gc_content": "0.4"}])
+    _write_csv(
+        track_d_distance,
+        ["phage", "phage_distance_umap_00"],
+        [{"phage": "p0", "phage_distance_umap_00": "0.05"}],
+    )
+    _write_csv(
+        track_e_rbp,
+        ["pair_id", "bacteria", "phage", "lookup_available"],
+        [{"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "lookup_available": "1"}],
+    )
+    _write_csv(
+        track_e_isolation,
+        ["pair_id", "bacteria", "phage", "isolation_host_distance"],
+        [{"pair_id": "b1__p0", "bacteria": "b1", "phage": "p0", "isolation_host_distance": "0.25"}],
+    )
+    v1_config.write_text(json.dumps({"winner_subset_blocks": ["defense", "phage_genomic"]}), encoding="utf-8")
+    _write_json(
+        tg01_summary,
+        {
+            "lightgbm": {
+                "best_params": {
+                    "n_estimators": 150,
+                    "learning_rate": 0.03,
+                    "num_leaves": 31,
+                    "min_child_samples": 10,
+                }
+            }
+        },
+    )
+    _write_json(
+        tk03_manifest,
+        {
+            "lift_assessment": "neutral",
+            "base_source_systems": ["internal", "vhrdb", "basel"],
+            "augmented_source_systems": ["internal", "vhrdb", "basel", "klebphacol"],
+            "best_source_systems": ["vhrdb", "basel", "klebphacol"],
+        },
+    )
+    _write_csv(
+        ti08_cohort,
+        [
+            "pair_id",
+            "bacteria",
+            "phage",
+            "label_hard_any_lysis",
+            "label_strict_confidence_tier",
+            "source_system",
+            "external_label_include_in_training",
+            "external_label_confidence_tier",
+            "external_label_confidence_score",
+            "external_label_training_weight",
+        ],
+        [
+            {
+                "pair_id": "b1__p9",
+                "bacteria": "b1",
+                "phage": "p9",
+                "label_hard_any_lysis": "1",
+                "label_strict_confidence_tier": "B",
+                "source_system": "gpb",
+                "external_label_include_in_training": "1",
+                "external_label_confidence_tier": "high",
+                "external_label_confidence_score": "3",
+                "external_label_training_weight": "1.0",
+            }
+        ],
+    )
+
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(ValueError, match="TI08 cohort contains no GPB rows that join into the locked ST03 train split"):
+        main(
+            [
+                "--st02-pair-table-path",
+                str(st02),
+                "--st03-split-assignments-path",
+                str(st03),
+                "--track-c-pair-table-path",
+                str(track_c),
+                "--track-d-genome-kmer-path",
+                str(track_d_genome),
+                "--track-d-distance-path",
+                str(track_d_distance),
+                "--track-e-rbp-compatibility-path",
+                str(track_e_rbp),
+                "--track-e-isolation-distance-path",
+                str(track_e_isolation),
+                "--v1-feature-config-path",
+                str(v1_config),
+                "--tg01-summary-path",
+                str(tg01_summary),
+                "--tk03-manifest-path",
+                str(tk03_manifest),
+                "--ti08-training-cohort-path",
+                str(ti08_cohort),
+                "--output-dir",
+                str(output_dir),
+                "--skip-prerequisites",
+            ]
+        )


### PR DESCRIPTION
Adds TK04 GPB cumulative lift measurement on top of the current best-so-far Track K cohort.

Changes:
- TK04 now fails closed if the TI08 cohort is missing or empty.
- TK04 now fails if no GPB rows survive the ST03 train-split join.
- Added regression tests for the missing-TI08 and zero-join failure paths.
- Updated the Track K notebook with the TK04 finding and interpretation.

Validation:
- `python -m pytest -q lyzortx/tests/test_track_k_gpb_lift.py`
- `python -m pytest -q lyzortx/tests/`

Posted by Codex gpt-5.4

Closes #246