### PR TITLE
[ORCH][TL11] Exclude holdout rows from rebuilt outputs

### DIFF
--- a/lyzortx/pipeline/track_l/steps/build_mechanistic_defense_evasion_features.py
+++ b/lyzortx/pipeline/track_l/steps/build_mechanistic_defense_evasion_features.py
@@ -329,7 +329,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     label_rows = read_delimited_rows(args.label_path)
     all_pair_rows = build_pair_rows(label_rows)
-    pair_rows = [row for row in all_pair_rows if row["bacteria"] not in set(provenance["holdout_bacteria_ids"])]
+    holdout_bacteria = set(provenance["holdout_bacteria_ids"])
+    pair_rows = [row for row in all_pair_rows if row["bacteria"] not in holdout_bacteria]
     bacteria = sorted({row["bacteria"] for row in pair_rows})
     phages = sorted({row["phage"] for row in pair_rows})
 
@@ -429,7 +430,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "enrichment_inputs": provenance["enrichment_inputs"],
         },
         "holdout_exclusion": {
-            "excluded_pair_rows": len(all_pair_rows) - len(feature_rows),
+            "excluded_pair_rows": len(all_pair_rows) - len(pair_rows),
         },
         "inputs": {
             "label_set_v1_pairs": {"path": str(args.label_path), "sha256": _sha256(args.label_path)},

--- a/lyzortx/pipeline/track_l/steps/build_mechanistic_rbp_receptor_features.py
+++ b/lyzortx/pipeline/track_l/steps/build_mechanistic_rbp_receptor_features.py
@@ -461,7 +461,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     label_rows = read_delimited_rows(args.label_path)
     all_pair_rows = build_pair_rows(label_rows)
-    pair_rows = [row for row in all_pair_rows if row["bacteria"] not in set(provenance["holdout_bacteria_ids"])]
+    holdout_bacteria = set(provenance["holdout_bacteria_ids"])
+    pair_rows = [row for row in all_pair_rows if row["bacteria"] not in holdout_bacteria]
     bacteria = sorted({row["bacteria"] for row in pair_rows})
     phages = sorted({row["phage"] for row in pair_rows})
 
@@ -569,7 +570,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "enrichment_inputs": provenance["enrichment_inputs"],
         },
         "holdout_exclusion": {
-            "excluded_pair_rows": len(all_pair_rows) - len(feature_rows),
+            "excluded_pair_rows": len(all_pair_rows) - len(pair_rows),
         },
         "inputs": {
             "label_set_v1_pairs": {"path": str(args.label_path), "sha256": _sha256(args.label_path)},

--- a/lyzortx/tests/test_track_l_mechanistic_defense_evasion_features.py
+++ b/lyzortx/tests/test_track_l_mechanistic_defense_evasion_features.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 
+from lyzortx.pipeline.track_l.steps import build_mechanistic_defense_evasion_features as defense_module
 from lyzortx.pipeline.track_l.steps.build_mechanistic_defense_evasion_features import (
     EXPERIMENTAL_STATUS,
     build_feature_rows,
@@ -315,3 +316,95 @@ def test_main_writes_mechanistic_defense_outputs(tmp_path: Path) -> None:
     assert manifest["outputs"]["feature_csv_sha256"] == _sha256(
         output_dir / "mechanistic_defense_evasion_features_v1.csv"
     )
+
+
+def test_main_reports_holdout_exclusion_independently_of_feature_row_drops(monkeypatch, tmp_path: Path) -> None:
+    label_path = tmp_path / "labels.csv"
+    cached_dir = tmp_path / "cached"
+    defense_path = tmp_path / "defense.csv"
+    antidef_enrichment_path = tmp_path / "antidef_enrichment.csv"
+    split_path = tmp_path / "st03_split_assignments.csv"
+    output_dir = tmp_path / "out"
+
+    cached_dir.mkdir()
+    label_path.write_text("bacteria,phage\nB1,P1\nB2,P1\nB1,P2\n", encoding="utf-8")
+    defense_path.write_text("bacteria;BREX_I\nB1;1\n", encoding="utf-8")
+    antidef_enrichment_path.write_text(
+        "phage_feature,host_feature,lysis_rate_diff,significant\nANTIDEF_PHROG_11,defense_BREX_I,0.4,True\n",
+        encoding="utf-8",
+    )
+    split_path.write_text(
+        "pair_id,bacteria,split_holdout,split_cv5_fold\n"
+        "B1__P1,B1,train_non_holdout,0\n"
+        "B2__P1,B2,holdout_test,-1\n"
+        "B1__P2,B1,train_non_holdout,1\n",
+        encoding="utf-8",
+    )
+
+    fake_provenance = {
+        "manifest_path": tmp_path / "manifest.json",
+        "split_assignments_path": split_path,
+        "split_assignments_sha256": "split-sha",
+        "holdout_bacteria_ids": ["B2"],
+        "enrichment_inputs": {},
+        "enrichment_manifest_sha256": "manifest-sha",
+    }
+
+    def fake_read_delimited_rows(path: Path, delimiter: str = ",") -> list[dict[str, str]]:
+        if path == label_path:
+            return [
+                {"bacteria": "B1", "phage": "P1"},
+                {"bacteria": "B2", "phage": "P1"},
+                {"bacteria": "B1", "phage": "P2"},
+            ]
+        if path == antidef_enrichment_path:
+            return [
+                {
+                    "phage_feature": "ANTIDEF_PHROG_11",
+                    "host_feature": "defense_BREX_I",
+                    "lysis_rate_diff": "0.4",
+                    "significant": "True",
+                }
+            ]
+        raise AssertionError(f"unexpected path: {path}")
+
+    real_build_feature_rows = defense_module.build_feature_rows
+
+    def fake_build_feature_rows(*args, **kwargs):
+        feature_rows, feature_columns = real_build_feature_rows(*args, **kwargs)
+        return feature_rows[:-1], feature_columns
+
+    monkeypatch.setattr(defense_module, "ensure_default_label_path", lambda *_: None)
+    monkeypatch.setattr(defense_module, "ensure_default_tl02_output", lambda *_: None)
+    monkeypatch.setattr(defense_module, "load_tl02_holdout_clean_provenance", lambda *_: fake_provenance)
+    monkeypatch.setattr(defense_module, "read_delimited_rows", fake_read_delimited_rows)
+    monkeypatch.setattr(
+        defense_module,
+        "load_pharokka_phrog_matrices",
+        lambda *_: (None, None, np.array([[1], [0]], dtype=np.int8), ["11"]),
+    )
+    monkeypatch.setattr(
+        defense_module, "load_defense_host_matrix", lambda *_: (np.array([[1]], dtype=np.int8), ["BREX_I"])
+    )
+    monkeypatch.setattr(defense_module, "build_feature_rows", fake_build_feature_rows)
+
+    exit_code = defense_module.main(
+        [
+            "--label-path",
+            str(label_path),
+            "--cached-annotations-dir",
+            str(cached_dir),
+            "--defense-path",
+            str(defense_path),
+            "--antidef-enrichment-path",
+            str(antidef_enrichment_path),
+            "--st03-split-assignments-path",
+            str(split_path),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    manifest = json.loads((output_dir / "mechanistic_defense_evasion_manifest_v1.json").read_text(encoding="utf-8"))
+    assert manifest["holdout_exclusion"]["excluded_pair_rows"] == 1

--- a/lyzortx/tests/test_track_l_mechanistic_rbp_receptor_features.py
+++ b/lyzortx/tests/test_track_l_mechanistic_rbp_receptor_features.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 
+from lyzortx.pipeline.track_l.steps import build_mechanistic_rbp_receptor_features as rbp_module
 from lyzortx.pipeline.track_l.steps.build_mechanistic_rbp_receptor_features import (
     build_feature_rows,
     build_sanity_check_rows,
@@ -341,3 +342,145 @@ def test_main_writes_mechanistic_feature_outputs(tmp_path: Path) -> None:
     assert manifest["provenance"]["split_assignments"]["path"] == str(split_path)
     assert manifest["holdout_exclusion"]["excluded_pair_rows"] == 1
     assert manifest["outputs"]["feature_csv_sha256"] == _sha256(output_dir / "mechanistic_rbp_receptor_features_v1.csv")
+
+
+def test_main_reports_holdout_exclusion_independently_of_feature_row_drops(monkeypatch, tmp_path: Path) -> None:
+    label_path = tmp_path / "labels.csv"
+    cached_dir = tmp_path / "cached"
+    omp_path = tmp_path / "omp.tsv"
+    lps_primary_path = tmp_path / "lps_primary.tsv"
+    lps_supplemental_path = tmp_path / "lps_supplemental.tsv"
+    omp_enrichment_path = tmp_path / "omp_enrichment.csv"
+    lps_enrichment_path = tmp_path / "lps_enrichment.csv"
+    split_path = tmp_path / "st03_split_assignments.csv"
+    rbp_list_path = tmp_path / "RBP_list.csv"
+    output_dir = tmp_path / "out"
+
+    cached_dir.mkdir()
+    label_path.write_text("bacteria,phage\nB1,P1\nB2,P1\nB1,P2\n", encoding="utf-8")
+    omp_path.write_text("bacteria\tOMPC\nB1\t99_1\n", encoding="utf-8")
+    lps_primary_path.write_text("bacteria\tLPS_type\nB1\tR1\n", encoding="utf-8")
+    lps_supplemental_path.write_text("Strain\tLPS_type\n", encoding="utf-8")
+    omp_enrichment_path.write_text(
+        "phage_feature,host_feature,lysis_rate_diff,significant\nRBP_PHROG_136,OMPC_99_1,0.6,True\n",
+        encoding="utf-8",
+    )
+    lps_enrichment_path.write_text(
+        "phage_feature,host_feature,lysis_rate_diff,significant\nRBP_PHROG_136,LPS_R1,0.6,True\n",
+        encoding="utf-8",
+    )
+    split_path.write_text(
+        "pair_id,bacteria,split_holdout,split_cv5_fold\n"
+        "B1__P1,B1,train_non_holdout,0\n"
+        "B2__P1,B2,holdout_test,-1\n"
+        "B1__P2,B1,train_non_holdout,1\n",
+        encoding="utf-8",
+    )
+    rbp_list_path.write_text(
+        "phage;Morphotype;Family;Subfamily;Genus;RBP;type\n"
+        "P1;Myoviridae;Other;Other;X;P1_gene;fiber\n"
+        "P2;Myoviridae;Other;Other;X;P2_gene;spike\n",
+        encoding="utf-8",
+    )
+
+    fake_provenance = {
+        "manifest_path": tmp_path / "manifest.json",
+        "split_assignments_path": split_path,
+        "split_assignments_sha256": "split-sha",
+        "holdout_bacteria_ids": ["B2"],
+        "enrichment_inputs": {},
+        "enrichment_manifest_sha256": "manifest-sha",
+    }
+
+    def fake_read_delimited_rows(path: Path, delimiter: str = ",") -> list[dict[str, str]]:
+        if path == label_path:
+            return [
+                {"bacteria": "B1", "phage": "P1"},
+                {"bacteria": "B2", "phage": "P1"},
+                {"bacteria": "B1", "phage": "P2"},
+            ]
+        if path == omp_enrichment_path:
+            return [
+                {
+                    "phage_feature": "RBP_PHROG_136",
+                    "host_feature": "OMPC_99_1",
+                    "lysis_rate_diff": "0.6",
+                    "significant": "True",
+                }
+            ]
+        if path == lps_enrichment_path:
+            return [
+                {
+                    "phage_feature": "RBP_PHROG_136",
+                    "host_feature": "LPS_R1",
+                    "lysis_rate_diff": "0.6",
+                    "significant": "True",
+                }
+            ]
+        raise AssertionError(f"unexpected path: {path}")
+
+    real_build_feature_rows = rbp_module.build_feature_rows
+
+    def fake_build_feature_rows(*args, **kwargs):
+        feature_rows, feature_columns = real_build_feature_rows(*args, **kwargs)
+        return feature_rows[:-1], feature_columns
+
+    monkeypatch.setattr(rbp_module, "ensure_default_label_path", lambda *_: None)
+    monkeypatch.setattr(rbp_module, "ensure_default_tl02_outputs", lambda *_: None)
+    monkeypatch.setattr(rbp_module, "load_tl02_holdout_clean_provenance", lambda *_: fake_provenance)
+    monkeypatch.setattr(rbp_module, "read_delimited_rows", fake_read_delimited_rows)
+    monkeypatch.setattr(
+        rbp_module,
+        "load_pharokka_phrog_matrices",
+        lambda *_: (np.array([[1], [0]], dtype=np.int8), ["136"], None, None),
+    )
+    monkeypatch.setattr(
+        rbp_module, "load_omp_receptor_host_matrix", lambda *_: (np.array([[1]], dtype=np.int8), ["OMPC_99_1"])
+    )
+    monkeypatch.setattr(rbp_module, "load_lps_host_matrix", lambda *_: (np.array([[1]], dtype=np.int8), ["LPS_R1"]))
+    monkeypatch.setattr(
+        rbp_module,
+        "load_curated_rbp_summary",
+        lambda *_: {
+            "P1": {"curated_rbp_count": 1, "curated_types": {"fiber"}, "curated_has_rbp": 1},
+            "P2": {"curated_rbp_count": 1, "curated_types": {"spike"}, "curated_has_rbp": 1},
+        },
+    )
+    monkeypatch.setattr(
+        rbp_module,
+        "load_pharokka_rbp_gene_summary",
+        lambda *_: {
+            "P1": {"pharokka_rbp_gene_count": 1, "pharokka_has_rbp": 1},
+            "P2": {"pharokka_rbp_gene_count": 1, "pharokka_has_rbp": 1},
+        },
+    )
+    monkeypatch.setattr(rbp_module, "build_feature_rows", fake_build_feature_rows)
+
+    exit_code = rbp_module.main(
+        [
+            "--label-path",
+            str(label_path),
+            "--cached-annotations-dir",
+            str(cached_dir),
+            "--omp-path",
+            str(omp_path),
+            "--lps-primary-path",
+            str(lps_primary_path),
+            "--lps-supplemental-path",
+            str(lps_supplemental_path),
+            "--omp-enrichment-path",
+            str(omp_enrichment_path),
+            "--lps-enrichment-path",
+            str(lps_enrichment_path),
+            "--rbp-list-path",
+            str(rbp_list_path),
+            "--st03-split-assignments-path",
+            str(split_path),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    manifest = json.loads((output_dir / "mechanistic_rbp_receptor_manifest_v1.json").read_text(encoding="utf-8"))
+    assert manifest["holdout_exclusion"]["excluded_pair_rows"] == 1


### PR DESCRIPTION
## Summary
Hoist the holdout-bacteria set out of the TL03 and TL04 pair filtering comprehensions, and compute `excluded_pair_rows` from `all_pair_rows - pair_rows` so the manifest count stays correct even if feature construction ever drops rows for another reason.

Add regression tests for both steps that force `build_feature_rows` to drop a row and verify the manifest still reports only the holdout exclusion delta.

Closes #278

Posted by Codex gpt-5.4