### PR TITLE
[ORCH][SX13] Host OMP k-mer features — validated null (all 4 arms)

### DIFF
--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -3,7 +3,7 @@
 <!-- Last consolidated: 2026-04-13T01:40:00+02:00 -->
 <!-- Source: lyzortx/research_notes/lab_notebooks -->
 
-**58 knowledge units** across 7 themes (44 active, 14 dead ends)
+**59 knowledge units** across 7 themes (44 active, 15 dead ends)
 
 ## Data & Labels
 
@@ -126,15 +126,17 @@ What works, what doesn't, leakage risks, and encoding decisions.
     reaches 0.823 AUC [0.781, 0.858]. The cross-terms capture a specific mechanism: this phage has a depolymerase that
     can degrade this host's capsule type. This works because capsule profiles vary richly across clinical E. coli (99
     features with distinct variation), unlike OMP receptor scores which are near-constant.*
-- **`omp-score-homogeneity`**: All 369 clinical E. coli hosts express all 12 core OMP receptors at nearly identical HMM
-  scores (CV 0.01-0.17), making receptor × OMP cross-terms collapse to phage-only features with no host-side
-  discrimination. [validated; source: GT03, GT06, 2026-04-12 pair-level analysis; see also: receptor-variant-richness,
-  receptor-specificity-solved, three-layer-hypothesis]
-  - *LptD CV=0.01, OmpA CV=0.02, Tsx CV=0.03, OmpC CV=0.04. The cross-term predicted_is_OmpC × host_OmpC_score ≈
-    predicted_is_OmpC × constant. Direct test: OmpC phages lyse high-OmpC hosts at 37.0% vs low-OmpC at 33.4% (Cohen
-    d=0.086, negligible). Moriniere's receptor classifiers were trained on K-12 (BW25113/BL21) which lack
-    O-antigen/capsule — in clinical strains, polysaccharide barriers mask OMP differences. OMP variant/allele-level
-    features (extracellular loop regions) might restore host-side variation.*
+- **`omp-score-homogeneity`**: Whole-gene OMP HMM scores are near-identical across 369 clinical E. coli (CV 0.01-0.17),
+  making whole-gene receptor × OMP cross-terms collapse. Loop-level allelic variation is substantial (BTUB 28 MMseqs2
+  99% clusters, OMPC 49, across 5546 retained 5-mers) but does not predict lysis either — see
+  host-omp-variation-unpredictive. [validated; source: GT03, GT06, 2026-04-12 pair-level analysis, SX13; see also:
+  receptor-variant-richness, receptor-specificity-solved, three-layer-hypothesis, host-omp-variation-unpredictive]
+  - *LptD CV=0.01, OmpA CV=0.02, Tsx CV=0.03, OmpC CV=0.04 on HMM scores. Direct test: OmpC phages lyse high-OmpC hosts
+    at 37.0% vs low-OmpC at 33.4% (Cohen d=0.086, negligible). SX13 tested whether loop-level k-mer or cluster
+    representations would restore host-side signal — they did not (AUC deltas ≤ +0.3 pp across marginal, cross-term, and
+    cluster arms). The homogeneity observation at the HMM level is real; the escalation to finer representations doesn't
+    rescue prediction because host-range variance lives downstream of OMP recognition in clinical strains
+    (polysaccharide access + post-adsorption factors).*
 - **`same-receptor-uncorrelated-hosts`**: Phages sharing a predicted receptor class have weakly correlated or
   uncorrelated host ranges: Tsx phages (8 phages) have mean pairwise Jaccard 0.091 (below random-pair baseline of 0.17);
   only OmpC phages show above-random cohesion (Jaccard 0.42) due to Felixounavirus family dominance. [validated; source:
@@ -379,6 +381,21 @@ Compressed lessons from approaches that didn't work.
     analysis: ~10 genuine wins (e.g., IAI78 +0.12 nDCG, ECOR-25 +0.17) exactly offset by ~10 genuine losses (e.g.,
     ECOR-19 -0.36, EDL933 -0.24). NILS53 (the canonical narrow-host case) gains +0.011 nDCG — k-mers do not break
     narrow-host prior collapse. Not a LightGBM shortcoming; a feature-redundancy + panel-size ceiling.*
+- **`host-omp-variation-unpredictive`**: Host-side OMP allelic variation is substantial (369 clinical E. coli span BTUB
+  28 MMseqs2 99%-identity clusters, OMPC 49, 5546 retained 5-mers across 12 core OMPs) but does not predict lysis. Four
+  arms tested in SX13 (k-mers marginal, k-mers × phage k-mers cross-term, cluster IDs, plus baseline) all land within
+  ±0.4 pp of SX10 on all metrics. [validated; source: SX13; see also: omp-score-homogeneity,
+  pairwise-cross-terms-dead-end, kmer-receptor-expansion-neutral, narrow-host-prior-collapse,
+  same-receptor-uncorrelated-hosts]
+  - *Permutation test on cross_term aggregate delta: 73% of random prediction swaps are as extreme — signal
+    indistinguishable from noise. Small directional signal in the marginal arm for moderate-narrow-host deciles (lysis
+    5-11%, mean +1-2 pp nDCG across ~70 bacteria), biologically consistent with OMP-variation-matters-for-narrow-phages
+    but not significant by sign test (75/137 positive, p=0.31). NILS53 specifically improved +2.59 pp under cross_term
+    but sits at the 76th percentile of its lysis-rate peers (mean Δ = -0.001) — one outlier draw, not a reproducible
+    rescue. Top-3 hit rate moves from 92.2% to 93.3% under cross_term (+4 strains). The finding refines
+    omp-score-homogeneity: HMM-score homogeneity was real, but escalating to finer representations doesn't rescue
+    prediction — host-range variance lives downstream of OMP recognition (polysaccharide access, intracellular defenses,
+    co-evolutionary dynamics).*
 - **`label-vision-reading-spot-checked-dead`**: Using a vision model to re-read the ambiguous 'n' plaque-image scores
   (the plate crops backing the ~10% of training rows labeled negative but with uninterpretable raw scores) was evaluated
   via manual spot checks before 2026-04 and did not look promising enough to justify a full re-read pipeline. Do not

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -254,21 +254,22 @@ themes:
 
       - id: omp-score-homogeneity
         statement: >
-          All 369 clinical E. coli hosts express all 12 core OMP receptors at nearly identical HMM
-          scores (CV 0.01-0.17), making receptor × OMP cross-terms collapse to phage-only features
-          with no host-side discrimination.
-        sources: [GT03, GT06, 2026-04-12 pair-level analysis]
+          Whole-gene OMP HMM scores are near-identical across 369 clinical E. coli (CV 0.01-0.17),
+          making whole-gene receptor × OMP cross-terms collapse. Loop-level allelic variation is
+          substantial (BTUB 28 MMseqs2 99% clusters, OMPC 49, across 5546 retained 5-mers) but does
+          not predict lysis either — see host-omp-variation-unpredictive.
+        sources: [GT03, GT06, 2026-04-12 pair-level analysis, SX13]
         status: active
         confidence: validated
         context: >
-          LptD CV=0.01, OmpA CV=0.02, Tsx CV=0.03, OmpC CV=0.04. The cross-term
-          predicted_is_OmpC × host_OmpC_score ≈ predicted_is_OmpC × constant. Direct test: OmpC
+          LptD CV=0.01, OmpA CV=0.02, Tsx CV=0.03, OmpC CV=0.04 on HMM scores. Direct test: OmpC
           phages lyse high-OmpC hosts at 37.0% vs low-OmpC at 33.4% (Cohen d=0.086, negligible).
-          Moriniere's receptor classifiers were trained on K-12 (BW25113/BL21) which lack
-          O-antigen/capsule — in clinical strains, polysaccharide barriers mask OMP differences.
-          OMP variant/allele-level features (extracellular loop regions) might restore host-side
-          variation.
-        relates_to: [receptor-variant-richness, receptor-specificity-solved, three-layer-hypothesis]
+          SX13 tested whether loop-level k-mer or cluster representations would restore host-side
+          signal — they did not (AUC deltas ≤ +0.3 pp across marginal, cross-term, and cluster
+          arms). The homogeneity observation at the HMM level is real; the escalation to finer
+          representations doesn't rescue prediction because host-range variance lives downstream
+          of OMP recognition in clinical strains (polysaccharide access + post-adsorption factors).
+        relates_to: [receptor-variant-richness, receptor-specificity-solved, three-layer-hypothesis, host-omp-variation-unpredictive]
 
       - id: same-receptor-uncorrelated-hosts
         statement: >
@@ -781,6 +782,29 @@ themes:
           nDCG — k-mers do not break narrow-host prior collapse. Not a LightGBM shortcoming;
           a feature-redundancy + panel-size ceiling.
         relates_to: [omp-score-homogeneity, pairwise-cross-terms-dead-end, receptor-specificity-solved, plm-rbp-redundant, narrow-host-prior-collapse, panel-size-ceiling]
+
+      - id: host-omp-variation-unpredictive
+        statement: >
+          Host-side OMP allelic variation is substantial (369 clinical E. coli span BTUB 28 MMseqs2
+          99%-identity clusters, OMPC 49, 5546 retained 5-mers across 12 core OMPs) but does not
+          predict lysis. Four arms tested in SX13 (k-mers marginal, k-mers × phage k-mers cross-term,
+          cluster IDs, plus baseline) all land within ±0.4 pp of SX10 on all metrics.
+        sources: [SX13]
+        status: dead-end
+        confidence: validated
+        context: >
+          Permutation test on cross_term aggregate delta: 73% of random prediction swaps are as
+          extreme — signal indistinguishable from noise. Small directional signal in the marginal
+          arm for moderate-narrow-host deciles (lysis 5-11%, mean +1-2 pp nDCG across ~70 bacteria),
+          biologically consistent with OMP-variation-matters-for-narrow-phages but not significant
+          by sign test (75/137 positive, p=0.31). NILS53 specifically improved +2.59 pp under
+          cross_term but sits at the 76th percentile of its lysis-rate peers (mean Δ = -0.001) —
+          one outlier draw, not a reproducible rescue. Top-3 hit rate moves from 92.2% to 93.3%
+          under cross_term (+4 strains). The finding refines omp-score-homogeneity: HMM-score
+          homogeneity was real, but escalating to finer representations doesn't rescue prediction —
+          host-range variance lives downstream of OMP recognition (polysaccharide access, intracellular
+          defenses, co-evolutionary dynamics).
+        relates_to: [omp-score-homogeneity, pairwise-cross-terms-dead-end, kmer-receptor-expansion-neutral, narrow-host-prior-collapse, same-receptor-uncorrelated-hosts]
 
       - id: label-vision-reading-spot-checked-dead
         statement: >

--- a/lyzortx/pipeline/autoresearch/build_host_omp_cluster_slot.py
+++ b/lyzortx/pipeline/autoresearch/build_host_omp_cluster_slot.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""SX13 Path 1 fallback: per-OMP MMseqs2 cluster IDs as host-side categorical features.
+
+For each of 12 core OMPs, gather all per-host best-hit protein sequences (from
+build_host_omp_kmer_slot's extraction step), MMseqs2-cluster them at 99% identity, and emit each
+host's cluster ID per OMP as a categorical feature.
+
+Inputs:
+  - .scratch/host_omp_proteins/{host}/{omp}.faa (built by build_host_omp_kmer_slot)
+
+Outputs:
+  - .scratch/host_omp_cluster/features.csv with columns:
+    bacteria, host_omp_cluster__BTUB, host_omp_cluster__OMPC, ...
+
+Usage:
+    python -m lyzortx.pipeline.autoresearch.build_host_omp_cluster_slot
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.build_host_omp_kmer_slot import (
+    DEFAULT_OMP_REFERENCE,
+    DEFAULT_PROTEIN_OUTPUT_DIR,
+    load_omp_reference_names,
+    parse_fasta,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_SLOT_OUTPUT_PATH = Path(".scratch/host_omp_cluster/features.csv")
+FEATURE_PREFIX = "host_omp_cluster__"
+CLUSTER_IDENTITY = 0.99
+NO_HIT_CLUSTER_ID = "NO_HIT"
+
+
+def cluster_omp_sequences(
+    omp: str,
+    host_seqs: dict[str, str],
+    *,
+    identity: float = CLUSTER_IDENTITY,
+) -> dict[str, str]:
+    """MMseqs2-cluster host sequences for one OMP. Returns host -> cluster_id mapping.
+
+    Hosts with empty sequence (no phmmer hit) get NO_HIT_CLUSTER_ID.
+    """
+    hosts_with_seq = {h: s for h, s in host_seqs.items() if s}
+    no_hit_hosts = [h for h, s in host_seqs.items() if not s]
+    LOGGER.info(
+        "%s: clustering %d host sequences (%d hosts had no phmmer hit)",
+        omp,
+        len(hosts_with_seq),
+        len(no_hit_hosts),
+    )
+
+    if not hosts_with_seq:
+        return {h: NO_HIT_CLUSTER_ID for h in host_seqs}
+
+    with tempfile.TemporaryDirectory(prefix=f"mmseqs_{omp}_") as tmp:
+        tmp_path = Path(tmp)
+        input_fasta = tmp_path / "input.faa"
+        with input_fasta.open("w", encoding="utf-8") as f:
+            for h, s in hosts_with_seq.items():
+                f.write(f">{h}\n{s}\n")
+
+        # MMseqs2 easy-cluster
+        result_prefix = tmp_path / "cluster_result"
+        scratch_dir = tmp_path / "scratch"
+        scratch_dir.mkdir()
+        subprocess.run(
+            [
+                "mmseqs",
+                "easy-cluster",
+                str(input_fasta),
+                str(result_prefix),
+                str(scratch_dir),
+                "--min-seq-id",
+                f"{identity}",
+                "-c",
+                "0.8",
+                "--cov-mode",
+                "0",
+                "-v",
+                "1",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        # Output: <prefix>_cluster.tsv with columns rep_id, member_id (one row per member)
+        cluster_tsv = Path(f"{result_prefix}_cluster.tsv")
+        if not cluster_tsv.exists():
+            raise FileNotFoundError(f"MMseqs2 output missing: {cluster_tsv}")
+
+        host_cluster: dict[str, str] = {}
+        # Use cluster representative as the cluster ID, prefixed for readability
+        with cluster_tsv.open("r", encoding="utf-8") as f:
+            for line in f:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) != 2:
+                    continue
+                rep, member = parts
+                host_cluster[member] = f"{omp}_C_{rep}"
+
+        # Add no-hit hosts
+        for h in no_hit_hosts:
+            host_cluster[h] = NO_HIT_CLUSTER_ID
+
+        n_clusters = len(set(v for v in host_cluster.values() if v != NO_HIT_CLUSTER_ID))
+        LOGGER.info("  %s: %d clusters across %d hosts", omp, n_clusters, len(host_cluster))
+        return host_cluster
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--omp-reference", type=Path, default=DEFAULT_OMP_REFERENCE)
+    parser.add_argument("--protein-input-dir", type=Path, default=DEFAULT_PROTEIN_OUTPUT_DIR)
+    parser.add_argument("--slot-output-path", type=Path, default=DEFAULT_SLOT_OUTPUT_PATH)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+
+    if not shutil.which("mmseqs"):
+        raise RuntimeError("mmseqs CLI not on PATH; activate the phage_env environment first")
+    if not args.protein_input_dir.exists():
+        raise FileNotFoundError(
+            f"Per-host OMP proteins missing at {args.protein_input_dir}; run build_host_omp_kmer_slot first"
+        )
+
+    omp_names = load_omp_reference_names(args.omp_reference)
+    hosts = sorted(d.name for d in args.protein_input_dir.iterdir() if d.is_dir())
+    LOGGER.info("Discovered %d hosts under %s", len(hosts), args.protein_input_dir)
+    LOGGER.info("Clustering %d OMPs at %.0f%% identity", len(omp_names), CLUSTER_IDENTITY * 100)
+
+    # Gather per-OMP host sequences
+    omp_host_clusters: dict[str, dict[str, str]] = {}
+    for omp in omp_names:
+        host_seqs: dict[str, str] = {}
+        for h in hosts:
+            faa = args.protein_input_dir / h / f"{omp}.faa"
+            if not faa.exists() or faa.stat().st_size == 0:
+                host_seqs[h] = ""
+                continue
+            seqs = parse_fasta(faa)
+            host_seqs[h] = next(iter(seqs.values()), "")
+        omp_host_clusters[omp] = cluster_omp_sequences(omp, host_seqs)
+
+    # Write slot CSV
+    args.slot_output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ["bacteria", *[f"{FEATURE_PREFIX}{omp}" for omp in omp_names]]
+    with args.slot_output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for h in hosts:
+            row: dict[str, object] = {"bacteria": h}
+            for omp in omp_names:
+                row[f"{FEATURE_PREFIX}{omp}"] = omp_host_clusters[omp].get(h, NO_HIT_CLUSTER_ID)
+            writer.writerow(row)
+
+    LOGGER.info(
+        "Wrote %d hosts × %d categorical OMP cluster columns to %s", len(hosts), len(omp_names), args.slot_output_path
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/pipeline/autoresearch/build_host_omp_kmer_slot.py
+++ b/lyzortx/pipeline/autoresearch/build_host_omp_kmer_slot.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""SX13: Build host-side OMP 5-mer feature slot.
+
+For each of 369 clinical E. coli hosts, extract the best phmmer-matched protein per core OMP
+(BTUB, FADL, FHUA, LAMB, LPTD, NFRA, OMPA, OMPC, OMPF, TOLC, TSX, PQQU). Enumerate amino-acid
+5-mers per (host, OMP), build a global per-OMP dictionary, prune to k-mers with 5-95%
+across-host frequency, and emit a binary presence-absence slot CSV.
+
+This inverts the Moriniere trick onto the host side: whole-gene HMM scores are CV 0.01-0.17 across
+clinical strains (omp-score-homogeneity), but loop-level allelic variation is preserved in the
+coding sequence and discoverable as 5-mer presence-absence.
+
+Inputs:
+  - Per-host predicted proteomes at lyzortx/generated_outputs/autoresearch/host_surface_cache_build/{host}/predicted_proteins.faa
+  - OMP reference at lyzortx/pipeline/track_l/assets/tl15_omp_reference_proteins.faa
+
+Outputs:
+  - .scratch/host_omp_proteins/{host}/{omp}.faa (per-host best-hit OMP protein)
+  - .scratch/host_omp_kmer/features.csv (presence-absence slot)
+
+Usage:
+    python -m lyzortx.pipeline.autoresearch.build_host_omp_kmer_slot
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+from lyzortx.log_config import setup_logging
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_HOST_CACHE_DIR = Path("lyzortx/generated_outputs/autoresearch/host_surface_cache_build")
+DEFAULT_OMP_REFERENCE = Path("lyzortx/pipeline/track_l/assets/tl15_omp_reference_proteins.faa")
+DEFAULT_PROTEIN_OUTPUT_DIR = Path(".scratch/host_omp_proteins")
+DEFAULT_SLOT_OUTPUT_PATH = Path(".scratch/host_omp_kmer/features.csv")
+FEATURE_PREFIX = "host_omp_kmer__"
+KMER_LEN = 5
+MIN_FREQ = 0.05
+MAX_FREQ = 0.95
+
+
+def parse_fasta(path: Path) -> dict[str, str]:
+    """Return name -> sequence dict from a FASTA file. Names are the first whitespace-token of header."""
+    seqs: dict[str, str] = {}
+    name: str | None = None
+    parts: list[str] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.rstrip("\n")
+            if line.startswith(">"):
+                if name is not None:
+                    seqs[name] = "".join(parts)
+                name = line[1:].split()[0]
+                parts = []
+            else:
+                parts.append(line)
+        if name is not None:
+            seqs[name] = "".join(parts)
+    return seqs
+
+
+def load_omp_reference_names(path: Path) -> list[str]:
+    """Return the OMP gene names from the reference FASTA in source order.
+
+    Accepts headers like '>sp|P06129|BTUB_ECOLI ...'. Returns ['BTUB', 'FADL', ...].
+    """
+    names: list[str] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.startswith(">"):
+                continue
+            header = line[1:].strip()
+            # Pattern: sp|ACCESSION|GENE_ECOLI ...
+            m = re.match(r"sp\|[^|]+\|([A-Z0-9]+)_ECOLI", header)
+            if m:
+                names.append(m.group(1))
+            else:
+                # Fall back to first token
+                names.append(header.split()[0])
+    return names
+
+
+def extract_best_hits_for_host(
+    *,
+    host: str,
+    proteome_path: Path,
+    omp_reference_path: Path,
+    output_dir: Path,
+    omp_names: Sequence[str],
+) -> dict[str, str]:
+    """Run phmmer and write best-hit-per-OMP FASTAs to output_dir/{host}/{omp}.faa.
+
+    Returns dict mapping OMP name to the matched protein sequence (empty if no hit).
+    """
+    host_out_dir = output_dir / host
+    host_out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Skip if all per-OMP outputs already exist (idempotent re-runs).
+    expected_files = [host_out_dir / f"{omp}.faa" for omp in omp_names]
+    if all(p.exists() for p in expected_files):
+        return {omp: _read_first_seq(p) for omp, p in zip(omp_names, expected_files)}
+
+    proteome_seqs = parse_fasta(proteome_path)
+
+    # phmmer: queries = OMP reference, db = host proteome
+    with tempfile.NamedTemporaryFile("w", suffix=".tbl", delete=False) as tbl:
+        tbl_path = Path(tbl.name)
+    try:
+        subprocess.run(
+            [
+                "phmmer",
+                "--noali",
+                "--cpu",
+                "1",
+                "--tblout",
+                str(tbl_path),
+                str(omp_reference_path),
+                str(proteome_path),
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        # Parse tblout: cols are target_name, target_acc, query_name, query_acc, evalue, score, ...
+        # Pick best score per query (each query is one OMP reference).
+        best_per_query: dict[str, tuple[str, float]] = {}
+        with tbl_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("#") or not line.strip():
+                    continue
+                parts = line.split()
+                target = parts[0]
+                query = parts[2]
+                score = float(parts[5])
+                if query not in best_per_query or score > best_per_query[query][1]:
+                    best_per_query[query] = (target, score)
+
+        result: dict[str, str] = {}
+        for omp in omp_names:
+            # Find query header matching this OMP name
+            matching_query = next((q for q in best_per_query if re.match(rf"sp\|[^|]+\|{omp}_ECOLI", q)), None)
+            if matching_query is None:
+                # No hit — write empty placeholder
+                (host_out_dir / f"{omp}.faa").write_text("", encoding="utf-8")
+                result[omp] = ""
+                continue
+            target, _ = best_per_query[matching_query]
+            seq = proteome_seqs.get(target, "")
+            (host_out_dir / f"{omp}.faa").write_text(f">{host}__{omp}__{target}\n{seq}\n", encoding="utf-8")
+            result[omp] = seq
+
+        return result
+    finally:
+        tbl_path.unlink(missing_ok=True)
+
+
+def _read_first_seq(path: Path) -> str:
+    """Return the first sequence in a single-record FASTA, or empty string if file is empty."""
+    if not path.exists() or path.stat().st_size == 0:
+        return ""
+    seqs = parse_fasta(path)
+    return next(iter(seqs.values()), "")
+
+
+def enumerate_kmers(seq: str, k: int) -> set[str]:
+    """Return all unique k-mers in seq."""
+    if len(seq) < k:
+        return set()
+    return {seq[i : i + k] for i in range(len(seq) - k + 1)}
+
+
+def discover_hosts(host_cache_dir: Path) -> list[str]:
+    """Return sorted host names that have a predicted_proteins.faa file."""
+    hosts: list[str] = []
+    for d in sorted(host_cache_dir.iterdir()):
+        if d.is_dir() and (d / "predicted_proteins.faa").exists():
+            hosts.append(d.name)
+    return hosts
+
+
+def build_kmer_matrix(
+    host_omp_seqs: dict[str, dict[str, str]],
+    omp_names: Sequence[str],
+    *,
+    k: int = KMER_LEN,
+    min_freq: float = MIN_FREQ,
+    max_freq: float = MAX_FREQ,
+) -> tuple[list[str], list[dict[str, object]]]:
+    """Build the pruned k-mer presence-absence matrix.
+
+    Per OMP, enumerate the union of host k-mers, count host coverage, keep only k-mers with
+    coverage in [min_freq, max_freq] of hosts. Returns (column_order, rows).
+    """
+    hosts = sorted(host_omp_seqs.keys())
+    n_hosts = len(hosts)
+    columns: list[str] = []
+    # per-OMP retained k-mers
+    retained_per_omp: dict[str, list[str]] = {}
+
+    for omp in omp_names:
+        host_kmers: dict[str, set[str]] = {}
+        all_kmers: set[str] = set()
+        for h in hosts:
+            seq = host_omp_seqs[h].get(omp, "")
+            kmers = enumerate_kmers(seq, k)
+            host_kmers[h] = kmers
+            all_kmers.update(kmers)
+
+        # Count coverage per k-mer
+        coverage: dict[str, int] = {km: 0 for km in all_kmers}
+        for kmers in host_kmers.values():
+            for km in kmers:
+                coverage[km] += 1
+
+        retained = [km for km in sorted(all_kmers) if min_freq * n_hosts <= coverage[km] <= max_freq * n_hosts]
+        retained_per_omp[omp] = retained
+        columns.extend(f"{FEATURE_PREFIX}{omp}__{km}" for km in retained)
+        LOGGER.info(
+            "  %s: %d unique k-mers, %d retained (%.0f%%-%.0f%% frequency band)",
+            omp,
+            len(all_kmers),
+            len(retained),
+            min_freq * 100,
+            max_freq * 100,
+        )
+
+    LOGGER.info("Total retained k-mer features across %d OMPs: %d", len(omp_names), len(columns))
+
+    rows: list[dict[str, object]] = []
+    for h in hosts:
+        row: dict[str, object] = {"bacteria": h}
+        for omp in omp_names:
+            seq = host_omp_seqs[h].get(omp, "")
+            kmers = enumerate_kmers(seq, k)
+            for km in retained_per_omp[omp]:
+                row[f"{FEATURE_PREFIX}{omp}__{km}"] = 1.0 if km in kmers else 0.0
+        rows.append(row)
+    return columns, rows
+
+
+def write_slot_csv(rows: list[dict[str, object]], columns: list[str], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ["bacteria", *columns]
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host-cache-dir", type=Path, default=DEFAULT_HOST_CACHE_DIR)
+    parser.add_argument("--omp-reference", type=Path, default=DEFAULT_OMP_REFERENCE)
+    parser.add_argument("--protein-output-dir", type=Path, default=DEFAULT_PROTEIN_OUTPUT_DIR)
+    parser.add_argument("--slot-output-path", type=Path, default=DEFAULT_SLOT_OUTPUT_PATH)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+
+    if not args.omp_reference.exists():
+        raise FileNotFoundError(f"OMP reference FASTA missing: {args.omp_reference}")
+    if not args.host_cache_dir.exists():
+        raise FileNotFoundError(f"Host cache dir missing: {args.host_cache_dir}")
+
+    omp_names = load_omp_reference_names(args.omp_reference)
+    LOGGER.info("Core OMPs (%d): %s", len(omp_names), ", ".join(omp_names))
+
+    hosts = discover_hosts(args.host_cache_dir)
+    LOGGER.info("Discovered %d hosts with predicted_proteins.faa", len(hosts))
+
+    # Step 1: per-host phmmer extraction
+    host_omp_seqs: dict[str, dict[str, str]] = {}
+    for i, host in enumerate(hosts, 1):
+        proteome_path = args.host_cache_dir / host / "predicted_proteins.faa"
+        host_omp_seqs[host] = extract_best_hits_for_host(
+            host=host,
+            proteome_path=proteome_path,
+            omp_reference_path=args.omp_reference,
+            output_dir=args.protein_output_dir,
+            omp_names=omp_names,
+        )
+        if i % 25 == 0 or i == len(hosts):
+            covered = sum(1 for s in host_omp_seqs[host].values() if s)
+            LOGGER.info("phmmer %d/%d hosts (last: %s, %d/%d OMPs hit)", i, len(hosts), host, covered, len(omp_names))
+
+    # Step 2: build pruned k-mer matrix
+    LOGGER.info(
+        "Building k-mer presence-absence matrix (k=%d, freq band %.0f%%-%.0f%%)",
+        KMER_LEN,
+        MIN_FREQ * 100,
+        MAX_FREQ * 100,
+    )
+    columns, rows = build_kmer_matrix(host_omp_seqs, omp_names)
+
+    write_slot_csv(rows, columns, args.slot_output_path)
+    LOGGER.info("Wrote %d hosts × %d k-mer features to %s", len(rows), len(columns), args.slot_output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/pipeline/autoresearch/sx13_eval.py
+++ b/lyzortx/pipeline/autoresearch/sx13_eval.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""SX13: Evaluate host OMP k-mer features (marginal, cross-term, fallback) against SX10 baseline.
+
+Four arms, all evaluated via SX01 10-fold bacteria-stratified CV with bootstrap CIs:
+
+  1. baseline             — SX10 configuration (reference)
+  2. marginal             — + host_omp_kmer slot on host side
+  3. cross_term           — + host_omp_kmer + within-fold top-100 phage_moriniere × host_omp_kmer pairs
+  4. path1_cluster        — + host_omp_cluster slot (categorical) on host side, fallback per spec
+
+Acceptance gate (per ticket): within-panel AUC ≥+2 pp OR Arm C AUC ≥+2 pp over SX10 baseline,
+AND NILS53 / Dhillonvirus narrow-host rank improves measurably. Honest null is a valued outcome.
+
+Cross-term arm leakage policy: the top-100 (phage_kmer, host_omp_kmer) pairs are selected by
+correlation with `any_lysis` computed ONLY on the training fold's pairs. Holdout fold pairs are
+never seen during selection.
+
+Usage:
+    python -m lyzortx.pipeline.autoresearch.build_host_omp_kmer_slot
+    python -m lyzortx.pipeline.autoresearch.build_host_omp_cluster_slot
+    python -m lyzortx.pipeline.autoresearch.sx13_eval --device-type cpu
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.build_host_omp_cluster_slot import (
+    DEFAULT_SLOT_OUTPUT_PATH as DEFAULT_CLUSTER_SLOT_PATH,
+    FEATURE_PREFIX as CLUSTER_PREFIX,
+)
+from lyzortx.pipeline.autoresearch.build_host_omp_kmer_slot import (
+    DEFAULT_SLOT_OUTPUT_PATH as DEFAULT_KMER_SLOT_PATH,
+    FEATURE_PREFIX as HOST_KMER_PREFIX,
+)
+from lyzortx.pipeline.autoresearch.build_moriniere_kmer_slot import FEATURE_PREFIX as PHAGE_KMER_PREFIX
+from lyzortx.pipeline.autoresearch.candidate_replay import (
+    build_st03_training_frame,
+    load_module_from_path,
+    load_st03_holdout_frame,
+    safe_round,
+)
+from lyzortx.pipeline.autoresearch.derive_pairwise_depo_capsule_features import (
+    compute_pairwise_depo_capsule_features,
+)
+from lyzortx.pipeline.autoresearch.derive_pairwise_receptor_omp_features import (
+    compute_pairwise_receptor_omp_features,
+)
+from lyzortx.pipeline.autoresearch.gt03_eval import apply_rfe
+from lyzortx.pipeline.autoresearch.gt09_clean_label_eval import identify_ambiguous_pairs
+from lyzortx.pipeline.autoresearch.spandex_metrics import evaluate_holdout_rows
+from lyzortx.pipeline.autoresearch.sx01_eval import (
+    BOOTSTRAP_RANDOM_STATE,
+    BOOTSTRAP_SAMPLES,
+    N_FOLDS,
+    SEEDS,
+    assign_bacteria_folds,
+    bootstrap_spandex_cis,
+    enrich_rows_with_mlc,
+    load_mlc_scores,
+    train_and_predict_fold,
+)
+from lyzortx.pipeline.autoresearch.sx12_eval import (
+    DEFAULT_KMER_SLOT_PATH as DEFAULT_PHAGE_KMER_SLOT_PATH,
+    MORINIERE_SLOT_NAME,
+    attach_moriniere_slot,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CACHE_DIR = Path("lyzortx/generated_outputs/autoresearch/search_cache_v1")
+DEFAULT_CANDIDATE_DIR = Path("lyzortx/autoresearch")
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/sx13_eval")
+RAW_INTERACTIONS_PATH = Path("data/interactions/raw/raw_interactions.csv")
+
+HOST_OMP_KMER_SLOT = "host_omp_kmer"
+HOST_OMP_CLUSTER_SLOT = "host_omp_cluster"
+ARMS = ("baseline", "marginal", "cross_term", "path1_cluster")
+TOP_N_CROSS_TERMS = 100
+CROSS_TERM_PREFIX = "pair_motif_cross__"
+
+LGBM_COMMON_PARAMS = {
+    "n_estimators": 300,
+    "learning_rate": 0.05,
+    "num_leaves": 31,
+    "min_child_samples": 10,
+    "subsample": 0.8,
+    "colsample_bytree": 0.8,
+    "reg_lambda": 1.0,
+}
+
+
+def attach_csv_slot(
+    *,
+    context: Any,
+    features_path: Path,
+    slot_name: str,
+    feature_prefix: str,
+    entity_key: str,
+) -> int:
+    """Attach a CSV-backed feature slot to context.slot_artifacts. Returns the feature column count."""
+    from lyzortx.autoresearch.train import SlotArtifact
+
+    if not features_path.exists():
+        raise FileNotFoundError(f"Slot CSV not found at {features_path}; build it before running SX13")
+    frame = pd.read_csv(features_path)
+    feature_cols = tuple(c for c in frame.columns if c.startswith(feature_prefix))
+    if entity_key not in frame.columns or not feature_cols:
+        raise ValueError(
+            f"Slot CSV {features_path} missing entity column '{entity_key}' or columns starting with '{feature_prefix}'"
+        )
+    artifact = SlotArtifact(
+        slot_name=slot_name,
+        entity_key=entity_key,
+        feature_columns=feature_cols,
+        frame=frame,
+    )
+    context.slot_artifacts[slot_name] = artifact
+    LOGGER.info("Attached slot %s: %d %s × %d features", slot_name, len(frame), entity_key, len(feature_cols))
+    return len(feature_cols)
+
+
+def _select_top_cross_term_pairs(
+    train_design: pd.DataFrame,
+    phage_kmer_cols: list[str],
+    host_kmer_cols: list[str],
+    *,
+    top_n: int = TOP_N_CROSS_TERMS,
+) -> list[tuple[str, str]]:
+    """Pick top-N (phage_kmer, host_kmer) pairs by absolute Pearson correlation with any_lysis.
+
+    Computed within-fold (training rows only) to avoid leakage. Fully vectorized via two matrix
+    multiplies, exploiting that both phage and host k-mer features are binary.
+
+    For binary cross-term X = phage_p * host_h:
+      sum(X)   = (P.T @ H)[p, h]
+      sum(X*y) = (P.T @ (H * y))[p, h]
+      mean(X)  = sum(X) / n
+      var(X)   = mean(X) * (1 - mean(X))     # binary
+      corr(X, y) = (sum(X*y)/n - mean(X)*mean(y)) / (std(X) * std(y))
+    """
+    y = train_design["label_any_lysis"].astype(np.float32).to_numpy()
+    n = len(y)
+    y_mean = float(y.mean())
+    y_std = float(y.std())
+    if y_std < 1e-9:
+        return []
+
+    P = train_design[phage_kmer_cols].astype(np.float32).to_numpy()  # n × n_p
+    H = train_design[host_kmer_cols].astype(np.float32).to_numpy()  # n × n_h
+
+    sum_x = P.T @ H  # n_p × n_h, count of co-occurrence
+    sum_xy = P.T @ (H * y[:, None])  # n_p × n_h, count of triple-positive
+    mean_x = sum_x / n
+    # var_x = mean_x * (1 - mean_x) for binary X; clamp tiny negatives from float noise
+    var_x = np.clip(mean_x * (1.0 - mean_x), 0.0, None)
+    std_x = np.sqrt(var_x)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        corr = (sum_xy / n - mean_x * y_mean) / (std_x * y_std)
+    corr = np.where(np.isfinite(corr), corr, 0.0)
+    abs_corr = np.abs(corr).ravel()
+
+    if top_n >= abs_corr.size:
+        order = np.argsort(-abs_corr)
+    else:
+        # argpartition is O(N), then sort the top-N for stable ranking
+        idx = np.argpartition(-abs_corr, top_n)[:top_n]
+        order = idx[np.argsort(-abs_corr[idx])]
+
+    n_h = len(host_kmer_cols)
+    return [(phage_kmer_cols[i // n_h], host_kmer_cols[i % n_h]) for i in order]
+
+
+def _add_cross_term_columns(design: pd.DataFrame, pairs: list[tuple[str, str]]) -> list[str]:
+    """Add cross-term product columns to design in place. Returns list of new column names."""
+    new_cols: list[str] = []
+    new_data: dict[str, np.ndarray] = {}
+    for phage_col, host_col in pairs:
+        col = f"{CROSS_TERM_PREFIX}{phage_col[len(PHAGE_KMER_PREFIX) :]}__x__{host_col[len(HOST_KMER_PREFIX) :]}"
+        new_data[col] = design[phage_col].astype(float).to_numpy() * design[host_col].astype(float).to_numpy()
+        new_cols.append(col)
+    new_frame = pd.DataFrame(new_data, index=design.index)
+    for col in new_cols:
+        design[col] = new_frame[col]
+    return new_cols
+
+
+def train_and_predict_fold_cross_term(
+    *,
+    candidate_module: ModuleType,
+    context: Any,
+    training_frame: pd.DataFrame,
+    holdout_frame: pd.DataFrame,
+    seed: int,
+    device_type: str,
+    host_slots: list[str],
+    phage_slots: list[str],
+) -> list[dict[str, object]]:
+    """Custom train/predict for the cross-term arm. Mirrors train_and_predict_fold but injects
+    within-fold-selected (phage_kmer × host_omp_kmer) cross-term columns before RFE.
+    """
+    from lyzortx.autoresearch.per_phage_model import fit_per_phage_models, predict_per_phage
+    from lyzortx.pipeline.autoresearch.candidate_replay import temporary_module_attribute
+
+    host_table = candidate_module.build_entity_feature_table(
+        context.slot_artifacts, slot_names=host_slots, entity_key="bacteria"
+    )
+    phage_table = candidate_module.build_entity_feature_table(
+        context.slot_artifacts, slot_names=phage_slots, entity_key="phage"
+    )
+    host_typed, _, host_categorical = candidate_module.type_entity_features(host_table, "bacteria")
+    phage_typed, _, phage_categorical = candidate_module.type_entity_features(phage_table, "phage")
+
+    train_design = candidate_module.build_raw_pair_design_matrix(
+        training_frame, host_features=host_typed, phage_features=phage_typed
+    )
+    holdout_design = candidate_module.build_raw_pair_design_matrix(
+        holdout_frame, host_features=host_typed, phage_features=phage_typed
+    )
+    compute_pairwise_depo_capsule_features(train_design)
+    compute_pairwise_depo_capsule_features(holdout_design)
+    compute_pairwise_receptor_omp_features(train_design)
+    compute_pairwise_receptor_omp_features(holdout_design)
+
+    # Within-fold selection of top phage_kmer × host_omp_kmer pairs.
+    phage_kmer_cols = [c for c in train_design.columns if c.startswith(PHAGE_KMER_PREFIX)]
+    host_kmer_cols = [c for c in train_design.columns if c.startswith(HOST_KMER_PREFIX)]
+    LOGGER.info(
+        "Cross-term selection: %d phage k-mers × %d host k-mers = %d candidate pairs",
+        len(phage_kmer_cols),
+        len(host_kmer_cols),
+        len(phage_kmer_cols) * len(host_kmer_cols),
+    )
+    if phage_kmer_cols and host_kmer_cols:
+        top_pairs = _select_top_cross_term_pairs(train_design, phage_kmer_cols, host_kmer_cols, top_n=TOP_N_CROSS_TERMS)
+        new_train_cols = _add_cross_term_columns(train_design, top_pairs)
+        _add_cross_term_columns(holdout_design, top_pairs)
+        LOGGER.info("Cross-term: added %d top-correlation product columns", len(new_train_cols))
+    else:
+        LOGGER.warning("Cross-term arm skipped: missing phage or host k-mer columns")
+
+    prefixes = tuple(f"{s}__" for s in host_slots + phage_slots) + (
+        "pair_depo_capsule__",
+        "pair_receptor_omp__",
+        CROSS_TERM_PREFIX,
+    )
+    feature_columns = [c for c in train_design.columns if c.startswith(prefixes)]
+    categorical_columns = [c for c in (host_categorical + phage_categorical) if c in feature_columns]
+
+    y_train = train_design["label_any_lysis"].astype(int).to_numpy(dtype=int)
+    rfe_features = apply_rfe(train_design, feature_columns, categorical_columns, y_train, seed=42)
+    rfe_categorical = [c for c in categorical_columns if c in rfe_features]
+    sample_weight = train_design["training_weight_v3"].astype(float).to_numpy(dtype=float)
+
+    LOGGER.info(
+        "Cross-term fold: %d features after RFE (from %d, including %d cross-terms), %d train / %d holdout",
+        len(rfe_features),
+        len(feature_columns),
+        sum(1 for c in rfe_features if c.startswith(CROSS_TERM_PREFIX)),
+        len(train_design),
+        len(holdout_design),
+    )
+
+    with temporary_module_attribute(candidate_module, "PAIR_SCORER_RANDOM_STATE", seed):
+        estimator = candidate_module.build_pair_scorer(device_type=device_type)
+    estimator.fit(
+        train_design[rfe_features],
+        y_train,
+        sample_weight=sample_weight,
+        categorical_feature=rfe_categorical,
+    )
+    all_pairs_predictions = estimator.predict_proba(holdout_design[rfe_features])[:, 1]
+
+    host_feature_columns = [
+        c
+        for c in rfe_features
+        if c.startswith(
+            ("host_surface__", "host_typing__", "host_stats__", "host_defense__", HOST_KMER_PREFIX, CLUSTER_PREFIX)
+        )
+    ]
+    per_phage_models = fit_per_phage_models(
+        train_design, host_feature_columns, device_type=device_type, random_state=seed
+    )
+    predictions, _ = predict_per_phage(
+        per_phage_models, holdout_design, host_feature_columns, all_pairs_predictions, blend_alpha=0.5
+    )
+
+    rows = []
+    for row, probability in zip(
+        holdout_design.loc[:, ["pair_id", "bacteria", "phage", "label_any_lysis"]].to_dict(orient="records"),
+        predictions,
+    ):
+        rows.append(
+            {
+                "arm_id": "cross_term",
+                "seed": seed,
+                "pair_id": str(row["pair_id"]),
+                "bacteria": str(row["bacteria"]),
+                "phage": str(row["phage"]),
+                "label_hard_any_lysis": int(row["label_any_lysis"]),
+                "predicted_probability": safe_round(float(probability)),
+            }
+        )
+    return rows
+
+
+def run_arm(
+    *,
+    arm_id: str,
+    candidate_module: ModuleType,
+    context: Any,
+    clean_frame: pd.DataFrame,
+    fold_assignments: dict[str, int],
+    mlc_lookup: dict[tuple[str, str], float],
+    device_type: str,
+    host_slots: list[str],
+    phage_slots: list[str],
+) -> list[dict[str, object]]:
+    """Run one arm across all folds × seeds; return enriched per-pair prediction rows."""
+    all_predictions: list[dict[str, object]] = []
+    for fold_id in range(N_FOLDS):
+        holdout_bacteria = {b for b, f in fold_assignments.items() if f == fold_id}
+        train_bacteria = {b for b, f in fold_assignments.items() if f != fold_id}
+        holdout_fold = clean_frame[clean_frame["bacteria"].isin(holdout_bacteria)].copy()
+        train_fold = clean_frame[clean_frame["bacteria"].isin(train_bacteria)].copy()
+        LOGGER.info(
+            "=== %s Fold %d: %d train bacteria (%d pairs), %d holdout bacteria (%d pairs) ===",
+            arm_id,
+            fold_id,
+            len(train_bacteria),
+            len(train_fold),
+            len(holdout_bacteria),
+            len(holdout_fold),
+        )
+
+        fold_rows: list[dict[str, object]] = []
+        for seed in SEEDS:
+            if arm_id == "cross_term":
+                rows = train_and_predict_fold_cross_term(
+                    candidate_module=candidate_module,
+                    context=context,
+                    training_frame=train_fold,
+                    holdout_frame=holdout_fold,
+                    seed=seed,
+                    device_type=device_type,
+                    host_slots=host_slots,
+                    phage_slots=phage_slots,
+                )
+            else:
+                rows = train_and_predict_fold(
+                    candidate_module=candidate_module,
+                    context=context,
+                    training_frame=train_fold,
+                    holdout_frame=holdout_fold,
+                    seed=seed,
+                    device_type=device_type,
+                    host_slots=host_slots,
+                    phage_slots=phage_slots,
+                )
+            for r in rows:
+                r["fold_id"] = fold_id
+                r["arm_id"] = arm_id
+            fold_rows.extend(rows)
+
+        df = pd.DataFrame(fold_rows)
+        agg = (
+            df.groupby(["fold_id", "pair_id", "bacteria", "phage", "label_hard_any_lysis"], as_index=False)[
+                "predicted_probability"
+            ]
+            .mean()
+            .sort_values(["bacteria", "phage"])
+        )
+        enriched = enrich_rows_with_mlc(agg.to_dict(orient="records"), mlc_lookup)
+        for r in enriched:
+            r["arm_id"] = arm_id
+        fold_metrics = evaluate_holdout_rows(enriched)
+        LOGGER.info(
+            "  %s Fold %d: nDCG=%.4f, mAP=%.4f, AUC=%.4f, Brier=%.4f",
+            arm_id,
+            fold_id,
+            fold_metrics.get("holdout_ndcg") or 0,
+            fold_metrics.get("holdout_map") or 0,
+            fold_metrics.get("holdout_roc_auc") or 0,
+            fold_metrics.get("holdout_brier_score") or 0,
+        )
+        all_predictions.extend(enriched)
+    return all_predictions
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device-type", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--candidate-dir", type=Path, default=DEFAULT_CANDIDATE_DIR)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--phage-kmer-slot-path", type=Path, default=DEFAULT_PHAGE_KMER_SLOT_PATH)
+    parser.add_argument("--host-kmer-slot-path", type=Path, default=DEFAULT_KMER_SLOT_PATH)
+    parser.add_argument("--host-cluster-slot-path", type=Path, default=DEFAULT_CLUSTER_SLOT_PATH)
+    parser.add_argument("--arms", type=str, default=",".join(ARMS))
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+    start = datetime.now(timezone.utc)
+    LOGGER.info("SX13 eval starting at %s", start.isoformat())
+
+    arms = tuple(a.strip() for a in args.arms.split(",") if a.strip())
+    unknown = set(arms) - set(ARMS)
+    if unknown:
+        raise ValueError(f"Unknown arms: {sorted(unknown)}. Valid: {ARMS}")
+
+    candidate_module = load_module_from_path("sx13_candidate", args.candidate_dir / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=args.cache_dir, include_host_defense=True)
+
+    # Always attach phage Moriniere k-mers (needed for cross_term arm and harmless otherwise).
+    if "cross_term" in arms or "marginal" in arms:
+        attach_moriniere_slot(context, args.phage_kmer_slot_path)
+    if "marginal" in arms or "cross_term" in arms:
+        attach_csv_slot(
+            context=context,
+            features_path=args.host_kmer_slot_path,
+            slot_name=HOST_OMP_KMER_SLOT,
+            feature_prefix=HOST_KMER_PREFIX,
+            entity_key="bacteria",
+        )
+    if "path1_cluster" in arms:
+        attach_csv_slot(
+            context=context,
+            features_path=args.host_cluster_slot_path,
+            slot_name=HOST_OMP_CLUSTER_SLOT,
+            feature_prefix=CLUSTER_PREFIX,
+            entity_key="bacteria",
+        )
+
+    holdout_frame = load_st03_holdout_frame()
+    training_frame = build_st03_training_frame()
+    full_frame = pd.concat([training_frame, holdout_frame], ignore_index=True)
+    ambiguous = identify_ambiguous_pairs(RAW_INTERACTIONS_PATH)
+    clean_frame = full_frame[~full_frame["pair_id"].isin(ambiguous)].copy()
+    LOGGER.info("Clean frame: %d pairs, %d bacteria", len(clean_frame), clean_frame["bacteria"].nunique())
+
+    mlc_df = load_mlc_scores()
+    mlc_lookup = {(r["bacteria"], r["phage"]): r["mlc_score"] for _, r in mlc_df.iterrows()}
+
+    fold_assignments = assign_bacteria_folds(sorted(clean_frame["bacteria"].unique()))
+
+    arm_specs = {
+        "baseline": {
+            "host_slots": ["host_surface", "host_typing", "host_stats", "host_defense"],
+            "phage_slots": ["phage_projection", "phage_stats"],
+        },
+        "marginal": {
+            "host_slots": ["host_surface", "host_typing", "host_stats", "host_defense", HOST_OMP_KMER_SLOT],
+            "phage_slots": ["phage_projection", "phage_stats"],
+        },
+        "cross_term": {
+            "host_slots": ["host_surface", "host_typing", "host_stats", "host_defense", HOST_OMP_KMER_SLOT],
+            "phage_slots": ["phage_projection", "phage_stats", MORINIERE_SLOT_NAME],
+        },
+        "path1_cluster": {
+            "host_slots": ["host_surface", "host_typing", "host_stats", "host_defense", HOST_OMP_CLUSTER_SLOT],
+            "phage_slots": ["phage_projection", "phage_stats"],
+        },
+    }
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    arm_summary_rows: list[dict[str, object]] = []
+    bootstrap_bundle: dict[str, dict[str, dict[str, float | None]]] = {}
+
+    for arm in arms:
+        spec = arm_specs[arm]
+        predictions = run_arm(
+            arm_id=arm,
+            candidate_module=candidate_module,
+            context=context,
+            clean_frame=clean_frame,
+            fold_assignments=fold_assignments,
+            mlc_lookup=mlc_lookup,
+            device_type=args.device_type,
+            host_slots=spec["host_slots"],
+            phage_slots=spec["phage_slots"],
+        )
+
+        LOGGER.info("=== Bootstrap for arm %s (%d predictions) ===", arm, len(predictions))
+        ci_results = bootstrap_spandex_cis(
+            predictions, bootstrap_samples=BOOTSTRAP_SAMPLES, bootstrap_random_state=BOOTSTRAP_RANDOM_STATE
+        )
+        bootstrap_bundle[arm] = {
+            metric: {"point_estimate": ci.point_estimate, "ci_low": ci.ci_low, "ci_high": ci.ci_high}
+            for metric, ci in ci_results.items()
+        }
+        summary_row: dict[str, object] = {"arm_id": arm}
+        for metric, ci in ci_results.items():
+            summary_row[metric] = ci.point_estimate
+            summary_row[f"{metric}_ci_low"] = ci.ci_low
+            summary_row[f"{metric}_ci_high"] = ci.ci_high
+        arm_summary_rows.append(summary_row)
+        pd.DataFrame(predictions).to_csv(args.output_dir / f"{arm}_predictions.csv", index=False)
+
+    with open(args.output_dir / "bootstrap_results.json", "w", encoding="utf-8") as f:
+        json.dump(bootstrap_bundle, f, indent=2)
+    pd.DataFrame(arm_summary_rows).to_csv(args.output_dir / "arm_comparison.csv", index=False)
+
+    elapsed = (datetime.now(timezone.utc) - start).total_seconds()
+    LOGGER.info("SX13 eval complete in %.0fs", elapsed)
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_SPANDEX.md
+++ b/lyzortx/research_notes/lab_notebooks/track_SPANDEX.md
@@ -972,3 +972,194 @@ genuine-wins table above filters to ≥5 positives.
 - Bootstrap CIs: `lyzortx/generated_outputs/sx12_eval/within_panel_bootstrap.json`
 - Per-pair predictions: `lyzortx/generated_outputs/sx12_eval/within_panel_predictions.csv`
 - K-mer feature slot: `.scratch/moriniere_kmer/features.csv` (148 phages × 815 k-mers)
+
+### 2026-04-15 14:19 CEST: SX13 — Host OMP k-mer features (validated null, all 4 arms)
+
+#### Executive summary
+
+Built per-host OMP 5-mer presence-absence features (369 hosts × 5546 features across 12 core OMPs) and evaluated
+four arms against SX10 baseline: marginal (host k-mers only), cross_term (+ within-fold top-100 phage × host
+k-mer products), path1_cluster (MMseqs2 99% cluster IDs as categorical fallback). **All four arms fail the +2 pp
+acceptance gate by wide margins (max AUC Δ = +0.26 pp).** A permutation test on cross_term's aggregate delta
+finds 73% of random prediction swaps are as extreme — the aggregate signal is indistinguishable from noise.
+NILS53 improved +2.59 pp nDCG under cross_term, but peer bacteria at the same lysis rate averaged Δ = -0.001 —
+NILS53 is an outlier, not a reproducible pattern. A small directional signal remains in the marginal arm for
+moderate-narrow hosts (lysis deciles 1-2, +1-2 pp mean), biologically consistent but statistically weak. The
+broader conclusion: host OMP allelic variation IS present in clinical *E. coli* (BTUB 1495 informative k-mers,
+FHUA 1184) but does NOT predict strain-level lysis — the actual bottleneck sits downstream of OMP recognition.
+
+#### Arm definitions
+
+All four arms share the SX10 baseline feature set and evaluation protocol (10-fold bacteria-stratified CV,
+3 seeds, RFE, per-phage blending, 1000-resample bootstrap CIs). They differ only in added host-side slots:
+
+1. **baseline** — SX10 configuration (reference)
+2. **marginal** — + `host_omp_kmer` slot (5546 features)
+3. **cross_term** — + `host_omp_kmer` + `phage_moriniere_kmer` + within-fold top-100 (phage_kmer × host_omp_kmer) products
+4. **path1_cluster** — + `host_omp_cluster` slot (12 categorical features, MMseqs2 99% identity cluster IDs)
+
+Cross-term selection is within-fold-safe: the top-100 (phage_kmer, host_kmer) pairs are chosen by Pearson
+correlation with `any_lysis` computed only on the training fold. Vectorized via two matrix multiplies
+(exploiting binary features); runs in ~1 second per fold.
+
+#### Results
+
+| Metric | baseline | marginal | cross_term | path1_cluster |
+|--------|----------|----------|------------|---------------|
+| nDCG  | 0.7958 [0.788, 0.812] | 0.7984 [0.790, 0.815] | 0.7946 [0.786, 0.811] | 0.7949 [0.787, 0.812] |
+| mAP   | 0.7111 [0.693, 0.729] | 0.7152 [0.697, 0.733] | 0.7119 [0.694, 0.730] | 0.7084 [0.690, 0.727] |
+| AUC   | 0.8699 [0.857, 0.882] | 0.8702 [0.857, 0.882] | **0.8725** [0.860, 0.884] | 0.8689 [0.855, 0.881] |
+| Brier | 0.1248 [0.119, 0.131] | 0.1245 [0.119, 0.131] | **0.1225** [0.116, 0.129] | 0.1253 [0.119, 0.131] |
+
+All deltas within ±0.4 pp. All CIs overlap baseline massively. No arm clears the +2 pp gate on either axis
+(within-panel AUC OR Arm C AUC — only within-panel was run; Arm C would not change the verdict).
+
+Feature retention through RFE (cross_term arm, per fold): **8-10 of the 100 candidate cross-term columns**
+survive pruning. The within-fold top-100 correlation selection is doing its job, but LightGBM sees most of
+the cross-terms as redundant with existing features.
+
+#### Permutation sanity check
+
+To test whether cross_term's aggregate delta is distinguishable from noise: for each of 200 permutations,
+randomly swap each pair's (baseline, cross_term) predictions 50/50, recompute per-bacterium nDCG, take the
+mean delta.
+
+- Actual mean Δ (cross_term − baseline): **−0.0012**
+- Null distribution mean: −0.0001 ± 0.0033
+- Fraction of perms as extreme as observed: **73%**
+
+The cross_term "signal" in the aggregate is functionally indistinguishable from random noise.
+
+#### Per-decile stratification
+
+Per-bacterium nDCG delta, binned by lysis rate (n≈36 per decile):
+
+| Decile | lysis range | n | marginal mean Δ | cross_term mean Δ |
+|--------|-------------|---|-----------------|--------------------|
+| 0 (hardest) | 1-5% | 36 | +0.0025 | **-0.0213** |
+| **1** | 5-7% | 37 | **+0.0188** | +0.0003 |
+| **2** | 8-11% | 34 | **+0.0118** | -0.0056 |
+| 3 | 11-16% | 38 | -0.0024 | +0.0080 |
+| 4 | 16-20% | 34 | -0.0006 | +0.0025 |
+| 5 | 20-25% | 36 | -0.0022 | +0.0023 |
+| 6 | 25-29% | 34 | -0.0023 | -0.0004 |
+| 7 | 30-38% | 36 | -0.0004 | +0.0000 |
+| 8 | 38-51% | 35 | -0.0003 | -0.0003 |
+| 9 (broadest) | 51-100% | 36 | +0.0006 | +0.0020 |
+
+**The marginal arm has a directional signal in moderate-narrow deciles (1-2)**: mean +1-2 pp across ~70
+bacteria with 5-11% lysis rate. This matches the biological prior — OMP variation should matter most for
+phages that can't spray-and-pray on broad receptors. But sign test on the full narrow-host bucket (n=137):
+75/137 positive (p=0.31), not significant.
+
+**The cross_term arm actively hurts the hardest-narrow decile** (-2.1 pp on lysis 1-5% cases). Cross-terms
+rearrange ranks in ways that rescue a few narrow hosts (NILS53) while pushing others further down.
+
+#### NILS53 specifically (acceptance-criterion named case)
+
+| Arm | nDCG | Δ vs baseline |
+|-----|------|---------------|
+| baseline | 0.4330 | — |
+| marginal | 0.4406 | +0.76 pp |
+| **cross_term** | **0.4589** | **+2.59 pp** |
+| path1_cluster | 0.4302 | -0.28 pp |
+
+Seven of 11 NILS53 positives moved to better ranks under cross_term; biggest gains on LM40_P2 (rank 33→18),
+LM40_P1 (28→15), LM40_P3 (22→12), LM33_P1 (26→17).
+
+**But NILS53 is an outlier among its peers.** 51 bacteria within ±3 pp of NILS53's 12% lysis rate had
+cross_term mean Δ = -0.001, median -0.001. NILS53's +2.59 pp places it at the 76th percentile of the peer
+distribution — one lucky draw, not a reproducible pattern. The ticket language ("NILS53 / Dhillonvirus
+narrow-host rank improves measurably") is satisfied in the literal sense, but the peer comparison shows
+this doesn't generalize to other narrow-host cases.
+
+#### Top-3 hit rate
+
+| Arm | top-3 hit rate |
+|-----|----------------|
+| baseline | 329/357 = 92.2% |
+| marginal | 332/357 = 93.0% |
+| cross_term | 333/357 = 93.3% |
+| path1_cluster | 331/357 = 92.7% |
+
+Cross_term rescues 4 additional strains. Marginal rescues 3. Small but directionally consistent.
+
+#### K-mer slot retention audit
+
+Per-OMP retained k-mer counts after 5%-95% frequency pruning (369 hosts × 12 OMPs):
+
+| OMP | unique k-mers | retained (5-95%) | fraction |
+|-----|---------------|------------------|----------|
+| BTUB | 2538 | 1495 | 59% |
+| FHUA | 3114 | 1184 | 38% |
+| NFRA | 3460 | 839 | 24% |
+| FADL | 1102 | 533 | 48% |
+| PQQU | 3084 | 402 | 13% |
+| OMPC | 1243 | 391 | 31% |
+| OMPF | 903 | 202 | 22% |
+| LPTD | 1463 | 166 | 11% |
+| OMPA | 517 | 131 | 25% |
+| LAMB | 791 | 98 | 12% |
+| TOLC | 1184 | 55 | 5% |
+| TSX | 440 | 50 | 11% |
+| **total** | **19839** | **5546** | |
+
+MMseqs2 99% identity clusters across 369 hosts: BTUB 28, OMPC 49, FHUA 16, NFRA 32, PQQU 39, LAMB 10,
+LPTD 10, OMPA 10, OMPF 15, TOLC 11, TSX 6, FADL 16.
+
+**Interpretation:** Host OMP allelic variation IS present at substantial scale (BTUB 1495 informative
+5-mers across 28 MMseqs2 clusters; OMPC 391 k-mers across 49 clusters — matching the knowledge model's
+`receptor-variant-richness` claim of 50 OmpC variants). But variation ≠ prediction: none of these
+representations (fine k-mer or coarse cluster) correlates with lysis outcome at a level the model can exploit.
+
+#### Biological conclusion
+
+`omp-score-homogeneity` was pointing at a real bottleneck but misidentified the *level* at which it applies.
+Whole-gene HMM scores are homogeneous (CV 0.01-0.17). Loop-level 5-mer variation is NOT homogeneous
+(BTUB has 28 distinct clusters, OMPC has 49). But host OMP variation at either level **does not predict
+lysis** in this panel. The biological reading is:
+
+1. In clinical *E. coli* (with intact capsule/O-antigen), physical access to OMP receptors is gated by
+   the polysaccharide layer — already captured by `depo × capsule` cross-terms (22% feature importance
+   in GT03, the validated pairwise signal).
+2. Once physical access is established, receptor-level allelic variation appears not to discriminate
+   strain-level host range at the resolution our data supports.
+3. Post-adsorption factors (injection efficiency, intracellular defenses, co-evolutionary dynamics) are
+   probably what determine the remaining variance — and these leave no detectable genomic signature at
+   the OMP level.
+
+This is consistent with `same-receptor-uncorrelated-hosts` (Tsx phages Jaccard 0.091): receptor identity
+and variant don't determine host range; something downstream does.
+
+#### Design notes
+
+**SX03 Arm C not evaluated.** The SX13 runner does within-panel 10-fold only. Given within-panel Δ at
+≤+0.3 pp on all arms, Arm C would not reach +2 pp. Documented omission.
+
+**Per-phage blending is expensive with 5546 host features.** Marginal arm folds took ~7 min each
+(vs ~3 min for SX11's lean binary arm). Per-phage LightGBM fits are where the time goes, not the k-mer
+features themselves. Acceptable for single evaluation runs; would be a bottleneck if SX13-style slots
+are used in per-seed hyperparameter sweeps.
+
+**Vectorized cross-term selection.** Initial implementation looped over 815 × 5546 = 4.5M pairs per fold
+with per-iteration Python-level sort, projected ~1 hr per fold. Replaced with two numpy matrix multiplies
+exploiting binary structure: `sum_x = P.T @ H`, `sum_xy = P.T @ (H * y[:, None])`, closed-form correlation.
+Drops to ~1 sec per fold (>1000× speedup). Generic pattern for binary feature interaction search.
+
+#### Knowledge update
+
+- Keep `omp-score-homogeneity` active but refine context: the HMM-score homogeneity was real; loop-level
+  k-mer / cluster variation IS substantial but does not predict lysis. Update the context field.
+- Add a new unit `host-omp-variation-unpredictive` (dead-end) noting the four-arm test of host-side OMP
+  features produced null at k-mer, cross-term, and cluster granularities.
+- Reinforce `narrow-host-prior-collapse`: NILS53 +2.59 pp cross_term hit is an outlier (76th percentile
+  among peers at 12% lysis rate), not a reproducible rescue. Narrow-host collapse remains unresolved.
+
+#### Where the numbers live
+
+- Bootstrap CIs: `lyzortx/generated_outputs/sx13_eval/bootstrap_results.json`
+- Arm comparison: `lyzortx/generated_outputs/sx13_eval/arm_comparison.csv`
+- Per-arm predictions: `lyzortx/generated_outputs/sx13_eval/{arm}_predictions.csv`
+- Host OMP k-mer slot: `.scratch/host_omp_kmer/features.csv` (369 hosts × 5546 features)
+- Host OMP cluster slot: `.scratch/host_omp_cluster/features.csv` (369 hosts × 12 categoricals)
+- Per-host OMP protein sequences: `.scratch/host_omp_proteins/{host}/{omp}.faa`


### PR DESCRIPTION
## Summary

Built per-host OMP 5-mer features (369 hosts × 5546 across 12 core OMPs) and MMseqs2 99% cluster-ID fallback. Evaluated four arms via 10-fold bacteria-stratified CV with bootstrap CIs.

- **All four arms fail the +2 pp AUC gate** (max delta: cross_term AUC +0.26 pp)
- **Permutation test on cross_term aggregate: p ≈ 0.73** — signal indistinguishable from noise
- **NILS53 gains +2.59 pp nDCG under cross_term** but sits at 76th percentile of its lysis-rate peers (peer mean Δ = -0.001) — outlier, not reproducible rescue
- **Small directional signal in marginal arm for moderate-narrow deciles** (lysis 5-11%, mean +1-2 pp nDCG), not significant by sign test
- **Biological conclusion**: host OMP variation IS substantial (BTUB 28 clusters, OMPC 49) but does NOT predict strain-level lysis — host-range variance lives downstream of OMP recognition

## Changes

- `build_host_omp_kmer_slot.py`: phmmer best-hit extraction per (host, OMP), 5-mer enumeration with 5-95% frequency pruning
- `build_host_omp_cluster_slot.py`: MMseqs2 99% identity clustering of per-OMP host sequences, cluster IDs as categorical
- `sx13_eval.py`: four-arm evaluator with vectorized within-fold cross-term selection (two matrix multiplies, ~1 sec per fold)
- `track_SPANDEX.md`: SX13 notebook entry with all 4 arms, permutation test, per-decile stratification, NILS53 peer analysis
- `knowledge.yml` + `KNOWLEDGE.md`:
  - Refined `omp-score-homogeneity` to reflect the escalation-to-k-mers failure
  - Added `host-omp-variation-unpredictive` dead-end unit

## Test plan

- [x] Per-host OMP extraction ran on 369/369 hosts with 12/12 OMPs hit
- [x] K-mer slot: 5546 features retained with 5-95% frequency filter
- [x] Cluster slot: 6-49 clusters per OMP at 99% identity (OMPC 49 matches `receptor-variant-richness` claim of 50 OmpC variants)
- [x] SX13 eval: 4 arms × 10 folds × 3 seeds × 1000 bootstrap resamples completed
- [x] Case-by-case + permutation analysis confirms null

## Notes

- SX03 Arm C not evaluated (within-panel Δ ≤ +0.3 pp would not reach +2 pp on Arm C either; documented)
- Vectorized cross-term selection: first implementation used a Python loop that projected ~1 hr/fold. Refactored to two numpy matmuls exploiting binary feature structure — runs in ~1 sec/fold (>1000× speedup).

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)