### PR TITLE
[ORCH][SX01] Graded evaluation framework + clean-label baseline

### DIFF
--- a/lyzortx/pipeline/autoresearch/candidate_replay.py
+++ b/lyzortx/pipeline/autoresearch/candidate_replay.py
@@ -72,7 +72,7 @@ FALLBACK_TG01_BEST_PARAMS = {
 }
 
 
-BOOTSTRAP_METRIC_NAMES = ("holdout_roc_auc", "holdout_top3_hit_rate_all_strains", "holdout_brier_score")
+BOOTSTRAP_METRIC_NAMES = ("holdout_roc_auc", "holdout_brier_score")
 
 
 @dataclass(frozen=True)
@@ -123,7 +123,6 @@ def _evaluate_holdout_rows(rows: Sequence[Mapping[str, object]]) -> dict[str, ob
     y_prob = [float(row["predicted_probability"]) for row in rows]
     return {
         "binary": train_v1_binary_classifier.compute_binary_metrics(y_true, y_prob),
-        "top3": train_v1_binary_classifier.compute_top3_hit_rate(rows, probability_key="predicted_probability"),
     }
 
 
@@ -191,9 +190,6 @@ def bootstrap_holdout_metric_cis(
         metrics_by_arm = {arm_id: _evaluate_holdout_rows(rows) for arm_id, rows in sampled_rows_by_arm.items()}
         baseline_metrics = metrics_by_arm[baseline_arm_id]
         for arm_id, metrics in metrics_by_arm.items():
-            metric_samples[arm_id]["holdout_top3_hit_rate_all_strains"].append(
-                float(metrics["top3"]["top3_hit_rate_all_strains"])
-            )
             metric_samples[arm_id]["holdout_brier_score"].append(float(metrics["binary"]["brier_score"]))
             if metrics["binary"]["roc_auc"] is not None:
                 metric_samples[arm_id]["holdout_roc_auc"].append(float(metrics["binary"]["roc_auc"]))
@@ -206,10 +202,6 @@ def bootstrap_holdout_metric_cis(
                 delta_samples[delta_key]["holdout_roc_auc"].append(
                     float(metrics["binary"]["roc_auc"]) - float(baseline_metrics["binary"]["roc_auc"])
                 )
-            delta_samples[delta_key]["holdout_top3_hit_rate_all_strains"].append(
-                float(metrics["top3"]["top3_hit_rate_all_strains"])
-                - float(baseline_metrics["top3"]["top3_hit_rate_all_strains"])
-            )
             delta_samples[delta_key]["holdout_brier_score"].append(
                 float(baseline_metrics["binary"]["brier_score"]) - float(metrics["binary"]["brier_score"])
             )
@@ -232,8 +224,6 @@ def bootstrap_holdout_metric_cis(
                 point_estimate=(
                     float(actual_metrics["binary"]["roc_auc"])
                     if metric_name == "holdout_roc_auc"
-                    else float(actual_metrics["top3"]["top3_hit_rate_all_strains"])
-                    if metric_name == "holdout_top3_hit_rate_all_strains"
                     else float(actual_metrics["binary"]["brier_score"])
                 ),
                 ci_low=ci_low,
@@ -977,10 +967,8 @@ def summarize_seed_metrics(rows: Sequence[Mapping[str, object]]) -> dict[str, Op
     y_true = [int(row["label_hard_any_lysis"]) for row in rows]
     y_prob = [float(row["predicted_probability"]) for row in rows]
     binary = train_v1_binary_classifier.compute_binary_metrics(y_true, y_prob)
-    top3 = train_v1_binary_classifier.compute_top3_hit_rate(rows, probability_key="predicted_probability")
     return {
         "holdout_roc_auc": binary["roc_auc"],
-        "holdout_top3_hit_rate_all_strains": top3["top3_hit_rate_all_strains"],
         "holdout_brier_score": binary["brier_score"],
     }
 
@@ -1013,7 +1001,6 @@ def summarize_arm(rows: Sequence[Mapping[str, object]]) -> dict[str, object]:
     metrics = summarize_seed_metrics(rows)
     return {
         "holdout_roc_auc": metrics["holdout_roc_auc"],
-        "holdout_top3_hit_rate_all_strains": metrics["holdout_top3_hit_rate_all_strains"],
         "holdout_brier_score": metrics["holdout_brier_score"],
     }
 
@@ -1043,28 +1030,21 @@ def build_decision_summary(
         "primary_metric": PRIMARY_METRIC,
         "promotion_requires": {
             "auc_delta_ci_low_gt_zero": True,
-            "top3_delta_ci_high_gte_zero": True,
             "brier_improvement_ci_high_gte_zero": True,
         },
     }
     auc_clear = delta_summary["holdout_roc_auc"].ci_low is not None and delta_summary["holdout_roc_auc"].ci_low > 0.0
-    top3_clear = (
-        delta_summary["holdout_top3_hit_rate_all_strains"].ci_high is not None
-        and delta_summary["holdout_top3_hit_rate_all_strains"].ci_high >= 0.0
-    )
     brier_clear = (
         delta_summary["holdout_brier_score"].ci_high is not None and delta_summary["holdout_brier_score"].ci_high >= 0.0
     )
-    if auc_clear and top3_clear and brier_clear:
+    if auc_clear and brier_clear:
         decision = "promote"
-        rationale = "candidate clears the predeclared AUC lift rule without material top-3 or Brier regression"
+        rationale = "candidate clears the predeclared AUC lift rule without material Brier regression"
     else:
         decision = "no_honest_lift"
         reasons = []
         if not auc_clear:
             reasons.append("AUC delta stays within bootstrap noise")
-        if not top3_clear:
-            reasons.append("top-3 hit rate materially degrades")
         if not brier_clear:
             reasons.append("Brier score materially degrades")
         rationale = "; ".join(reasons)

--- a/lyzortx/pipeline/autoresearch/spandex_metrics.py
+++ b/lyzortx/pipeline/autoresearch/spandex_metrics.py
@@ -1,0 +1,131 @@
+"""SPANDEX evaluation metrics: nDCG (graded) and mAP (binary) per bacterium.
+
+Replaces top-3 hit rate with ranking metrics that:
+- Use graded MLC 0-4 relevance for nDCG
+- Support partial ground truth (score only observed pairs per bacterium)
+- Handle mixed-source data (different relevance granularity)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Sequence
+
+import numpy as np
+from sklearn.metrics import average_precision_score, brier_score_loss, ndcg_score, roc_auc_score
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _is_nan(value: object) -> bool:
+    """Check if a value is NaN (works for float, np.float64, etc.)."""
+    try:
+        return value != value  # NaN != NaN is True
+    except (TypeError, ValueError):
+        return False
+
+
+def compute_per_bacterium_ndcg(
+    rows: Sequence[dict[str, object]],
+    *,
+    relevance_key: str = "mlc_score",
+    probability_key: str = "predicted_probability",
+) -> Optional[float]:
+    """Compute mean nDCG across bacteria using graded relevance.
+
+    For each bacterium, ranks phages by predicted probability and scores the
+    ranking against graded MLC relevance (0-4). Pairs with None relevance
+    are excluded (partial ground truth support).
+
+    Returns None if no bacteria have at least one positive.
+    """
+    by_bacterium: dict[str, list[dict[str, object]]] = {}
+    for row in rows:
+        by_bacterium.setdefault(str(row["bacteria"]), []).append(row)
+
+    ndcg_values = []
+    for bacteria, bact_rows in by_bacterium.items():
+        observed = [r for r in bact_rows if r.get(relevance_key) is not None and not _is_nan(r[relevance_key])]
+        if len(observed) < 2:
+            continue
+        y_rel = np.array([float(r[relevance_key]) for r in observed])
+        if y_rel.max() == 0:
+            continue  # no positives — nDCG undefined
+        y_pred = np.array([float(r[probability_key]) for r in observed])
+        ndcg_values.append(float(ndcg_score([y_rel], [y_pred])))
+
+    if not ndcg_values:
+        return None
+    return float(np.mean(ndcg_values))
+
+
+def compute_per_bacterium_map(
+    rows: Sequence[dict[str, object]],
+    *,
+    label_key: str = "label_binary",
+    probability_key: str = "predicted_probability",
+) -> Optional[float]:
+    """Compute mean Average Precision across bacteria (binary relevance).
+
+    For each bacterium, computes AP from the ranked list of phages.
+    Pairs with None label are excluded (partial ground truth support).
+
+    Returns None if no bacteria have at least one positive.
+    """
+    by_bacterium: dict[str, list[dict[str, object]]] = {}
+    for row in rows:
+        by_bacterium.setdefault(str(row["bacteria"]), []).append(row)
+
+    ap_values = []
+    for bacteria, bact_rows in by_bacterium.items():
+        observed = [r for r in bact_rows if r.get(label_key) is not None and not _is_nan(r[label_key])]
+        if len(observed) < 2:
+            continue
+        y_true = np.array([int(r[label_key]) for r in observed])
+        if y_true.sum() == 0 or y_true.sum() == len(y_true):
+            continue  # all same class — AP undefined
+        y_pred = np.array([float(r[probability_key]) for r in observed])
+        ap_values.append(float(average_precision_score(y_true, y_pred)))
+
+    if not ap_values:
+        return None
+    return float(np.mean(ap_values))
+
+
+def compute_binary_metrics(
+    rows: Sequence[dict[str, object]],
+    *,
+    label_key: str = "label_binary",
+    probability_key: str = "predicted_probability",
+) -> dict[str, Optional[float]]:
+    """Compute AUC and Brier score (pair-level, not per-bacterium)."""
+    observed = [r for r in rows if r.get(label_key) is not None and not _is_nan(r[label_key])]
+    if len(observed) < 2:
+        return {"roc_auc": None, "brier_score": None}
+    y_true = np.array([int(r[label_key]) for r in observed])
+    y_pred = np.array([float(r[probability_key]) for r in observed])
+    auc = float(roc_auc_score(y_true, y_pred)) if len(np.unique(y_true)) > 1 else None
+    brier = float(brier_score_loss(y_true, y_pred))
+    return {"roc_auc": auc, "brier_score": brier}
+
+
+SPANDEX_METRIC_NAMES = ("holdout_ndcg", "holdout_map", "holdout_roc_auc", "holdout_brier_score")
+
+
+def evaluate_holdout_rows(
+    rows: Sequence[dict[str, object]],
+) -> dict[str, Optional[float]]:
+    """Compute all SPANDEX metrics on a set of holdout rows.
+
+    Each row must have: bacteria, predicted_probability, mlc_score (graded 0-4),
+    label_binary (0 or 1). Either can be None for unobserved pairs.
+    """
+    ndcg = compute_per_bacterium_ndcg(rows, relevance_key="mlc_score", probability_key="predicted_probability")
+    mAP = compute_per_bacterium_map(rows, label_key="label_binary", probability_key="predicted_probability")
+    binary = compute_binary_metrics(rows, label_key="label_binary", probability_key="predicted_probability")
+    return {
+        "holdout_ndcg": ndcg,
+        "holdout_map": mAP,
+        "holdout_roc_auc": binary["roc_auc"],
+        "holdout_brier_score": binary["brier_score"],
+    }

--- a/lyzortx/pipeline/autoresearch/sx01_eval.py
+++ b/lyzortx/pipeline/autoresearch/sx01_eval.py
@@ -157,22 +157,107 @@ def train_and_predict_fold(
     seed: int,
     device_type: str,
 ) -> list[dict[str, object]]:
-    """Train on training_frame, predict on holdout_frame. Returns prediction rows."""
-    from lyzortx.pipeline.autoresearch.candidate_replay import build_candidate_holdout_rows
-
-    rows = build_candidate_holdout_rows(
-        candidate_module=candidate_module,
-        context=context,
-        holdout_frame=holdout_frame,
-        seed=seed,
-        device_type=device_type,
-        include_host_defense=True,
-        include_pairwise_depo_capsule=True,
-        include_pairwise_receptor_omp=True,
-        variant="per-phage-blend",
-        blend_alpha=0.5,
-        training_frame_override=training_frame,
+    """Train with RFE + per-phage blending, predict on holdout_frame."""
+    from lyzortx.autoresearch.per_phage_model import fit_per_phage_models, predict_per_phage
+    from lyzortx.pipeline.autoresearch.candidate_replay import temporary_module_attribute
+    from lyzortx.pipeline.autoresearch.derive_pairwise_depo_capsule_features import (
+        compute_pairwise_depo_capsule_features,
     )
+    from lyzortx.pipeline.autoresearch.derive_pairwise_receptor_omp_features import (
+        compute_pairwise_receptor_omp_features,
+    )
+    from lyzortx.pipeline.autoresearch.gt03_eval import apply_rfe
+
+    # Build entity feature tables.
+    host_slots = ["host_surface", "host_typing", "host_stats", "host_defense"]
+    phage_slots = ["phage_projection", "phage_stats"]
+
+    host_table = candidate_module.build_entity_feature_table(
+        context.slot_artifacts, slot_names=host_slots, entity_key="bacteria"
+    )
+    phage_table = candidate_module.build_entity_feature_table(
+        context.slot_artifacts, slot_names=phage_slots, entity_key="phage"
+    )
+    host_typed, _, host_categorical = candidate_module.type_entity_features(host_table, "bacteria")
+    phage_typed, _, phage_categorical = candidate_module.type_entity_features(phage_table, "phage")
+
+    # Build design matrices.
+    train_design = candidate_module.build_raw_pair_design_matrix(
+        training_frame, host_features=host_typed, phage_features=phage_typed
+    )
+    holdout_design = candidate_module.build_raw_pair_design_matrix(
+        holdout_frame, host_features=host_typed, phage_features=phage_typed
+    )
+
+    # Add pairwise cross-terms.
+    compute_pairwise_depo_capsule_features(train_design)
+    compute_pairwise_depo_capsule_features(holdout_design)
+    compute_pairwise_receptor_omp_features(train_design)
+    compute_pairwise_receptor_omp_features(holdout_design)
+
+    # Identify feature columns.
+    prefixes = tuple(f"{s}__" for s in host_slots + phage_slots) + (
+        "pair_depo_capsule__",
+        "pair_receptor_omp__",
+    )
+    feature_columns = [col for col in train_design.columns if col.startswith(prefixes)]
+    categorical_columns = [col for col in (host_categorical + phage_categorical) if col in feature_columns]
+
+    # Apply RFE.
+    y_train = train_design["label_any_lysis"].astype(int).to_numpy(dtype=int)
+    rfe_features = apply_rfe(train_design, feature_columns, categorical_columns, y_train, seed=42)
+    rfe_categorical = [c for c in categorical_columns if c in rfe_features]
+    sample_weight = train_design["training_weight_v3"].astype(float).to_numpy(dtype=float)
+
+    LOGGER.info(
+        "Fold training: %d features after RFE (from %d), %d train, %d holdout",
+        len(rfe_features),
+        len(feature_columns),
+        len(train_design),
+        len(holdout_design),
+    )
+
+    # Train all-pairs model.
+    with temporary_module_attribute(candidate_module, "PAIR_SCORER_RANDOM_STATE", seed):
+        estimator = candidate_module.build_pair_scorer(device_type=device_type)
+    estimator.fit(
+        train_design[rfe_features],
+        y_train,
+        sample_weight=sample_weight,
+        categorical_feature=rfe_categorical,
+    )
+    all_pairs_predictions = estimator.predict_proba(holdout_design[rfe_features])[:, 1]
+
+    # Per-phage blending.
+    host_feature_columns = [
+        col
+        for col in rfe_features
+        if col.startswith(("host_surface__", "host_typing__", "host_stats__", "host_defense__"))
+    ]
+    per_phage_models = fit_per_phage_models(
+        train_design, host_feature_columns, device_type=device_type, random_state=seed
+    )
+    predictions, _ = predict_per_phage(
+        per_phage_models, holdout_design, host_feature_columns, all_pairs_predictions, blend_alpha=0.5
+    )
+
+    # Build result rows.
+    rows = []
+    for row, probability in zip(
+        holdout_design.loc[:, ["pair_id", "bacteria", "phage", "label_any_lysis"]].to_dict(orient="records"),
+        predictions,
+    ):
+        rows.append(
+            {
+                "arm_id": "spandex_baseline",
+                "seed": seed,
+                "pair_id": str(row["pair_id"]),
+                "bacteria": str(row["bacteria"]),
+                "phage": str(row["phage"]),
+                "label_hard_any_lysis": int(row["label_any_lysis"]),
+                "predicted_probability": safe_round(float(probability)),
+            }
+        )
     return rows
 
 

--- a/lyzortx/pipeline/autoresearch/sx01_eval.py
+++ b/lyzortx/pipeline/autoresearch/sx01_eval.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""SX01: Graded evaluation framework + clean-label baseline.
+
+Implements the SPANDEX evaluation suite:
+  - nDCG with graded MLC 0-4 relevance (primary ranking metric)
+  - mAP with binary relevance (secondary ranking metric)
+  - AUC and Brier (secondary discrimination/calibration metrics)
+  - 10-fold bacteria-stratified CV with bootstrap CIs
+  - Clean-label training (exclude ambiguous 'n' pairs)
+
+Pre-flight gate: checks whether existing GT03 predictions separate MLC
+grades. If Spearman rho < 0.1 among positives, graded nDCG is cosmetic.
+
+Usage:
+    python -m lyzortx.pipeline.autoresearch.sx01_eval --device-type cpu
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+from scipy.stats import spearmanr
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.candidate_replay import (
+    BootstrapMetricCI,
+    build_st03_training_frame,
+    load_module_from_path,
+    load_st03_holdout_frame,
+    safe_round,
+)
+from lyzortx.pipeline.autoresearch.gt09_clean_label_eval import identify_ambiguous_pairs
+from lyzortx.pipeline.autoresearch.spandex_metrics import (
+    SPANDEX_METRIC_NAMES,
+    evaluate_holdout_rows,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CACHE_DIR = Path("lyzortx/generated_outputs/autoresearch/search_cache_v1")
+DEFAULT_CANDIDATE_DIR = Path("lyzortx/autoresearch")
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/sx01_eval")
+RAW_INTERACTIONS_PATH = Path("data/interactions/raw/raw_interactions.csv")
+INTERACTION_MATRIX_PATH = Path("data/interactions/interaction_matrix.csv")
+
+N_FOLDS = 10
+FOLD_SALT = "spandex_v1"
+SEEDS = [7, 42, 123]
+BOOTSTRAP_SAMPLES = 1000
+BOOTSTRAP_RANDOM_STATE = 42
+
+
+def load_mlc_scores() -> pd.DataFrame:
+    """Load MLC 0-4 scores from interaction matrix, return long-form DataFrame."""
+    matrix = pd.read_csv(INTERACTION_MATRIX_PATH, sep=";", index_col=0)
+    rows = []
+    for bacteria in matrix.index:
+        for phage in matrix.columns:
+            rows.append(
+                {
+                    "bacteria": str(bacteria),
+                    "phage": str(phage),
+                    "mlc_score": float(matrix.loc[bacteria, phage]),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def assign_bacteria_folds(
+    bacteria_list: Sequence[str], n_folds: int = N_FOLDS, salt: str = FOLD_SALT
+) -> dict[str, int]:
+    """Deterministic fold assignment via hashing."""
+    assignments = {}
+    for bacteria in bacteria_list:
+        h = hashlib.sha256(f"{salt}:{bacteria}".encode()).hexdigest()
+        assignments[bacteria] = int(h, 16) % n_folds
+    return assignments
+
+
+def run_preflight(output_dir: Path) -> dict[str, object]:
+    """Pre-flight: check MLC grade separability in existing GT03 predictions."""
+    gt03_path = Path("lyzortx/generated_outputs/gt03_eval/aggregated_predictions.csv")
+    if not gt03_path.exists():
+        LOGGER.warning("GT03 predictions not found at %s — skipping pre-flight", gt03_path)
+        return {"status": "skipped", "reason": "GT03 predictions not found"}
+
+    preds = pd.read_csv(gt03_path)
+    best_arm = preds[preds["arm_id"] == "all_gates_rfe"].copy()
+    mlc = load_mlc_scores()
+    merged = best_arm.merge(mlc, on=["bacteria", "phage"], how="left")
+
+    positives = merged[merged["mlc_score"] >= 1]
+    mean_by_grade = {}
+    for grade in [0, 1, 2, 3, 4]:
+        subset = merged[merged["mlc_score"] == grade]
+        if len(subset) > 0:
+            mean_by_grade[str(grade)] = round(float(subset["predicted_probability"].mean()), 4)
+
+    rho, pval = spearmanr(positives["mlc_score"], positives["predicted_probability"])
+    rho = float(rho)
+
+    result = {
+        "status": "pass" if rho >= 0.1 else "fail",
+        "spearman_rho_positives": round(rho, 4),
+        "spearman_pvalue": float(pval),
+        "mean_pred_by_mlc_grade": mean_by_grade,
+        "n_positives": len(positives),
+        "monotonic": all(mean_by_grade.get(str(i), 0) <= mean_by_grade.get(str(i + 1), 0) for i in range(1, 4)),
+    }
+
+    LOGGER.info("Pre-flight: Spearman rho=%.4f (threshold 0.1), status=%s", rho, result["status"])
+    for grade, mean_p in sorted(mean_by_grade.items()):
+        LOGGER.info("  MLC=%s: mean P(lysis)=%.4f", grade, mean_p)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with open(output_dir / "preflight_results.json", "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+
+    return result
+
+
+def enrich_rows_with_mlc(
+    rows: Sequence[dict[str, object]],
+    mlc_lookup: dict[tuple[str, str], float],
+) -> list[dict[str, object]]:
+    """Add mlc_score and label_binary to prediction rows."""
+    enriched = []
+    for row in rows:
+        key = (str(row["bacteria"]), str(row["phage"]))
+        mlc = mlc_lookup.get(key)
+        enriched.append(
+            {
+                **row,
+                "mlc_score": mlc,
+                "label_binary": int(mlc > 0) if mlc is not None else None,
+            }
+        )
+    return enriched
+
+
+def train_and_predict_fold(
+    *,
+    candidate_module: ModuleType,
+    context: Any,
+    training_frame: pd.DataFrame,
+    holdout_frame: pd.DataFrame,
+    seed: int,
+    device_type: str,
+) -> list[dict[str, object]]:
+    """Train on training_frame, predict on holdout_frame. Returns prediction rows."""
+    from lyzortx.pipeline.autoresearch.candidate_replay import build_candidate_holdout_rows
+
+    rows = build_candidate_holdout_rows(
+        candidate_module=candidate_module,
+        context=context,
+        holdout_frame=holdout_frame,
+        seed=seed,
+        device_type=device_type,
+        include_host_defense=True,
+        include_pairwise_depo_capsule=True,
+        include_pairwise_receptor_omp=True,
+        variant="per-phage-blend",
+        blend_alpha=0.5,
+        training_frame_override=training_frame,
+    )
+    return rows
+
+
+def run_kfold_evaluation(
+    *,
+    candidate_module: ModuleType,
+    context: Any,
+    full_frame: pd.DataFrame,
+    mlc_lookup: dict[tuple[str, str], float],
+    device_type: str,
+    output_dir: Path,
+) -> dict[str, object]:
+    """Run 10-fold bacteria-stratified CV with SPANDEX metrics."""
+    all_bacteria = sorted(full_frame["bacteria"].unique())
+    fold_assignments = assign_bacteria_folds(all_bacteria)
+
+    LOGGER.info("k-fold CV: %d bacteria across %d folds", len(all_bacteria), N_FOLDS)
+    fold_sizes = defaultdict(int)
+    for fold in fold_assignments.values():
+        fold_sizes[fold] += 1
+    for fold_id in range(N_FOLDS):
+        LOGGER.info("  Fold %d: %d bacteria", fold_id, fold_sizes[fold_id])
+
+    all_predictions: list[dict[str, object]] = []
+    fold_metrics: list[dict[str, object]] = []
+
+    for fold_id in range(N_FOLDS):
+        holdout_bacteria = {b for b, f in fold_assignments.items() if f == fold_id}
+        train_bacteria = {b for b, f in fold_assignments.items() if f != fold_id}
+
+        holdout_frame = full_frame[full_frame["bacteria"].isin(holdout_bacteria)].copy()
+        training_frame = full_frame[full_frame["bacteria"].isin(train_bacteria)].copy()
+
+        LOGGER.info(
+            "=== Fold %d: %d train bacteria (%d pairs), %d holdout bacteria (%d pairs) ===",
+            fold_id,
+            len(train_bacteria),
+            len(training_frame),
+            len(holdout_bacteria),
+            len(holdout_frame),
+        )
+
+        fold_seed_rows: list[dict[str, object]] = []
+        for seed in SEEDS:
+            rows = train_and_predict_fold(
+                candidate_module=candidate_module,
+                context=context,
+                training_frame=training_frame,
+                holdout_frame=holdout_frame,
+                seed=seed,
+                device_type=device_type,
+            )
+            for r in rows:
+                r["fold_id"] = fold_id
+            fold_seed_rows.extend(rows)
+
+        # Aggregate across seeds.
+        df = pd.DataFrame(fold_seed_rows)
+        aggregated = (
+            df.groupby(["fold_id", "pair_id", "bacteria", "phage", "label_hard_any_lysis"], as_index=False)[
+                "predicted_probability"
+            ]
+            .mean()
+            .sort_values(["bacteria", "phage"])
+        )
+        agg_rows = aggregated.to_dict(orient="records")
+        enriched = enrich_rows_with_mlc(agg_rows, mlc_lookup)
+        all_predictions.extend(enriched)
+
+        metrics = evaluate_holdout_rows(enriched)
+        metrics["fold_id"] = fold_id
+        metrics["n_holdout_bacteria"] = len(holdout_bacteria)
+        metrics["n_holdout_pairs"] = len(holdout_frame)
+        fold_metrics.append(metrics)
+
+        LOGGER.info(
+            "Fold %d: nDCG=%.4f, mAP=%.4f, AUC=%.4f, Brier=%.4f",
+            fold_id,
+            metrics.get("holdout_ndcg") or 0,
+            metrics.get("holdout_map") or 0,
+            metrics.get("holdout_roc_auc") or 0,
+            metrics.get("holdout_brier_score") or 0,
+        )
+
+    # Overall metrics across all folds.
+    overall_metrics = evaluate_holdout_rows(all_predictions)
+    LOGGER.info("=" * 60)
+    LOGGER.info("Overall k-fold CV metrics:")
+    for name, value in overall_metrics.items():
+        LOGGER.info("  %s: %.4f", name, value or 0)
+
+    # Bootstrap CIs.
+    LOGGER.info("Running bootstrap CIs (%d resamples)...", BOOTSTRAP_SAMPLES)
+    bootstrap_results = bootstrap_spandex_cis(
+        all_predictions,
+        bootstrap_samples=BOOTSTRAP_SAMPLES,
+        bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+    )
+
+    LOGGER.info("Bootstrap CIs:")
+    for metric_name, ci in bootstrap_results.items():
+        LOGGER.info(
+            "  %s: %.4f [%.4f, %.4f]",
+            metric_name,
+            ci.point_estimate or 0,
+            ci.ci_low or 0,
+            ci.ci_high or 0,
+        )
+
+    # Write outputs.
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(all_predictions).to_csv(output_dir / "kfold_predictions.csv", index=False)
+    pd.DataFrame(fold_metrics).to_csv(output_dir / "fold_metrics.csv", index=False)
+
+    bootstrap_json = {
+        metric: {"point_estimate": ci.point_estimate, "ci_low": ci.ci_low, "ci_high": ci.ci_high}
+        for metric, ci in bootstrap_results.items()
+    }
+    with open(output_dir / "bootstrap_results.json", "w", encoding="utf-8") as f:
+        json.dump(bootstrap_json, f, indent=2)
+
+    return {
+        "overall_metrics": overall_metrics,
+        "fold_metrics": fold_metrics,
+        "bootstrap_results": bootstrap_results,
+    }
+
+
+def bootstrap_spandex_cis(
+    rows: Sequence[dict[str, object]],
+    *,
+    bootstrap_samples: int,
+    bootstrap_random_state: int,
+) -> dict[str, BootstrapMetricCI]:
+    """Bootstrap CIs for SPANDEX metrics, resampling at bacterium level."""
+    by_bacterium: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in rows:
+        by_bacterium[str(row["bacteria"])].append(row)
+
+    bacteria_ids = tuple(sorted(by_bacterium.keys()))
+    n_bacteria = len(bacteria_ids)
+    rng = np.random.default_rng(bootstrap_random_state)
+
+    metric_samples: dict[str, list[float]] = {name: [] for name in SPANDEX_METRIC_NAMES}
+
+    progress_interval = max(1, bootstrap_samples // 5)
+    for i in range(bootstrap_samples):
+        if i == 0 or (i + 1) % progress_interval == 0 or i + 1 == bootstrap_samples:
+            LOGGER.info("Bootstrap progress: %d/%d", i + 1, bootstrap_samples)
+
+        sampled_indices = rng.integers(0, n_bacteria, size=n_bacteria)
+        sampled_rows: list[dict[str, object]] = []
+        for idx in sampled_indices.tolist():
+            sampled_rows.extend(by_bacterium[bacteria_ids[idx]])
+
+        metrics = evaluate_holdout_rows(sampled_rows)
+        for name in SPANDEX_METRIC_NAMES:
+            val = metrics.get(name)
+            if val is not None:
+                metric_samples[name].append(val)
+
+    actual_metrics = evaluate_holdout_rows(list(rows))
+
+    def _ci(values: Sequence[float]) -> tuple[Optional[float], Optional[float], int]:
+        if not values:
+            return None, None, 0
+        arr = np.asarray(values, dtype=float)
+        low, high = np.quantile(arr, [0.025, 0.975])
+        return safe_round(float(low)), safe_round(float(high)), len(values)
+
+    results = {}
+    for name in SPANDEX_METRIC_NAMES:
+        ci_low, ci_high, used = _ci(metric_samples[name])
+        results[name] = BootstrapMetricCI(
+            point_estimate=actual_metrics.get(name),
+            ci_low=ci_low,
+            ci_high=ci_high,
+            bootstrap_samples_requested=bootstrap_samples,
+            bootstrap_samples_used=used,
+        )
+    return results
+
+
+def run_sx01_eval(
+    *,
+    candidate_module: ModuleType,
+    context: Any,
+    device_type: str,
+    output_dir: Path,
+) -> None:
+    start_time = datetime.now(timezone.utc)
+
+    # Pre-flight gate.
+    preflight = run_preflight(output_dir)
+    if preflight["status"] == "fail":
+        LOGGER.error(
+            "PRE-FLIGHT FAILED: Spearman rho=%.4f < 0.1 — graded nDCG is cosmetic. Consider cancelling SX04.",
+            preflight.get("spearman_rho_positives", 0),
+        )
+        # Continue anyway — mAP and k-fold CV are still valuable.
+
+    # Load full frame and apply clean-label filter.
+    holdout_frame = load_st03_holdout_frame()
+    training_frame = build_st03_training_frame()
+    full_frame = pd.concat([training_frame, holdout_frame], ignore_index=True)
+    LOGGER.info("Full frame: %d pairs, %d bacteria", len(full_frame), full_frame["bacteria"].nunique())
+
+    ambiguous_pairs = identify_ambiguous_pairs(RAW_INTERACTIONS_PATH)
+    clean_frame = full_frame[~full_frame["pair_id"].isin(ambiguous_pairs)].copy()
+    LOGGER.info(
+        "Clean-label frame: %d pairs (%d excluded), %d bacteria",
+        len(clean_frame),
+        len(full_frame) - len(clean_frame),
+        clean_frame["bacteria"].nunique(),
+    )
+
+    # Load MLC scores for graded evaluation.
+    mlc_df = load_mlc_scores()
+    mlc_lookup = {(r["bacteria"], r["phage"]): r["mlc_score"] for _, r in mlc_df.iterrows()}
+    LOGGER.info("MLC lookup: %d pairs", len(mlc_lookup))
+
+    # Run k-fold CV on clean data.
+    run_kfold_evaluation(
+        candidate_module=candidate_module,
+        context=context,
+        full_frame=clean_frame,
+        mlc_lookup=mlc_lookup,
+        device_type=device_type,
+        output_dir=output_dir,
+    )
+
+    elapsed = (datetime.now(timezone.utc) - start_time).total_seconds()
+    LOGGER.info("SX01 evaluation completed in %.1f seconds", elapsed)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device-type", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--candidate-dir", type=Path, default=DEFAULT_CANDIDATE_DIR)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+    LOGGER.info("SX01 eval starting at %s", datetime.now(timezone.utc).isoformat())
+
+    candidate_module = load_module_from_path("sx01_candidate", args.candidate_dir / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=args.cache_dir, include_host_defense=True)
+
+    run_sx01_eval(
+        candidate_module=candidate_module,
+        context=context,
+        device_type=args.device_type,
+        output_dir=args.output_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_SPANDEX.md
+++ b/lyzortx/research_notes/lab_notebooks/track_SPANDEX.md
@@ -58,3 +58,67 @@ phages), and (3) evaluation methodology (top-3 discards ranking information and 
 - **SX03:** Check BASEL phage feature overlap with Guelin phages. If >90% nearest-neighbor overlap, training signal is
   redundant.
 - **SX04:** Gated on SX01 pre-flight. If binary model doesn't separate MLC grades, ordinal prediction can't help.
+
+### 2026-04-12 23:28 CEST: SX01 — Graded evaluation framework + clean-label baseline
+
+#### Executive summary
+
+Implemented SPANDEX evaluation suite (nDCG with graded MLC 0-4 relevance, mAP, k-fold CV, bootstrap CIs) and
+established the clean-label baseline. Pre-flight gate passed: existing predictions separate MLC grades monotonically
+(Spearman rho=0.24 among positives, well above 0.1 threshold). SX04 lives.
+
+#### Pre-flight results
+
+Mean predicted P(lysis) by MLC grade in GT03 all_gates_rfe holdout predictions:
+
+| MLC grade | Mean P(lysis) | Median P(lysis) | N pairs |
+|-----------|---------------|-----------------|---------|
+| 0 | 0.267 | 0.118 | 5,096 |
+| 1 | 0.611 | 0.721 | 469 |
+| 2 | 0.674 | 0.785 | 312 |
+| 3 | 0.740 | 0.840 | 198 |
+| 4 | 0.816 | 0.880 | 160 |
+
+Clear monotonic increase. The binary classifier already implicitly ranks higher-potency phages higher, validating
+graded nDCG as a meaningful metric.
+
+#### SPANDEX baseline (10-fold CV, clean labels, per-phage blending)
+
+| Metric | Value | 95% CI |
+|--------|-------|--------|
+| nDCG (graded MLC 0-4) | 0.779 | [0.772, 0.796] |
+| mAP (binary >= 1) | 0.714 | [0.696, 0.732] |
+| AUC | 0.871 | [0.858, 0.883] |
+| Brier | 0.125 | [0.119, 0.131] |
+
+Per-fold variation:
+
+| Fold | Bacteria | nDCG | mAP | AUC | Brier |
+|------|----------|------|-----|-----|-------|
+| 0 | 38 | 0.771 | 0.691 | 0.882 | 0.118 |
+| 1 | 43 | 0.756 | 0.666 | 0.884 | 0.121 |
+| 2 | 42 | 0.835 | 0.786 | 0.888 | 0.113 |
+| 3 | 39 | 0.768 | 0.731 | 0.856 | 0.129 |
+| 4 | 41 | 0.783 | 0.717 | 0.858 | 0.134 |
+| 5 | 37 | 0.766 | 0.711 | 0.880 | 0.126 |
+| 6 | 35 | 0.802 | 0.744 | 0.886 | 0.116 |
+| 7 | 31 | 0.809 | 0.760 | 0.847 | 0.142 |
+| 8 | 26 | 0.719 | 0.641 | 0.890 | 0.116 |
+| 9 | 37 | 0.768 | 0.678 | 0.861 | 0.131 |
+
+#### Interpretation
+
+The AUC of 0.871 is substantially higher than the old ST03 fixed-holdout result (0.823). This is not a model
+improvement — it reflects two evaluation changes: (1) 10-fold CV uses all bacteria for evaluation instead of 65
+fixed ones, giving a more representative estimate, and (2) clean labels exclude ~3,462 ambiguous pairs that were
+mislabeled as negatives. The model and features are identical to GT03 + AX02.
+
+nDCG 0.779 and mAP 0.714 establish the SPANDEX ranking baselines. These are the first proper ranking metrics for
+this project — they replace the retired top-3 hit rate.
+
+#### Output artifacts
+
+- `lyzortx/generated_outputs/sx01_eval/preflight_results.json`
+- `lyzortx/generated_outputs/sx01_eval/kfold_predictions.csv`
+- `lyzortx/generated_outputs/sx01_eval/fold_metrics.csv`
+- `lyzortx/generated_outputs/sx01_eval/bootstrap_results.json`

--- a/lyzortx/research_notes/lab_notebooks/track_SPANDEX.md
+++ b/lyzortx/research_notes/lab_notebooks/track_SPANDEX.md
@@ -82,33 +82,33 @@ Mean predicted P(lysis) by MLC grade in GT03 all_gates_rfe holdout predictions:
 Clear monotonic increase. The binary classifier already implicitly ranks higher-potency phages higher, validating
 graded nDCG as a meaningful metric.
 
-#### SPANDEX baseline (10-fold CV, clean labels, per-phage blending)
+#### SPANDEX baseline (10-fold CV, clean labels, RFE + per-phage blending)
 
 | Metric | Value | 95% CI |
 |--------|-------|--------|
-| nDCG (graded MLC 0-4) | 0.779 | [0.772, 0.796] |
-| mAP (binary >= 1) | 0.714 | [0.696, 0.732] |
-| AUC | 0.871 | [0.858, 0.883] |
+| nDCG (graded MLC 0-4) | 0.779 | [0.771, 0.795] |
+| mAP (binary >= 1) | 0.711 | [0.693, 0.729] |
+| AUC | 0.870 | [0.857, 0.882] |
 | Brier | 0.125 | [0.119, 0.131] |
 
-Per-fold variation:
+Per-fold variation (RFE selects 207-257 features from 507 per fold):
 
 | Fold | Bacteria | nDCG | mAP | AUC | Brier |
 |------|----------|------|-----|-----|-------|
-| 0 | 38 | 0.771 | 0.691 | 0.882 | 0.118 |
-| 1 | 43 | 0.756 | 0.666 | 0.884 | 0.121 |
-| 2 | 42 | 0.835 | 0.786 | 0.888 | 0.113 |
-| 3 | 39 | 0.768 | 0.731 | 0.856 | 0.129 |
-| 4 | 41 | 0.783 | 0.717 | 0.858 | 0.134 |
-| 5 | 37 | 0.766 | 0.711 | 0.880 | 0.126 |
-| 6 | 35 | 0.802 | 0.744 | 0.886 | 0.116 |
-| 7 | 31 | 0.809 | 0.760 | 0.847 | 0.142 |
-| 8 | 26 | 0.719 | 0.641 | 0.890 | 0.116 |
-| 9 | 37 | 0.768 | 0.678 | 0.861 | 0.131 |
+| 0 | 38 | 0.766 | 0.683 | 0.880 | 0.119 |
+| 1 | 43 | 0.765 | 0.673 | 0.884 | 0.121 |
+| 2 | 42 | 0.833 | 0.782 | 0.888 | 0.113 |
+| 3 | 39 | 0.770 | 0.731 | 0.856 | 0.131 |
+| 4 | 41 | 0.786 | 0.719 | 0.857 | 0.134 |
+| 5 | 37 | 0.759 | 0.708 | 0.877 | 0.126 |
+| 6 | 35 | 0.808 | 0.745 | 0.885 | 0.116 |
+| 7 | 31 | 0.812 | 0.759 | 0.848 | 0.142 |
+| 8 | 26 | 0.718 | 0.641 | 0.890 | 0.116 |
+| 9 | 37 | 0.754 | 0.659 | 0.861 | 0.130 |
 
 #### Interpretation
 
-The AUC of 0.871 is substantially higher than the old ST03 fixed-holdout result (0.823). This is not a model
+The AUC of 0.870 is substantially higher than the old ST03 fixed-holdout result (0.823). This is not a model
 improvement — it reflects two evaluation changes: (1) 10-fold CV uses all bacteria for evaluation instead of 65
 fixed ones, giving a more representative estimate, and (2) clean labels exclude ~3,462 ambiguous pairs that were
 mislabeled as negatives. The model and features are identical to GT03 + AX02.

--- a/lyzortx/tests/test_spandex_metrics.py
+++ b/lyzortx/tests/test_spandex_metrics.py
@@ -1,0 +1,146 @@
+"""Tests for SPANDEX evaluation metrics (nDCG, mAP)."""
+
+import pytest
+
+from lyzortx.pipeline.autoresearch.spandex_metrics import (
+    compute_binary_metrics,
+    compute_per_bacterium_map,
+    compute_per_bacterium_ndcg,
+    evaluate_holdout_rows,
+)
+
+
+def _make_rows(bacteria: str, phages_relevance_pred: list[tuple[str, float, float]]) -> list[dict]:
+    """Helper: create rows for one bacterium with (phage, relevance, predicted_prob)."""
+    return [
+        {
+            "bacteria": bacteria,
+            "phage": phage,
+            "mlc_score": rel,
+            "label_binary": int(rel > 0) if rel is not None else None,
+            "predicted_probability": pred,
+        }
+        for phage, rel, pred in phages_relevance_pred
+    ]
+
+
+class TestNDCG:
+    def test_perfect_ranking(self):
+        """Model ranks phages in exact MLC order -> nDCG = 1.0."""
+        rows = _make_rows(
+            "B1",
+            [
+                ("P1", 4.0, 0.95),
+                ("P2", 3.0, 0.80),
+                ("P3", 1.0, 0.60),
+                ("P4", 0.0, 0.10),
+            ],
+        )
+        ndcg = compute_per_bacterium_ndcg(rows)
+        assert ndcg is not None
+        assert ndcg == pytest.approx(1.0, abs=0.001)
+
+    def test_inverted_ranking(self):
+        """Model ranks lowest-MLC phage highest -> nDCG < 1.0."""
+        rows = _make_rows(
+            "B1",
+            [
+                ("P1", 4.0, 0.10),
+                ("P2", 1.0, 0.95),
+                ("P3", 0.0, 0.50),
+            ],
+        )
+        ndcg = compute_per_bacterium_ndcg(rows)
+        assert ndcg is not None
+        assert ndcg < 1.0
+
+    def test_all_negatives_returns_none(self):
+        """No positives -> nDCG undefined."""
+        rows = _make_rows("B1", [("P1", 0.0, 0.5), ("P2", 0.0, 0.3)])
+        assert compute_per_bacterium_ndcg(rows) is None
+
+    def test_partial_ground_truth(self):
+        """Rows with None relevance are excluded."""
+        rows = _make_rows(
+            "B1",
+            [
+                ("P1", 4.0, 0.95),
+                ("P2", 0.0, 0.10),
+            ],
+        ) + [{"bacteria": "B1", "phage": "P3", "mlc_score": None, "predicted_probability": 0.80}]
+        ndcg = compute_per_bacterium_ndcg(rows)
+        assert ndcg is not None
+        assert ndcg == pytest.approx(1.0, abs=0.001)
+
+    def test_multi_bacterium_average(self):
+        """nDCG is averaged across bacteria."""
+        rows = (
+            _make_rows("B1", [("P1", 4.0, 0.9), ("P2", 0.0, 0.1)])  # perfect
+            + _make_rows("B2", [("P1", 4.0, 0.1), ("P2", 0.0, 0.9)])  # inverted
+        )
+        ndcg = compute_per_bacterium_ndcg(rows)
+        assert ndcg is not None
+        assert 0.5 < ndcg < 1.0  # average of 1.0 and inverted (nDCG floor is ~0.63 for 2 items)
+
+
+class TestMAP:
+    def test_perfect_ranking(self):
+        """Positives ranked above all negatives -> mAP = 1.0."""
+        rows = _make_rows(
+            "B1",
+            [
+                ("P1", 4.0, 0.95),
+                ("P2", 2.0, 0.80),
+                ("P3", 0.0, 0.10),
+                ("P4", 0.0, 0.05),
+            ],
+        )
+        mAP = compute_per_bacterium_map(rows)
+        assert mAP is not None
+        assert mAP == pytest.approx(1.0, abs=0.001)
+
+    def test_all_same_class_returns_none(self):
+        """All positives or all negatives -> mAP undefined."""
+        rows = _make_rows("B1", [("P1", 4.0, 0.9), ("P2", 2.0, 0.5)])
+        assert compute_per_bacterium_map(rows) is None
+
+    def test_partial_ground_truth(self):
+        """Rows with None label are excluded."""
+        rows = _make_rows(
+            "B1",
+            [
+                ("P1", 4.0, 0.95),
+                ("P2", 0.0, 0.10),
+            ],
+        ) + [{"bacteria": "B1", "phage": "P3", "label_binary": None, "predicted_probability": 0.80}]
+        mAP = compute_per_bacterium_map(rows)
+        assert mAP is not None
+        assert mAP == pytest.approx(1.0, abs=0.001)
+
+
+class TestBinaryMetrics:
+    def test_basic(self):
+        rows = _make_rows(
+            "B1",
+            [
+                ("P1", 4.0, 0.95),
+                ("P2", 0.0, 0.10),
+            ],
+        )
+        metrics = compute_binary_metrics(rows)
+        assert metrics["roc_auc"] == pytest.approx(1.0)
+        assert metrics["brier_score"] is not None
+        assert metrics["brier_score"] < 0.1
+
+
+class TestEvaluateHoldoutRows:
+    def test_returns_all_metrics(self):
+        rows = _make_rows("B1", [("P1", 4.0, 0.9), ("P2", 0.0, 0.1)]) + _make_rows(
+            "B2", [("P1", 3.0, 0.8), ("P2", 0.0, 0.2)]
+        )
+        metrics = evaluate_holdout_rows(rows)
+        assert "holdout_ndcg" in metrics
+        assert "holdout_map" in metrics
+        assert "holdout_roc_auc" in metrics
+        assert "holdout_brier_score" in metrics
+        assert all(v is not None for v in metrics.values())


### PR DESCRIPTION
## Summary

- Implement SPANDEX evaluation suite: per-bacterium nDCG (graded MLC 0-4 relevance) + mAP (binary) replacing top-3
- 10-fold bacteria-stratified CV with deterministic fold assignment replaces fixed ST03 holdout
- Clean-label training excludes ~3,462 ambiguous 'n' pairs
- RFE feature selection applied per fold (207-257 features from 507)
- Per-phage blending (AX02) with 50/50 blend alpha
- Pre-flight gate: Spearman rho=0.24 among positives — graded nDCG is meaningful, SX04 lives
- Baseline: nDCG=0.779, mAP=0.711, AUC=0.870, Brier=0.125 (all with bootstrap CIs)
- Top-3 metric deleted from evaluation suite AND from candidate_replay.py shared infrastructure
- 468 existing tests pass after top-3 removal
- 10 new unit tests for metrics module

## Test plan

- [x] `pytest lyzortx/tests/test_spandex_metrics.py` — 10 tests pass
- [x] `pytest lyzortx/tests/` — 468 tests pass (no breakage from top-3 removal)
- [x] Full 10-fold CV evaluation with RFE completes (605s)
- [x] Pre-flight MLC grade separability check passes
- [x] Bootstrap CIs computed (1000 resamples)

Closes #394

🤖 Generated by Claude Opus 4.6