### PR TITLE
[ORCH][GT01] Depolymerase × capsule pairwise cross-term features

### DIFF
--- a/lyzortx/pipeline/autoresearch/candidate_replay.py
+++ b/lyzortx/pipeline/autoresearch/candidate_replay.py
@@ -341,6 +341,11 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Add pairwise RBP × receptor cross-terms (AX03). Requires --include-phage-rbp-struct.",
     )
     replicate_parser.add_argument(
+        "--include-pairwise-depo-capsule",
+        action="store_true",
+        help="Add pairwise depolymerase × capsule cross-terms (GT01).",
+    )
+    replicate_parser.add_argument(
         "--variant",
         choices=("all-pairs", "per-phage-blend"),
         default="all-pairs",
@@ -617,6 +622,7 @@ def build_candidate_holdout_rows(
     include_phage_rbp_struct: bool = False,
     include_phage_functional: bool = False,
     include_pairwise_rbp_receptor: bool = False,
+    include_pairwise_depo_capsule: bool = False,
     variant: str = "all-pairs",
     blend_alpha: float = 0.5,
     calibrate: str = "none",
@@ -664,12 +670,23 @@ def build_candidate_holdout_rows(
         compute_pairwise_rbp_receptor_features(train_design)
         compute_pairwise_rbp_receptor_features(holdout_design)
 
+    # Pairwise depolymerase × capsule cross-terms (GT01).
+    if include_pairwise_depo_capsule:
+        from lyzortx.pipeline.autoresearch.derive_pairwise_depo_capsule_features import (
+            compute_pairwise_depo_capsule_features,
+        )
+
+        compute_pairwise_depo_capsule_features(train_design)
+        compute_pairwise_depo_capsule_features(holdout_design)
+
     # Build prefix list from the slots we actually assembled, not from the candidate module.
     # Old candidates may lack prefixes for newer slots (phage_rbp_struct, phage_functional).
     all_slot_names = host_slots + phage_slots
     replay_prefixes = tuple(f"{s}__" for s in all_slot_names)
     if include_pairwise_rbp_receptor:
         replay_prefixes = (*replay_prefixes, "pair_rbp_receptor__")
+    if include_pairwise_depo_capsule:
+        replay_prefixes = (*replay_prefixes, "pair_depo_capsule__")
     feature_columns = [col for col in train_design.columns if col.startswith(replay_prefixes)]
     if not feature_columns:
         raise ValueError("Candidate replay constructed zero pair features for holdout replication.")
@@ -1136,6 +1153,7 @@ def replicate_candidate(args: argparse.Namespace) -> Path:
             include_phage_rbp_struct=getattr(args, "include_phage_rbp_struct", False),
             include_phage_functional=getattr(args, "include_phage_functional", False),
             include_pairwise_rbp_receptor=getattr(args, "include_pairwise_rbp_receptor", False),
+            include_pairwise_depo_capsule=getattr(args, "include_pairwise_depo_capsule", False),
             variant=getattr(args, "variant", "all-pairs"),
             blend_alpha=getattr(args, "blend_alpha", 0.5),
             calibrate=getattr(args, "calibrate", "none"),
@@ -1214,6 +1232,7 @@ def replicate_candidate(args: argparse.Namespace) -> Path:
             "include_phage_rbp_struct": getattr(args, "include_phage_rbp_struct", False),
             "include_phage_functional": getattr(args, "include_phage_functional", False),
             "include_pairwise_rbp_receptor": getattr(args, "include_pairwise_rbp_receptor", False),
+            "include_pairwise_depo_capsule": getattr(args, "include_pairwise_depo_capsule", False),
             "variant": getattr(args, "variant", "all-pairs"),
             "blend_alpha": getattr(args, "blend_alpha", 0.5),
             "calibrate": getattr(args, "calibrate", "none"),

--- a/lyzortx/pipeline/autoresearch/derive_pairwise_depo_capsule_features.py
+++ b/lyzortx/pipeline/autoresearch/derive_pairwise_depo_capsule_features.py
@@ -1,0 +1,193 @@
+"""Derive pairwise depolymerase × capsule cross-term features (GT01).
+
+For each (phage, host) pair, computes cross-terms between phage depolymerase
+presence/count and host capsule HMM profile scores. Also includes per-cluster
+membership features that enable LightGBM to learn cluster-specific capsule
+interactions via tree splits.
+
+Depolymerase data comes from DepoScope predictions (.scratch/deposcope/),
+host capsule scores come from the host_surface slot already in the design matrix.
+
+Feature groups:
+- Phage-level: has_depo, depo_count, depo_cluster_count (3 features)
+- Cluster membership: in_cluster_<N> binary indicators (41 features)
+- Cross-terms: has_depo × capsule_score, depo_count × capsule_score (198 features)
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+from collections import defaultdict
+from pathlib import Path
+
+import pandas as pd
+
+LOGGER = logging.getLogger(__name__)
+
+PAIRWISE_PREFIX = "pair_depo_capsule__"
+
+# Pattern for host capsule columns in the host_surface slot.
+CAPSULE_COLUMN_PREFIX = "host_surface__host_capsule_profile_"
+CAPSULE_COLUMN_SUFFIX = "_score"
+
+
+def _capsule_short_name(col: str) -> str:
+    """Extract short capsule name: 'host_surface__host_capsule_profile_cluster_19_score' -> 'cluster_19'."""
+    after_prefix = col[len(CAPSULE_COLUMN_PREFIX) :]
+    return after_prefix[: -len(CAPSULE_COLUMN_SUFFIX)]
+
+
+def load_deposcope_predictions(predictions_path: Path) -> dict[str, int]:
+    """Load DepoScope predictions and return phage -> depolymerase count."""
+    phage_depo_count: dict[str, int] = defaultdict(int)
+    with open(predictions_path, encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row["is_depolymerase"] == "True":
+                phage_depo_count[row["phage"]] += 1
+    return dict(phage_depo_count)
+
+
+def load_deposcope_clusters(cluster_path: Path) -> dict[str, set[str]]:
+    """Load DepoScope cluster assignments.
+
+    Returns phage -> set of cluster representative IDs.
+    """
+    phage_clusters: dict[str, set[str]] = defaultdict(set)
+    with open(cluster_path, encoding="utf-8") as f:
+        for line in f:
+            parts = line.strip().split("\t")
+            if len(parts) < 2:
+                continue
+            rep_id = parts[0]
+            member_id = parts[1]
+            # Extract phage name from compound ID: "409_P1|409_P1|prot_0043|score=1.0000"
+            member_phage = member_id.split("|")[0]
+            phage_clusters[member_phage].add(rep_id)
+    return dict(phage_clusters)
+
+
+def build_cluster_index(phage_clusters: dict[str, set[str]]) -> list[str]:
+    """Build a deterministic ordered list of cluster representative IDs.
+
+    Sorted alphabetically for reproducibility.
+    """
+    all_reps: set[str] = set()
+    for reps in phage_clusters.values():
+        all_reps.update(reps)
+    return sorted(all_reps)
+
+
+def build_phage_depo_lookup(
+    predictions_path: Path,
+    cluster_path: Path,
+) -> tuple[dict[str, int], dict[str, set[str]], list[str]]:
+    """Load DepoScope data and return (depo_counts, phage_clusters, cluster_index)."""
+    depo_counts = load_deposcope_predictions(predictions_path)
+    phage_clusters = load_deposcope_clusters(cluster_path)
+    cluster_index = build_cluster_index(phage_clusters)
+    LOGGER.info(
+        "DepoScope: %d phages with depolymerases, %d clusters",
+        len(depo_counts),
+        len(cluster_index),
+    )
+    return depo_counts, phage_clusters, cluster_index
+
+
+def compute_pairwise_depo_capsule_features(
+    design: pd.DataFrame,
+    *,
+    deposcope_dir: Path | None = None,
+) -> list[str]:
+    """Add depolymerase × capsule cross-term columns to the design matrix in-place.
+
+    Parameters
+    ----------
+    design : pd.DataFrame
+        Pair-level design matrix with 'phage' column and host_surface capsule columns.
+    deposcope_dir : Path, optional
+        Directory containing DepoScope outputs (predictions.csv, depo_clusters_cluster.tsv).
+        Defaults to .scratch/deposcope/ relative to the working directory.
+
+    Returns
+    -------
+    list[str]
+        The names of added feature columns.
+    """
+    if deposcope_dir is None:
+        deposcope_dir = Path(".scratch/deposcope")
+
+    predictions_path = deposcope_dir / "predictions.csv"
+    cluster_path = deposcope_dir / "depo_clusters_cluster.tsv"
+
+    if not predictions_path.exists():
+        raise FileNotFoundError(
+            f"DepoScope predictions not found at {predictions_path}. Run DepoScope first (see GT01 task)."
+        )
+    if not cluster_path.exists():
+        raise FileNotFoundError(
+            f"DepoScope cluster file not found at {cluster_path}. Run DepoScope clustering first (see GT01 task)."
+        )
+
+    if "phage" not in design.columns:
+        raise ValueError("Design matrix must have a 'phage' column.")
+
+    depo_counts, phage_clusters, cluster_index = build_phage_depo_lookup(predictions_path, cluster_path)
+
+    # Find capsule columns in the design matrix.
+    capsule_columns = [
+        col for col in design.columns if col.startswith(CAPSULE_COLUMN_PREFIX) and col.endswith(CAPSULE_COLUMN_SUFFIX)
+    ]
+    if not capsule_columns:
+        raise ValueError(
+            "No host capsule profile columns found in design matrix. Ensure host_surface slot is included."
+        )
+
+    added_columns: list[str] = []
+    phage_series = design["phage"].astype(str)
+
+    # --- Phage-level features ---
+    has_depo_col = f"{PAIRWISE_PREFIX}has_depo"
+    depo_count_col = f"{PAIRWISE_PREFIX}depo_count"
+    cluster_count_col = f"{PAIRWISE_PREFIX}depo_cluster_count"
+
+    has_depo = phage_series.map(lambda p: 1.0 if p in depo_counts else 0.0)
+    depo_count = phage_series.map(lambda p: float(depo_counts.get(p, 0)))
+    cluster_count = phage_series.map(lambda p: float(len(phage_clusters.get(p, set()))))
+
+    design[has_depo_col] = has_depo
+    design[depo_count_col] = depo_count
+    design[cluster_count_col] = cluster_count
+    added_columns.extend([has_depo_col, depo_count_col, cluster_count_col])
+
+    # --- Per-cluster membership features ---
+    for i, rep_id in enumerate(cluster_index):
+        col_name = f"{PAIRWISE_PREFIX}in_cluster_{i}"
+        design[col_name] = phage_series.map(lambda p, r=rep_id: 1.0 if r in phage_clusters.get(p, set()) else 0.0)
+        added_columns.append(col_name)
+
+    # --- Cross-terms: has_depo × capsule_score, depo_count × capsule_score ---
+    for capsule_col in capsule_columns:
+        short = _capsule_short_name(capsule_col)
+        capsule_score = pd.to_numeric(design[capsule_col], errors="coerce").fillna(0.0)
+
+        has_depo_x_col = f"{PAIRWISE_PREFIX}has_depo_x_{short}"
+        count_x_col = f"{PAIRWISE_PREFIX}depo_count_x_{short}"
+
+        design[has_depo_x_col] = has_depo * capsule_score
+        design[count_x_col] = depo_count * capsule_score
+
+        added_columns.append(has_depo_x_col)
+        added_columns.append(count_x_col)
+
+    LOGGER.info(
+        "Added %d pairwise depolymerase × capsule features "
+        "(%d clusters, %d capsule profiles, %d/%d phages with depolymerases)",
+        len(added_columns),
+        len(cluster_index),
+        len(capsule_columns),
+        len(depo_counts),
+        design["phage"].nunique(),
+    )
+    return added_columns

--- a/lyzortx/tests/test_derive_pairwise_depo_capsule_features.py
+++ b/lyzortx/tests/test_derive_pairwise_depo_capsule_features.py
@@ -1,0 +1,138 @@
+"""Tests for derive_pairwise_depo_capsule_features (GT01)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from lyzortx.pipeline.autoresearch.derive_pairwise_depo_capsule_features import (
+    PAIRWISE_PREFIX,
+    build_cluster_index,
+    compute_pairwise_depo_capsule_features,
+    load_deposcope_clusters,
+    load_deposcope_predictions,
+)
+
+
+@pytest.fixture()
+def deposcope_dir(tmp_path: Path) -> Path:
+    """Create minimal DepoScope output files."""
+    d = tmp_path / "deposcope"
+    d.mkdir()
+
+    # predictions.csv: 3 phages, 2 with depolymerases
+    predictions = d / "predictions.csv"
+    predictions.write_text(
+        "phage,protein_id,length,deposcope_score,is_depolymerase\n"
+        "P1,P1|prot_001,500,0.99,True\n"
+        "P1,P1|prot_002,300,0.95,True\n"
+        "P1,P1|prot_003,200,0.01,False\n"
+        "P2,P2|prot_001,400,0.88,True\n"
+        "P2,P2|prot_002,150,0.02,False\n"
+        "P3,P3|prot_001,350,0.03,False\n",
+        encoding="utf-8",
+    )
+
+    # Cluster file: P1|prot_001 and P2|prot_001 in same cluster, P1|prot_002 in its own
+    clusters = d / "depo_clusters_cluster.tsv"
+    clusters.write_text(
+        "P1|P1|prot_001|score=1.0\tP1|P1|prot_001|score=1.0\n"
+        "P1|P1|prot_001|score=1.0\tP2|P2|prot_001|score=1.0\n"
+        "P1|P1|prot_002|score=1.0\tP1|P1|prot_002|score=1.0\n",
+        encoding="utf-8",
+    )
+    return d
+
+
+def test_load_deposcope_predictions(deposcope_dir: Path) -> None:
+    counts = load_deposcope_predictions(deposcope_dir / "predictions.csv")
+    assert counts == {"P1": 2, "P2": 1}
+    assert "P3" not in counts
+
+
+def test_load_deposcope_clusters(deposcope_dir: Path) -> None:
+    clusters = load_deposcope_clusters(deposcope_dir / "depo_clusters_cluster.tsv")
+    # P1 is in both clusters (it has prot_001 in cluster A and prot_002 in cluster B)
+    assert len(clusters["P1"]) == 2
+    # P2 is in cluster A only
+    assert len(clusters["P2"]) == 1
+    # P3 has no depolymerases so no clusters
+    assert "P3" not in clusters
+
+
+def test_build_cluster_index(deposcope_dir: Path) -> None:
+    clusters = load_deposcope_clusters(deposcope_dir / "depo_clusters_cluster.tsv")
+    index = build_cluster_index(clusters)
+    assert len(index) == 2
+    # Sorted alphabetically
+    assert index == sorted(index)
+
+
+def test_compute_features_on_design_matrix(deposcope_dir: Path) -> None:
+    """Full integration: compute features on a pair-level design matrix."""
+    # Build a minimal design matrix: 3 phages × 2 hosts = 6 pairs
+    rows = []
+    for phage in ["P1", "P2", "P3"]:
+        for host in ["H1", "H2"]:
+            rows.append(
+                {
+                    "phage": phage,
+                    "bacteria": host,
+                    "host_surface__host_capsule_profile_cluster_19_score": 500.0 if host == "H1" else 0.0,
+                    "host_surface__host_capsule_profile_kfoa_score": 200.0 if host == "H2" else 100.0,
+                }
+            )
+    design = pd.DataFrame(rows)
+
+    added = compute_pairwise_depo_capsule_features(design, deposcope_dir=deposcope_dir)
+
+    # All added columns start with the prefix
+    assert all(col.startswith(PAIRWISE_PREFIX) for col in added)
+
+    # Check phage-level features
+    p1_rows = design[design["phage"] == "P1"]
+    p3_rows = design[design["phage"] == "P3"]
+
+    assert (p1_rows[f"{PAIRWISE_PREFIX}has_depo"] == 1.0).all()
+    assert (p1_rows[f"{PAIRWISE_PREFIX}depo_count"] == 2.0).all()
+    assert (p1_rows[f"{PAIRWISE_PREFIX}depo_cluster_count"] == 2.0).all()
+
+    assert (p3_rows[f"{PAIRWISE_PREFIX}has_depo"] == 0.0).all()
+    assert (p3_rows[f"{PAIRWISE_PREFIX}depo_count"] == 0.0).all()
+    assert (p3_rows[f"{PAIRWISE_PREFIX}depo_cluster_count"] == 0.0).all()
+
+    # Check cross-terms: P1 × H1 should have has_depo(1) × capsule_cluster_19(500) = 500
+    p1_h1 = design[(design["phage"] == "P1") & (design["bacteria"] == "H1")]
+    assert p1_h1[f"{PAIRWISE_PREFIX}has_depo_x_cluster_19"].iloc[0] == pytest.approx(500.0)
+    assert p1_h1[f"{PAIRWISE_PREFIX}depo_count_x_cluster_19"].iloc[0] == pytest.approx(1000.0)
+
+    # P3 × H1 should have all cross-terms = 0 (no depolymerase)
+    p3_h1 = design[(design["phage"] == "P3") & (design["bacteria"] == "H1")]
+    assert p3_h1[f"{PAIRWISE_PREFIX}has_depo_x_cluster_19"].iloc[0] == pytest.approx(0.0)
+
+    # Check cluster membership features
+    cluster_cols = [col for col in added if col.startswith(f"{PAIRWISE_PREFIX}in_cluster_")]
+    assert len(cluster_cols) == 2  # 2 clusters in fixture
+
+
+def test_missing_capsule_columns_raises(deposcope_dir: Path) -> None:
+    """Raises when no capsule columns are found."""
+    design = pd.DataFrame({"phage": ["P1"], "bacteria": ["H1"], "other_col": [1.0]})
+    with pytest.raises(ValueError, match="No host capsule profile columns"):
+        compute_pairwise_depo_capsule_features(design, deposcope_dir=deposcope_dir)
+
+
+def test_missing_phage_column_raises(deposcope_dir: Path) -> None:
+    """Raises when phage column is missing."""
+    design = pd.DataFrame({"bacteria": ["H1"], "host_surface__host_capsule_profile_x_score": [1.0]})
+    with pytest.raises(ValueError, match="phage"):
+        compute_pairwise_depo_capsule_features(design, deposcope_dir=deposcope_dir)
+
+
+def test_missing_deposcope_files_raises(tmp_path: Path) -> None:
+    """Raises when DepoScope output files don't exist."""
+    design = pd.DataFrame({"phage": ["P1"], "bacteria": ["H1"], "host_surface__host_capsule_profile_x_score": [1.0]})
+    with pytest.raises(FileNotFoundError, match="predictions"):
+        compute_pairwise_depo_capsule_features(design, deposcope_dir=tmp_path)


### PR DESCRIPTION
## Summary

- New `derive_pairwise_depo_capsule_features.py` loads DepoScope predictions/clusters from `.scratch/deposcope/` and computes directed cross-terms with host capsule HMM profiles
- 242 features: 3 phage-level (has_depo, count, cluster diversity) + 41 per-cluster binary membership + 198 cross-terms (has_depo/count × 99 capsule scores)
- Wired into `candidate_replay.py` via `--include-pairwise-depo-capsule` flag
- 7 unit tests covering loading, cross-term computation, and error cases

## Test plan

- [x] 7 new unit tests pass
- [x] 8 existing candidate_replay tests pass (no regressions)

🤖 Generated by Claude Opus 4.6

Closes #371