### PR TITLE
[ORCH][GT07] OMP allele-variant receptor features

### DIFF
--- a/lyzortx/pipeline/autoresearch/derive_pairwise_receptor_omp_variant_features.py
+++ b/lyzortx/pipeline/autoresearch/derive_pairwise_receptor_omp_variant_features.py
@@ -1,0 +1,158 @@
+"""Derive directed receptor × OMP allele-variant cross-terms (GT07).
+
+Replaces the near-constant whole-gene HMM scores (CV 0.01-0.17) with binary
+OMP allele cluster features from Track C (99% identity BLAST clustering).
+These variant features have variance 0.08-0.25 and measurable discriminative
+power (e.g., BtuB cluster 99_15: Cohen's d=0.455 for lysed vs non-lysed).
+
+Cross-term pattern: predicted_receptor_is_X × host_X_variant_cluster_Y.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from lyzortx.pipeline.autoresearch.predict_receptor_from_kmers import (
+    ReceptorPrediction,
+    predict_receptors,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+PAIRWISE_PREFIX = "pair_receptor_omp_variant__"
+
+# Maps k-mer receptor short names to the prefix used in Track C variant feature columns.
+RECEPTOR_TO_VARIANT_PREFIX = {
+    "btub": "host_omp_receptor_btub_cluster_",
+    "fadL": "host_omp_receptor_fadl_cluster_",
+    "fhua": "host_omp_receptor_fhua_cluster_",
+    "lamB": "host_omp_receptor_lamb_cluster_",
+    "lptD": "host_omp_receptor_lptd_cluster_",
+    "nfrA": "host_omp_receptor_nfra_cluster_",
+    "ompA": "host_omp_receptor_ompa_cluster_",
+    "ompC": "host_omp_receptor_ompc_cluster_",
+    "ompF": "host_omp_receptor_ompf_cluster_",
+    "tolC": "host_omp_receptor_tolc_cluster_",
+    "tsx": "host_omp_receptor_tsx_cluster_",
+    "yncD": "host_omp_receptor_yncd_cluster_",
+}
+
+DEFAULT_VARIANT_FEATURES_PATH = Path(
+    "lyzortx/generated_outputs/track_c/omp_receptor_variant_feature_block/host_omp_receptor_variant_features_v1.csv"
+)
+DEFAULT_PROTEOME_PATH = Path(
+    "lyzortx/generated_outputs/autoresearch/phage_projection_cache_build/_batched/combined_queries.faa"
+)
+DEFAULT_DATASET_PATH = Path(".scratch/genophi/Supplementary_Datasets_S1-S7.xlsx")
+
+
+def compute_pairwise_receptor_omp_variant_features(
+    design: pd.DataFrame,
+    *,
+    variant_features_path: Path | None = None,
+    proteome_path: Path | None = None,
+    dataset_path: Path | None = None,
+) -> list[str]:
+    """Add receptor × OMP allele-variant directed cross-terms to the design matrix.
+
+    For each phage with a k-mer receptor prediction targeting an OMP receptor,
+    creates cross-terms: predicted_receptor_is_X × host_X_variant_cluster_Y
+    for each binary variant cluster of that receptor.
+    """
+    if variant_features_path is None:
+        variant_features_path = DEFAULT_VARIANT_FEATURES_PATH
+    if proteome_path is None:
+        proteome_path = DEFAULT_PROTEOME_PATH
+    if dataset_path is None:
+        dataset_path = DEFAULT_DATASET_PATH
+
+    if not variant_features_path.exists():
+        raise FileNotFoundError(f"OMP variant features not found at {variant_features_path}")
+    if not proteome_path.exists():
+        raise FileNotFoundError(f"Phage proteome not found at {proteome_path}")
+    if not dataset_path.exists():
+        raise FileNotFoundError(f"GenoPHI Dataset S6 not found at {dataset_path}")
+    if "phage" not in design.columns:
+        raise ValueError("Design matrix must have a 'phage' column.")
+    if "bacteria" not in design.columns:
+        raise ValueError("Design matrix must have a 'bacteria' column.")
+
+    # Load OMP variant features (binary cluster assignments per host).
+    variant_df = pd.read_csv(variant_features_path)
+    variant_df = variant_df.set_index("bacteria")
+    variant_cols = [c for c in variant_df.columns if c.startswith("host_omp_receptor_")]
+    LOGGER.info("Loaded %d OMP variant features for %d bacteria", len(variant_cols), len(variant_df))
+
+    # Load k-mer receptor predictions.
+    predictions = predict_receptors(proteome_path, dataset_path)
+    phage_pred: dict[str, ReceptorPrediction] = {p.phage: p for p in predictions}
+
+    phage_series = design["phage"].astype(str)
+    bacteria_series = design["bacteria"].astype(str)
+    added_columns: list[str] = []
+
+    # Merge variant features into design by bacteria.
+    bacteria_in_variants = set(variant_df.index)
+    for vcol in variant_cols:
+        mapped = bacteria_series.map(lambda b, col=vcol: variant_df.loc[b, col] if b in bacteria_in_variants else 0.0)
+        design[vcol] = mapped.astype(float)
+
+    # For each OMP receptor, create directed cross-terms.
+    for receptor_short, variant_prefix in RECEPTOR_TO_VARIANT_PREFIX.items():
+        # Find variant columns for this receptor.
+        receptor_variant_cols = [c for c in variant_cols if c.startswith(variant_prefix)]
+        if not receptor_variant_cols:
+            continue
+
+        # predicted_is_X indicator.
+        predicted_col = f"{PAIRWISE_PREFIX}predicted_is_{receptor_short}"
+        design[predicted_col] = phage_series.map(
+            lambda p, target=receptor_short: (
+                1.0
+                if p in phage_pred
+                and phage_pred[p].receptor_type == "omp"
+                and phage_pred[p].predicted_receptor == target
+                else 0.0
+            )
+        )
+        added_columns.append(predicted_col)
+
+        # Cross-terms: predicted_is_X × host_X_variant_cluster_Y.
+        for vcol in receptor_variant_cols:
+            cluster_id = vcol.replace(variant_prefix, "")
+            cross_col = f"{PAIRWISE_PREFIX}predicted_{receptor_short}_x_{cluster_id}"
+            design[cross_col] = design[predicted_col] * design[vcol]
+            added_columns.append(cross_col)
+
+    # LPS indicator and confidence (reuse from kmer features pattern).
+    lps_col = f"{PAIRWISE_PREFIX}predicted_is_lps"
+    design[lps_col] = phage_series.map(
+        lambda p: 1.0 if p in phage_pred and phage_pred[p].receptor_type == "lps" else 0.0
+    )
+    added_columns.append(lps_col)
+
+    conf_col = f"{PAIRWISE_PREFIX}prediction_confidence"
+    design[conf_col] = phage_series.map(lambda p: phage_pred[p].confidence if p in phage_pred else 0.0)
+    added_columns.append(conf_col)
+
+    # Log summary.
+    omp_indicators = [c for c in added_columns if c.startswith(f"{PAIRWISE_PREFIX}predicted_is_") and c != lps_col]
+    cross_terms = [c for c in added_columns if "_x_" in c]
+    omp_count = sum(1 for p in phage_pred.values() if p.receptor_type == "omp")
+    LOGGER.info(
+        "Added %d OMP variant cross-term features (%d indicators + %d cross-terms + 2 global; %d OMP phages)",
+        len(added_columns),
+        len(omp_indicators),
+        len(cross_terms),
+        omp_count,
+    )
+
+    # Clean up: remove the raw variant columns from design (they're host-only, not pairwise).
+    for vcol in variant_cols:
+        if vcol in design.columns:
+            design.drop(columns=[vcol], inplace=True)
+
+    return added_columns

--- a/lyzortx/pipeline/autoresearch/derive_pairwise_receptor_omp_variant_features.py
+++ b/lyzortx/pipeline/autoresearch/derive_pairwise_receptor_omp_variant_features.py
@@ -91,14 +91,15 @@ def compute_pairwise_receptor_omp_variant_features(
     phage_pred: dict[str, ReceptorPrediction] = {p.phage: p for p in predictions}
 
     phage_series = design["phage"].astype(str)
-    bacteria_series = design["bacteria"].astype(str)
     added_columns: list[str] = []
 
-    # Merge variant features into design by bacteria.
-    bacteria_in_variants = set(variant_df.index)
+    # Merge variant features into design by bacteria (vectorized join).
+    variant_lookup = variant_df[variant_cols]
+    design_idx = design.index
+    merged = design[["bacteria"]].merge(variant_lookup, left_on="bacteria", right_index=True, how="left")
+    merged.index = design_idx
     for vcol in variant_cols:
-        mapped = bacteria_series.map(lambda b, col=vcol: variant_df.loc[b, col] if b in bacteria_in_variants else 0.0)
-        design[vcol] = mapped.astype(float)
+        design[vcol] = merged[vcol].fillna(0.0).astype(float)
 
     # For each OMP receptor, create directed cross-terms.
     for receptor_short, variant_prefix in RECEPTOR_TO_VARIANT_PREFIX.items():

--- a/lyzortx/pipeline/autoresearch/gt07_eval.py
+++ b/lyzortx/pipeline/autoresearch/gt07_eval.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""GT07: OMP allele-variant receptor features to replace near-constant HMM scores.
+
+Compares two arms on ST03 holdout:
+  1. gt03_baseline  — all_gates_rfe (0.823 AUC, the GT03 best)
+  2. +omp_variants  — all_gates_rfe + OMP allele-variant cross-terms
+
+The hypothesis: binary OMP allele clusters (99% identity BLAST, Track C) provide
+host-side discrimination that the whole-gene HMM scores (CV 0.01-0.17) cannot.
+Cross-terms like predicted_receptor_is_OmpC × host_OmpC_cluster_99_24 should let
+the model distinguish hosts that have different OmpC alleles.
+
+Usage:
+    python -m lyzortx.pipeline.autoresearch.gt07_eval --device-type cpu
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pandas as pd
+from lightgbm import LGBMClassifier
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.candidate_replay import (
+    bootstrap_holdout_metric_cis,
+    build_st03_training_frame,
+    load_module_from_path,
+    load_st03_holdout_frame,
+    summarize_seed_metrics,
+)
+from lyzortx.pipeline.autoresearch.derive_pairwise_depo_capsule_features import (
+    compute_pairwise_depo_capsule_features,
+)
+from lyzortx.pipeline.autoresearch.derive_pairwise_receptor_omp_features import (
+    compute_pairwise_receptor_omp_features,
+)
+from lyzortx.pipeline.autoresearch.derive_pairwise_receptor_omp_variant_features import (
+    compute_pairwise_receptor_omp_variant_features,
+)
+from lyzortx.pipeline.autoresearch.gt03_eval import (
+    LGBM_PARAMS,
+    apply_rfe,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CACHE_DIR = Path("lyzortx/generated_outputs/autoresearch/search_cache_v1")
+DEFAULT_CANDIDATE_DIR = Path("lyzortx/autoresearch")
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/gt07_eval")
+
+SEEDS = [7, 42, 123]
+BOOTSTRAP_SAMPLES = 1000
+BOOTSTRAP_RANDOM_STATE = 42
+
+
+def build_design_with_omp_variant(
+    *,
+    candidate_module: ModuleType,
+    context: Any,
+    training_frame: pd.DataFrame,
+    holdout_frame: pd.DataFrame,
+    include_omp_variants: bool,
+) -> tuple[pd.DataFrame, pd.DataFrame, list[str], list[str]]:
+    """Build all-gates design, optionally adding OMP variant cross-terms."""
+    host_slots = ["host_surface", "host_typing", "host_stats", "host_defense"]
+    phage_slots = ["phage_projection", "phage_stats"]
+
+    host_table = candidate_module.build_entity_feature_table(
+        context.slot_artifacts, slot_names=host_slots, entity_key="bacteria"
+    )
+    phage_table = candidate_module.build_entity_feature_table(
+        context.slot_artifacts, slot_names=phage_slots, entity_key="phage"
+    )
+
+    host_typed, _, host_categorical = candidate_module.type_entity_features(host_table, "bacteria")
+    phage_typed, _, phage_categorical = candidate_module.type_entity_features(phage_table, "phage")
+
+    train_design = candidate_module.build_raw_pair_design_matrix(
+        training_frame, host_features=host_typed, phage_features=phage_typed
+    )
+    holdout_design = candidate_module.build_raw_pair_design_matrix(
+        holdout_frame, host_features=host_typed, phage_features=phage_typed
+    )
+
+    # Gate 1: depolymerase × capsule.
+    compute_pairwise_depo_capsule_features(train_design)
+    compute_pairwise_depo_capsule_features(holdout_design)
+
+    # Gate 2: genus-level receptor × OMP (baseline).
+    compute_pairwise_receptor_omp_features(train_design)
+    compute_pairwise_receptor_omp_features(holdout_design)
+
+    prefixes = list(f"{s}__" for s in host_slots + phage_slots) + [
+        "pair_depo_capsule__",
+        "pair_receptor_omp__",
+    ]
+
+    if include_omp_variants:
+        compute_pairwise_receptor_omp_variant_features(train_design)
+        compute_pairwise_receptor_omp_variant_features(holdout_design)
+        prefixes.append("pair_receptor_omp_variant__")
+
+    feature_columns = [col for col in train_design.columns if col.startswith(tuple(prefixes))]
+    categorical_columns = [col for col in (host_categorical + phage_categorical) if col in feature_columns]
+
+    return train_design, holdout_design, feature_columns, categorical_columns
+
+
+def evaluate_arm(
+    *,
+    train_design: pd.DataFrame,
+    holdout_design: pd.DataFrame,
+    feature_columns: list[str],
+    categorical_columns: list[str],
+    arm_id: str,
+    device_type: str,
+) -> list[dict[str, object]]:
+    """Train LightGBM with RFE, evaluate on holdout for 3 seeds."""
+    y_train = train_design["label_any_lysis"].astype(int).to_numpy(dtype=int)
+    rfe_features = apply_rfe(train_design, feature_columns, categorical_columns, y_train, seed=42)
+    rfe_categorical = [c for c in categorical_columns if c in rfe_features]
+    sample_weight = train_design["training_weight_v3"].astype(float).to_numpy(dtype=float)
+
+    LOGGER.info("Arm %s: %d features after RFE (from %d)", arm_id, len(rfe_features), len(feature_columns))
+
+    all_rows: list[dict[str, object]] = []
+    for seed in SEEDS:
+        LOGGER.info("Arm %s seed %d", arm_id, seed)
+        estimator = LGBMClassifier(
+            **LGBM_PARAMS,
+            objective="binary",
+            class_weight="balanced",
+            random_state=seed,
+            n_jobs=1,
+            verbosity=-1,
+            device_type=device_type,
+            **({"deterministic": True, "force_col_wise": True} if device_type == "cpu" else {}),
+        )
+        estimator.fit(
+            train_design[rfe_features],
+            y_train,
+            sample_weight=sample_weight,
+            categorical_feature=rfe_categorical,
+        )
+        predictions = estimator.predict_proba(holdout_design[rfe_features])[:, 1]
+
+        # Feature importance by slot.
+        imp = estimator.feature_importances_
+        slot_imp: dict[str, float] = {}
+        for col, val in zip(rfe_features, imp):
+            slot = col.split("__")[0]
+            slot_imp[slot] = slot_imp.get(slot, 0) + val
+        total_imp = sum(slot_imp.values()) or 1
+        parts = [f"{s}={v / total_imp * 100:.1f}%" for s, v in sorted(slot_imp.items(), key=lambda x: -x[1])]
+        LOGGER.info("Feature importance: %s", ", ".join(parts))
+
+        for row, prob in zip(
+            holdout_design.loc[:, ["pair_id", "bacteria", "phage", "label_any_lysis"]].to_dict(orient="records"),
+            predictions,
+        ):
+            all_rows.append(
+                {
+                    "arm_id": arm_id,
+                    "seed": seed,
+                    "pair_id": str(row["pair_id"]),
+                    "bacteria": str(row["bacteria"]),
+                    "phage": str(row["phage"]),
+                    "label_hard_any_lysis": int(row["label_any_lysis"]),
+                    "predicted_probability": round(float(prob), 6),
+                }
+            )
+
+        metrics = summarize_seed_metrics(all_rows[-len(holdout_design) :])
+        LOGGER.info(
+            "Arm %s seed %d: AUC=%.4f, top-3=%.1f%%, Brier=%.4f",
+            arm_id,
+            seed,
+            metrics.get("holdout_roc_auc", 0),
+            metrics.get("holdout_top3_hit_rate_all_strains", 0) * 100,
+            metrics.get("holdout_brier_score", 0),
+        )
+    return all_rows
+
+
+def run_gt07_eval(
+    *,
+    candidate_module: ModuleType,
+    context: Any,
+    device_type: str,
+    output_dir: Path,
+) -> None:
+    holdout_frame = load_st03_holdout_frame()
+    training_frame = build_st03_training_frame()
+    LOGGER.info("ST03 split: %d training, %d holdout rows", len(training_frame), len(holdout_frame))
+
+    arms = [
+        ("gt03_baseline", False),
+        ("+omp_variants", True),
+    ]
+
+    all_rows: list[dict[str, object]] = []
+    for arm_id, include_variants in arms:
+        LOGGER.info("=== Arm: %s (omp_variants=%s) ===", arm_id, include_variants)
+        train_design, holdout_design, features, categoricals = build_design_with_omp_variant(
+            candidate_module=candidate_module,
+            context=context,
+            training_frame=training_frame,
+            holdout_frame=holdout_frame,
+            include_omp_variants=include_variants,
+        )
+        LOGGER.info("Arm %s: %d total features", arm_id, len(features))
+        all_rows.extend(
+            evaluate_arm(
+                train_design=train_design,
+                holdout_design=holdout_design,
+                feature_columns=features,
+                categorical_columns=categoricals,
+                arm_id=arm_id,
+                device_type=device_type,
+            )
+        )
+
+    # Aggregate and bootstrap.
+    df = pd.DataFrame(all_rows)
+    aggregated = (
+        df.groupby(["arm_id", "pair_id", "bacteria", "phage", "label_hard_any_lysis"], as_index=False)[
+            "predicted_probability"
+        ]
+        .mean()
+        .sort_values(["arm_id", "bacteria", "phage"])
+    )
+
+    holdout_rows_by_arm: dict[str, list[dict[str, object]]] = {}
+    for _, row in aggregated.iterrows():
+        holdout_rows_by_arm.setdefault(str(row["arm_id"]), []).append(dict(row))
+
+    bootstrap_results = bootstrap_holdout_metric_cis(
+        holdout_rows_by_arm,
+        bootstrap_samples=BOOTSTRAP_SAMPLES,
+        bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+        baseline_arm_id="gt03_baseline",
+    )
+
+    # Write outputs.
+    output_dir.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output_dir / "all_seed_predictions.csv", index=False)
+    aggregated.to_csv(output_dir / "aggregated_predictions.csv", index=False)
+
+    bootstrap_json = {}
+    for arm_id, ci_dict in bootstrap_results.items():
+        bootstrap_json[arm_id] = {
+            metric: {"point_estimate": ci.point_estimate, "ci_low": ci.ci_low, "ci_high": ci.ci_high}
+            for metric, ci in ci_dict.items()
+        }
+    with open(output_dir / "bootstrap_results.json", "w", encoding="utf-8") as f:
+        json.dump(bootstrap_json, f, indent=2)
+
+    # Summary.
+    LOGGER.info("=" * 60)
+    LOGGER.info("GT07 Results")
+    LOGGER.info("=" * 60)
+    for arm_id, ci_dict in bootstrap_results.items():
+        if "__delta_vs_" in arm_id:
+            continue
+        auc = ci_dict.get("holdout_roc_auc")
+        top3 = ci_dict.get("holdout_top3_hit_rate_all_strains")
+        brier = ci_dict.get("holdout_brier_score")
+        if auc and auc.point_estimate is not None:
+            LOGGER.info(
+                "  %s: AUC=%.4f [%.3f, %.3f], top-3=%.1f%%, Brier=%.4f",
+                arm_id,
+                auc.point_estimate,
+                auc.ci_low or 0,
+                auc.ci_high or 0,
+                (top3.point_estimate or 0) * 100,
+                brier.point_estimate or 0,
+            )
+    for arm_id, ci_dict in bootstrap_results.items():
+        if "__delta_vs_gt03_baseline" not in arm_id:
+            continue
+        auc = ci_dict.get("holdout_roc_auc")
+        if auc and auc.ci_low is not None:
+            clean = arm_id.replace("__delta_vs_gt03_baseline", "")
+            LOGGER.info("  Delta %s vs baseline: [%+.4f, %+.4f]", clean, auc.ci_low, auc.ci_high)
+
+    LOGGER.info("Results saved to %s", output_dir)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device-type", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--candidate-dir", type=Path, default=DEFAULT_CANDIDATE_DIR)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+    LOGGER.info("GT07 OMP variant eval starting at %s", datetime.now(timezone.utc).isoformat())
+
+    candidate_module = load_module_from_path("gt07_candidate", args.candidate_dir / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=args.cache_dir, include_host_defense=True)
+
+    run_gt07_eval(
+        candidate_module=candidate_module,
+        context=context,
+        device_type=args.device_type,
+        output_dir=args.output_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_GIANTS.md
+++ b/lyzortx/research_notes/lab_notebooks/track_GIANTS.md
@@ -411,3 +411,62 @@ host_OmpC_loop3_variant` rather than `predicted_receptor_is_OmpC × host_OmpC_HM
 The BASEL collection's 56 new phages tested against 25 ECOR strains would help break the lysis-breadth prior by adding
 more narrow-host phages with diverse receptor specificities. However, earlier external data expansion attempts (TK01-03)
 showed neutral lift, suggesting the bottleneck is feature quality, not training volume.
+
+### 2026-04-12 14:17 CEST: GT07 — OMP extracellular loop variant features
+
+#### Executive summary
+
+Replaced near-constant whole-gene OMP HMM scores (CV 0.01-0.17) with binary OMP allele-variant features from Track C
+(99% identity BLAST clustering, 22 features with variance 0.08-0.25). Variance pre-flight passed: BtuB cluster 99_15
+showed Cohen's d=0.455, Tsx cluster 99_11 d=0.264. However, the directed cross-terms (predicted_receptor_is_X ×
+host_X_variant_cluster_Y) produce no significant holdout improvement: AUC 0.826 vs 0.823, delta CI [-0.001, +0.006].
+The OMP variant features capture 5.1% feature importance (vs 2.0% for HMM-based) but this does not translate to better
+discrimination on 65 holdout bacteria.
+
+#### Variance pre-flight results
+
+| Feature | Variance | Cohen's d (lysed vs non-lysed) | Status |
+|---------|----------|-------------------------------|--------|
+| BtuB cluster 99_15 | 0.168 | +0.455 | Pass |
+| Tsx cluster 99_11 | 0.212 | +0.264 | Pass |
+| BtuB cluster 99_6 | 0.250 | -0.176 | Pass (anti-correlated) |
+| Tsx cluster 99_2 | 0.225 | -0.218 | Pass (anti-correlated) |
+| OmpC cluster 99_24 | 0.111 | (not tested, only 13 OmpC phages) | Marginal |
+
+Pre-flight conclusion: features have real variance and measurable discrimination. Proceeded with full evaluation.
+
+#### Holdout results
+
+| Arm | AUC | 95% CI | Top-3 | Brier |
+|-----|-----|--------|-------|-------|
+| gt03_baseline (all_gates_rfe) | 0.823 | [0.782, 0.859] | 89.2% | 0.161 |
+| +omp_variants | 0.826 | [0.784, 0.861] | 87.7% | 0.159 |
+
+Delta (+omp_variants vs baseline): [-0.001, +0.006] — not significant.
+
+#### Feature importance
+
+The OMP variant cross-terms capture 5.1% feature importance (seed-averaged), vs 2.0% for the HMM-based receptor
+features. This confirms the variant features are more informative than the near-constant HMM scores, but the
+improvement is absorbed by the existing host_surface slot (20.2%) which already captures OMP information at the
+whole-gene level.
+
+#### Interpretation
+
+The variance pre-flight correctly identified that OMP variant features have real discriminative power at the
+single-feature level (BtuB d=0.455). But this per-feature discrimination doesn't compound into a holdout AUC
+improvement because:
+
+1. **The variant features are still binary (present/absent) for each allele cluster.** A host either has BtuB allele
+   99_15 or it doesn't — there's no continuous interaction strength. The cross-term is still 0 or 1.
+2. **RFE selects 278/543 features.** The OMP variant cross-terms survive RFE (they have real information), but they
+   compete with 270+ other features that already capture host-surface variation.
+3. **The 0.823 ceiling persists.** Neither more accurate receptor predictions (GT06), nor better host-side features
+   (GT07) breaks through — the constraint may be in the interaction matrix itself (96 phages, 65 holdout bacteria).
+
+#### Conclusion
+
+OMP allele-variant features are a genuine improvement over HMM scores (5.1% vs 2.0% importance, real variance, real
+per-feature discrimination), but they do not break the 0.823 AUC ceiling on ST03 holdout. The remaining Gate 2 path
+is exhausted at the feature level — receptor × OMP cross-terms cannot significantly improve all-pairs predictions
+regardless of how the host side is encoded.


### PR DESCRIPTION
## Summary

- Replace near-constant whole-gene OMP HMM scores (CV 0.01-0.17) with binary OMP allele-variant cluster features from Track C (99% identity BLAST clustering, 22 features with variance 0.08-0.25)
- Variance pre-flight passed: BtuB cluster 99_15 Cohen's d=0.455, Tsx cluster 99_11 d=0.264
- Holdout result: AUC 0.826 vs 0.823 baseline, delta CI [-0.001, +0.006] — not significant
- OMP variant features capture 5.1% feature importance (vs 2.0% for HMM-based), but don't break the 0.823 ceiling

## Test plan

- [ ] GT07 eval completes without error
- [ ] Variance pre-flight statistics reported in notebook entry
- [ ] Bootstrap CIs computed with 1000 resamples on 65 holdout bacteria
- [ ] Results and interpretation recorded in track_GIANTS.md

Closes #386

🤖 Generated by Claude Opus 4.6