### PR TITLE
Block auto-merge on unresolved review threads

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -115,26 +115,12 @@ jobs:
           PR_NUM="${{ github.event.pull_request.number }}"
           LATEST_REVIEW=$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUM}/reviews" \
             --jq '[.[] | select(.user.login == "claude[bot]")] | last | .state')
-          UNRESOLVED_REVIEW_THREADS=$(gh api graphql \
-            -f owner="${{ github.repository_owner }}" \
-            -f repo="${{ github.event.repository.name }}" \
-            -F number="$PR_NUM" \
-            -f query='
-              query($owner: String!, $repo: String!, $number: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $number) {
-                    reviewThreads(first: 100) {
-                      nodes {
-                        isResolved
-                      }
-                    }
-                  }
-                }
-              }
-            ' \
-            --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-              | select(.isResolved == false)
-            ] | length')
+          UNRESOLVED_REVIEW_THREADS=$(python -m lyzortx.orchestration.review_threads \
+            "${{ github.repository_owner }}" \
+            "${{ github.event.repository.name }}" \
+            "$PR_NUM" \
+            /dev/null \
+            --count-only)
           UNRESOLVED_REVIEW_THREADS=${UNRESOLVED_REVIEW_THREADS:-}
           if ! [[ "$UNRESOLVED_REVIEW_THREADS" =~ ^[0-9]+$ ]]; then
             echo "::error::Failed to fetch unresolved review thread count: '${UNRESOLVED_REVIEW_THREADS}'"

--- a/lyzortx/orchestration/README.md
+++ b/lyzortx/orchestration/README.md
@@ -91,8 +91,9 @@ stateDiagram-v2
   workflows and available as a CLI: `echo "$BODY" | python -m lyzortx.orchestration.parse_model_directive`.
 - `render_plan.py` — generates `PLAN.md` from `plan.yml` with Mermaid DAG and track checklists.
 - `orchestrator.py` — CLI runner that dispatches tasks as GitHub issues.
-- `review_threads.py` — fetches unresolved PR review threads via GraphQL and formats them into a Codex feedback prompt.
-  Includes a signing instruction so Codex identifies itself in every reply ("Posted by Codex \<model\>").
+- `review_threads.py` — fetches unresolved PR review threads via GitHub GraphQL, paginates across thread pages, filters
+  to unresolved non-outdated threads, and formats them into a Codex feedback prompt. Includes a signing instruction so
+  Codex identifies itself in every reply ("Posted by Codex \<model\>").
 - `verify_review_replies.py` — checks that PR review comments have been addressed with replies.
 - `ci_token_usage.py` — CLI for token/cost analysis across all LLM-invoking workflows (Codex + Claude).
 - `.github/workflows/orchestrator.yml` — CI trigger: task dispatch and plan updates.
@@ -177,9 +178,9 @@ Claude reads `AGENTS.md` review guidelines, submits formal `APPROVE` or `COMMENT
 the sole judge of thread resolution (can resolve/unresolve threads via GraphQL mutations). Requires the
 `ANTHROPIC_API_KEY` repository secret. The workflow explicitly allows the repo's `czarphage` GitHub App bot to trigger
 re-reviews after Codex pushes, which would otherwise be blocked by `claude-code-action`'s default "no bots" policy.
-After reviewing, it auto-merges only when Claude's latest review is `APPROVED` and the PR has zero unresolved review
-threads. If Claude leaves a `COMMENTED` review or any unresolved review threads remain, it dispatches
-`codex-pr-lifecycle.yml`.
+After reviewing, it auto-merges only when Claude's latest review is `APPROVED` and the shared
+`lyzortx.orchestration.review_threads` helper reports zero unresolved review threads. If Claude leaves a `COMMENTED`
+review or any unresolved review threads remain, it dispatches `codex-pr-lifecycle.yml`.
 
 ### codex-pr-lifecycle.yml
 

--- a/lyzortx/orchestration/review_threads.py
+++ b/lyzortx/orchestration/review_threads.py
@@ -8,14 +8,11 @@ import subprocess
 import sys
 from typing import Any
 
-# TODO: reviewThreads(first: 100) and comments(first: 10) will silently
-# truncate PRs with >100 threads or >10 comments per thread. Add cursor-based
-# pagination if this becomes an issue in practice.
 REVIEW_THREADS_QUERY = """
-query($owner: String!, $repo: String!, $pr: Int!) {
+query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $cursor) {
         nodes {
           id
           isResolved
@@ -28,6 +25,10 @@ query($owner: String!, $repo: String!, $pr: Int!) {
               author { login }
             }
           }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
         }
       }
     }
@@ -44,6 +45,17 @@ def extract_threads(graphql_response: dict[str, Any]) -> list[dict[str, Any]]:
         .get("pullRequest", {})
         .get("reviewThreads", {})
         .get("nodes", [])
+    )
+
+
+def extract_page_info(graphql_response: dict[str, Any]) -> dict[str, Any]:
+    """Extract the reviewThreads pageInfo block from a GraphQL response."""
+    return (
+        graphql_response.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+        .get("pageInfo", {})
     )
 
 
@@ -95,8 +107,11 @@ def format_prompt(pr_number: int, threads: list[dict[str, Any]]) -> str:
 
 def fetch_threads(owner: str, repo: str, pr_number: int) -> dict[str, Any]:
     """Call gh api graphql to fetch review threads. Requires gh CLI."""
-    result = subprocess.run(
-        [
+    all_threads: list[dict[str, Any]] = []
+    cursor: str | None = None
+
+    while True:
+        command = [
             "gh",
             "api",
             "graphql",
@@ -108,12 +123,28 @@ def fetch_threads(owner: str, repo: str, pr_number: int) -> dict[str, Any]:
             f"repo={repo}",
             "-F",
             f"pr={pr_number}",
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return json.loads(result.stdout)
+        ]
+        if cursor is not None:
+            command.extend(["-f", f"cursor={cursor}"])
+
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        response = json.loads(result.stdout)
+        all_threads.extend(extract_threads(response))
+
+        page_info = extract_page_info(response)
+        if not page_info.get("hasNextPage"):
+            break
+
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            raise ValueError("GitHub GraphQL returned hasNextPage=true without an endCursor for reviewThreads")
+
+    return {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": all_threads}}}}}
 
 
 def main() -> None:

--- a/lyzortx/research_notes/lab_notebooks/devops.md
+++ b/lyzortx/research_notes/lab_notebooks/devops.md
@@ -23,16 +23,21 @@ while any review feedback is still open.
 
 #### Implementation
 
-Updated `claude-pr-review.yml` to query PR review threads via GitHub GraphQL, count unresolved threads, and gate
-auto-merge on that count being zero. The workflow still accepts a clean Claude approval path, but any unresolved review
-thread now forces the "request addressing feedback" path through the Codex PR lifecycle workflow.
+Updated `claude-pr-review.yml` to gate auto-merge on the unresolved-thread count returned by the shared
+`lyzortx.orchestration.review_threads` helper. That keeps the Claude merge gate aligned with the Codex lifecycle, which
+already uses the same helper to decide whether feedback remains. The workflow still accepts a clean Claude approval
+path, but any unresolved review thread now forces the "request addressing feedback" path through the Codex PR
+lifecycle workflow.
 
 #### Follow-up after PR #283
 
 PR #283 showed that author filtering was the wrong design entirely. The intended policy is that any unresolved review
 thread blocks auto-merge, not only comments authored by Claude. The GraphQL author-login mismatch (`claude[bot]` in
 REST, `claude` in GraphQL) was just the symptom that exposed this. The correct fix is to remove author filtering and
-count every unresolved review thread on the PR.
+count every unresolved review thread on the PR. A second follow-up was needed after review pointed out that the
+workflow's inline GraphQL query also disagreed with `review_threads.py` on outdated threads and silently capped itself
+at 100 threads. Moving the count into the shared helper, and adding thread pagination there, keeps the automation
+consistent.
 
 ### 2026-03-29: Fix conda environment solve failure — downgrade openjdk 25 to 24
 

--- a/lyzortx/tests/test_review_threads.py
+++ b/lyzortx/tests/test_review_threads.py
@@ -1,7 +1,12 @@
 """Tests for review_threads."""
 
+import json
+from types import SimpleNamespace
+
 from lyzortx.orchestration.review_threads import (
+    extract_page_info,
     extract_threads,
+    fetch_threads,
     filter_unresolved,
     format_prompt,
     format_thread,
@@ -41,6 +46,28 @@ def test_extract_threads() -> None:
 
 def test_extract_threads_empty_response() -> None:
     assert extract_threads({}) == []
+
+
+def test_extract_page_info() -> None:
+    response = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": {
+                            "hasNextPage": True,
+                            "endCursor": "CURSOR_1",
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert extract_page_info(response) == {"hasNextPage": True, "endCursor": "CURSOR_1"}
+
+
+def test_extract_page_info_empty_response() -> None:
+    assert extract_page_info({}) == {}
 
 
 def test_filter_unresolved_keeps_active() -> None:
@@ -105,3 +132,53 @@ def test_format_prompt_empty() -> None:
     prompt = format_prompt(1, [])
     assert "PR #1" in prompt
     assert "Address every unresolved thread" in prompt
+
+
+def test_fetch_threads_paginates(monkeypatch) -> None:
+    first_page = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [_thread(id="page1")],
+                        "pageInfo": {
+                            "hasNextPage": True,
+                            "endCursor": "CURSOR_1",
+                        },
+                    }
+                }
+            }
+        }
+    }
+    second_page = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [_thread(id="page2")],
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": None,
+                        },
+                    }
+                }
+            }
+        }
+    }
+    responses = iter([first_page, second_page])
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], capture_output: bool, text: bool, check: bool) -> SimpleNamespace:
+        assert capture_output is True
+        assert text is True
+        assert check is True
+        commands.append(command)
+        return SimpleNamespace(stdout=json.dumps(next(responses)))
+
+    monkeypatch.setattr("lyzortx.orchestration.review_threads.subprocess.run", fake_run)
+
+    result = fetch_threads("owner", "repo", 42)
+
+    assert [thread["id"] for thread in extract_threads(result)] == ["page1", "page2"]
+    assert not any(part == "cursor=CURSOR_1" for part in commands[0])
+    assert any(part == "cursor=CURSOR_1" for part in commands[1])


### PR DESCRIPTION
## Summary
Update `.github/workflows/claude-pr-review.yml` so auto-merge only proceeds when Claude's latest review is `APPROVED` and the shared `lyzortx.orchestration.review_threads` helper reports zero unresolved review threads.

This replaces the duplicated inline GraphQL query in the workflow. The merge gate and `codex-pr-lifecycle.yml` now use the same helper semantics, including ignoring outdated threads.

Add review-thread pagination to `lyzortx/orchestration/review_threads.py` so the count and prompt generation do not silently stop at the first 100 threads.

Update `lyzortx/orchestration/README.md` and the devops notebook entry to document the corrected behavior and the PR #283 follow-up.

## Testing
- `pytest -q lyzortx/tests/test_review_threads.py`
- Parsed `.github/workflows/claude-pr-review.yml` with `yaml.safe_load`
- Ran the final unresolved-thread GraphQL count against PR #283 during investigation
- Ran repo hooks on commit/push (`ruff`, `ruff-format`, `pymarkdown`, `check-rebase-on-main`)

Generated by Codex gpt-5