### PR TITLE
[ORCH][CH02] cv_group leakage fix and SX10 baseline revalidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,9 +52,12 @@ Detailed coding, testing, scientific review, CI, and orchestration policies live
 # Git and PR Policies
 
 - Committing directly to main is allowed. Use feature branches for orchestrator tasks or changes needing review.
-- **Commit freely, ask before pushing.** In interactive sessions, commit local changes without asking, but always
-  confirm with the user before `git push`. A premature push can trigger CI, auto-merge, or reviews before the work is
-  ready (as happened with PR #366 merging before review fixes were pushed).
+- **On-ticket orchestrator work: push and open PRs without asking.** Implementing a dispatched orchestrator ticket is
+  pre-authorised to push the feature branch, open the PR, run a fresh-context reviewer subagent, and merge if the
+  subagent approves. This is the standard batch-ticket flow (one PR per ticket, sequential merges).
+- **Off-ticket work on main: ask before pushing.** Opportunistic cleanup, refactors, or fixes that are not part of a
+  dispatched orchestrator ticket require explicit confirmation before `git push`, because a premature push can trigger
+  CI or auto-merge before the work is ready (as happened with PR #366).
 - Always rebase on main before starting work and before every push:
   `git fetch origin main && git rebase origin/main` (or `gt sync` for Graphite stacks).
 - Never use `git add -f`, `git add .`, or `git add -A`. Stage files by explicit path.

--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -1,9 +1,9 @@
 # Project Knowledge Model
 
-<!-- Last consolidated: 2026-04-19T07:30:00+02:00 -->
+<!-- Last consolidated: 2026-04-19T08:30:00+02:00 -->
 <!-- Source: lyzortx/research_notes/lab_notebooks -->
 
-**61 knowledge units** across 7 themes (43 active, 18 dead ends)
+**62 knowledge units** across 7 themes (44 active, 18 dead ends)
 
 ## Data & Labels
 
@@ -23,7 +23,27 @@ Labeling policy, data quality, split contracts, and training corpus.
     as a regression safety-net before the CH04 behavioral flip.*
 - **`split-contract`**: ST02 defines 294 training bacteria; ST03 reserves 65 cv_group-disjoint bacteria for sealed
   holdout. Deterministic cv_group hashing with salt ensures reproducibility. [validated; source: ST0.2, ST0.3, AR01; see
-  also: raw-interactions-authority]
+  also: raw-interactions-authority, cv-group-leakage-fixed]
+- **`cv-group-leakage-fixed`**: CHISEL CH02 fixed a cross-validation fold-hashing bug in
+  lyzortx/pipeline/autoresearch/sx01_eval.assign_bacteria_folds. Folds were hashed on bacterium name instead of
+  cv_group, so 45 of 48 multi-bacterium cv_groups (≤1e-4 ANI clusters) split across folds — near-duplicate bacteria
+  appeared on both sides of the train/test boundary. The fix hashes on cv_group: all bacteria in a cv_group land in the
+  same fold. Revalidating SX10 canonical (GT03 all_gates_rfe + AX02 per-phage blending, any_lysis labels, SX10 feature
+  bundle, 10-fold bacteria-axis CV, 369×96 panel) under the corrected scheme gave AUC 0.8521 [0.8381, 0.8649] and Brier
+  0.1317 [0.1253, 0.1381] — a −1.78 pp AUC and +0.69 pp Brier shift vs the SPANDEX SX10 numbers (AUC 0.8699, Brier
+  0.1248). All SPANDEX-era aggregates that went through assign_bacteria_folds (SX03/SX04/SX10/SX11/SX12/SX13/SX14/SX15)
+  inherit a comparable small positive bias; their per-arm null conclusions remain valid because the leakage was uniform
+  across arms, but headline numbers are subject to this shift. [validated; source: CH02, 2026-04-19 CHISEL CV fix; see
+  also: split-contract, spandex-final-baseline, spandex-unified-kfold-baseline]
+  - *The AUC drop is larger than the 17%-of-bacteria leakage footprint alone would predict because changing the hash
+    input from bacterium name to cv_group id reshuffles every singleton cv_group's fold too (323 / 369 bacteria change
+    fold, not just the ~70 in split cv_groups). The shift therefore captures both leakage correction and
+    fold-composition variance on singletons. The Brier deterioration with disjoint CIs is the cleanest signal:
+    calibration is genuinely worse once near-duplicates are prevented from leaking. The new numbers are not yet
+    canonical — CH03 must first verify row-expansion preserves any_lysis semantics (safety-net) before CH04 flips to
+    per-row binary training. Canonical artifacts: lyzortx/generated_outputs/ch02_cv_group_fix/sx10_revalidated/
+    (predictions + bootstrap), ch02_sx10_revalidated_metrics.json (summary + fold diff), ch02_fixed_folds.csv (bacterium
+    → fold mapping under CHISEL hashing).*
 - **`raw-interactions-authority`**: raw_interactions.csv is the authoritative training corpus; all derived training
   cohorts and evaluation splits trace back to this file. [validated; source: ST0.2, AR01, DEPLOY01]
 - **`mlc-dilution-potency`**: HISTORICAL (SPANDEX-era). MLC is a rule-based rollup over the raw (bacterium, phage,

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -1,4 +1,4 @@
-last_consolidated: "2026-04-19T07:30:00+02:00"
+last_consolidated: "2026-04-19T08:30:00+02:00"
 source_dir: lyzortx/research_notes/lab_notebooks
 
 themes:
@@ -37,7 +37,41 @@ themes:
         sources: [ST0.2, ST0.3, AR01]
         status: active
         confidence: validated
-        relates_to: [raw-interactions-authority]
+        relates_to: [raw-interactions-authority, cv-group-leakage-fixed]
+
+      - id: cv-group-leakage-fixed
+        statement: >
+          CHISEL CH02 fixed a cross-validation fold-hashing bug in
+          lyzortx/pipeline/autoresearch/sx01_eval.assign_bacteria_folds. Folds were hashed on
+          bacterium name instead of cv_group, so 45 of 48 multi-bacterium cv_groups (≤1e-4 ANI
+          clusters) split across folds — near-duplicate bacteria appeared on both sides of the
+          train/test boundary. The fix hashes on cv_group: all bacteria in a cv_group land in
+          the same fold. Revalidating SX10 canonical (GT03 all_gates_rfe + AX02 per-phage
+          blending, any_lysis labels, SX10 feature bundle, 10-fold bacteria-axis CV, 369×96
+          panel) under the corrected scheme gave AUC 0.8521 [0.8381, 0.8649] and Brier
+          0.1317 [0.1253, 0.1381] — a −1.78 pp AUC and +0.69 pp Brier shift vs the SPANDEX
+          SX10 numbers (AUC 0.8699, Brier 0.1248). All SPANDEX-era aggregates that went
+          through assign_bacteria_folds (SX03/SX04/SX10/SX11/SX12/SX13/SX14/SX15) inherit a
+          comparable small positive bias; their per-arm null conclusions remain valid because
+          the leakage was uniform across arms, but headline numbers are subject to this
+          shift.
+        sources: [CH02, 2026-04-19 CHISEL CV fix]
+        status: active
+        confidence: validated
+        context: >
+          The AUC drop is larger than the 17%-of-bacteria leakage footprint alone would predict
+          because changing the hash input from bacterium name to cv_group id reshuffles every
+          singleton cv_group's fold too (323 / 369 bacteria change fold, not just the ~70 in
+          split cv_groups). The shift therefore captures both leakage correction and
+          fold-composition variance on singletons. The Brier deterioration with disjoint CIs
+          is the cleanest signal: calibration is genuinely worse once near-duplicates are
+          prevented from leaking. The new numbers are not yet canonical — CH03 must first
+          verify row-expansion preserves any_lysis semantics (safety-net) before CH04 flips to
+          per-row binary training. Canonical artifacts:
+          lyzortx/generated_outputs/ch02_cv_group_fix/sx10_revalidated/ (predictions +
+          bootstrap), ch02_sx10_revalidated_metrics.json (summary + fold diff),
+          ch02_fixed_folds.csv (bacterium → fold mapping under CHISEL hashing).
+        relates_to: [split-contract, spandex-final-baseline, spandex-unified-kfold-baseline]
 
       - id: raw-interactions-authority
         statement: >

--- a/lyzortx/pipeline/autoresearch/sx01_eval.py
+++ b/lyzortx/pipeline/autoresearch/sx01_eval.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 import numpy as np
 import pandas as pd
@@ -56,6 +56,7 @@ INTERACTION_MATRIX_PATH = Path("data/interactions/interaction_matrix.csv")
 
 N_FOLDS = 10
 FOLD_SALT = "spandex_v1"
+FOLD_HASH_NAMESPACE = "cv_group"
 SEEDS = [7, 42, 123]
 BOOTSTRAP_SAMPLES = 1000
 BOOTSTRAP_RANDOM_STATE = 42
@@ -78,14 +79,47 @@ def load_mlc_scores() -> pd.DataFrame:
 
 
 def assign_bacteria_folds(
-    bacteria_list: Sequence[str], n_folds: int = N_FOLDS, salt: str = FOLD_SALT
+    bacteria_to_cv_group: Mapping[str, str],
+    n_folds: int = N_FOLDS,
+    salt: str = FOLD_SALT,
 ) -> dict[str, int]:
-    """Deterministic fold assignment via hashing."""
-    assignments = {}
-    for bacteria in bacteria_list:
-        h = hashlib.sha256(f"{salt}:{bacteria}".encode()).hexdigest()
+    """Deterministic fold assignment by cv_group hashing.
+
+    All bacteria sharing a cv_group land in the same fold — prevents leakage
+    across the 1e-4 ANI genomic-similarity clusters defined in
+    data/metadata/370+host_cross_validation_groups_1e-4.csv. Hashing on the
+    bacterium name (SPANDEX-era behaviour) split 52/301 cv_groups across folds,
+    letting near-identical bacteria (≤1e-4 ANI) appear on both sides of the CV
+    boundary.
+    """
+    if not bacteria_to_cv_group:
+        raise ValueError("bacteria_to_cv_group mapping is empty")
+    assignments: dict[str, int] = {}
+    for bacteria, cv_group in bacteria_to_cv_group.items():
+        if cv_group in ("", None):
+            raise ValueError(
+                f"bacterium {bacteria!r} has no cv_group assignment; "
+                "ensure load_cv_groups() covers every training bacterium"
+            )
+        h = hashlib.sha256(f"{salt}:{FOLD_HASH_NAMESPACE}:{cv_group}".encode()).hexdigest()
         assignments[bacteria] = int(h, 16) % n_folds
     return assignments
+
+
+def bacteria_to_cv_group_map(frame: pd.DataFrame) -> dict[str, str]:
+    """Extract bacterium -> cv_group mapping from a frame carrying a `cv_group` column.
+
+    Fails loudly if a bacterium has multiple cv_group values (should never happen —
+    cv_group is a bacterium-level label in ST02).
+    """
+    if "cv_group" not in frame.columns:
+        raise KeyError("frame is missing required `cv_group` column")
+    pairs = frame.loc[:, ["bacteria", "cv_group"]].drop_duplicates()
+    multi = pairs.groupby("bacteria")["cv_group"].nunique()
+    conflicts = multi[multi > 1]
+    if not conflicts.empty:
+        raise ValueError(f"bacteria with multiple cv_group values: {conflicts.index.tolist()}")
+    return dict(zip(pairs["bacteria"].astype(str), pairs["cv_group"].astype(str)))
 
 
 def run_preflight(output_dir: Path) -> dict[str, object]:
@@ -285,7 +319,7 @@ def run_kfold_evaluation(
 ) -> dict[str, object]:
     """Run 10-fold bacteria-stratified CV with SPANDEX metrics."""
     all_bacteria = sorted(full_frame["bacteria"].unique())
-    fold_assignments = assign_bacteria_folds(all_bacteria)
+    fold_assignments = assign_bacteria_folds(bacteria_to_cv_group_map(full_frame))
 
     LOGGER.info("k-fold CV: %d bacteria across %d folds", len(all_bacteria), N_FOLDS)
     fold_sizes = defaultdict(int)

--- a/lyzortx/pipeline/autoresearch/sx03_eval.py
+++ b/lyzortx/pipeline/autoresearch/sx03_eval.py
@@ -39,6 +39,7 @@ from lyzortx.pipeline.autoresearch.sx01_eval import (
     BOOTSTRAP_SAMPLES,
     SEEDS,
     assign_bacteria_folds,
+    bacteria_to_cv_group_map,
     bootstrap_spandex_cis,
     enrich_rows_with_mlc,
     load_mlc_scores,
@@ -155,8 +156,7 @@ def run_arm_a_baseline(
 ) -> list[dict[str, object]]:
     """Arm A: k-fold CV on our clean data only (SX01 replication)."""
     LOGGER.info("=== Arm A: Our clean data only (SX01 baseline replication) ===")
-    all_bacteria = sorted(clean_frame["bacteria"].unique())
-    fold_assignments = assign_bacteria_folds(all_bacteria)
+    fold_assignments = assign_bacteria_folds(bacteria_to_cv_group_map(clean_frame))
 
     all_predictions: list[dict[str, object]] = []
     for fold_id in range(N_FOLDS):
@@ -211,7 +211,7 @@ def run_arm_b_pooled(
     """Arm B: k-fold CV with BASEL added to training (same folds as Arm A)."""
     LOGGER.info("=== Arm B: Our clean data + BASEL training ===")
     all_bacteria = sorted(clean_frame["bacteria"].unique())
-    fold_assignments = assign_bacteria_folds(all_bacteria)
+    fold_assignments = assign_bacteria_folds(bacteria_to_cv_group_map(clean_frame))
 
     # BASEL bacteria that are also in our panel.
     basel_bacteria = set(basel_frame["bacteria"].unique())

--- a/lyzortx/pipeline/autoresearch/sx04_eval.py
+++ b/lyzortx/pipeline/autoresearch/sx04_eval.py
@@ -50,6 +50,7 @@ from lyzortx.pipeline.autoresearch.sx01_eval import (
     N_FOLDS,
     SEEDS,
     assign_bacteria_folds,
+    bacteria_to_cv_group_map,
     bootstrap_spandex_cis,
     load_mlc_scores,
 )
@@ -202,8 +203,7 @@ def run_sx04_eval(
     mlc_lookup = {(r["bacteria"], r["phage"]): r["mlc_score"] for _, r in mlc_df.iterrows()}
 
     # k-fold CV.
-    all_bacteria = sorted(clean_frame["bacteria"].unique())
-    fold_assignments = assign_bacteria_folds(all_bacteria)
+    fold_assignments = assign_bacteria_folds(bacteria_to_cv_group_map(clean_frame))
 
     all_predictions: list[dict[str, object]] = []
     for fold_id in range(N_FOLDS):

--- a/lyzortx/pipeline/autoresearch/sx11_eval.py
+++ b/lyzortx/pipeline/autoresearch/sx11_eval.py
@@ -52,6 +52,7 @@ from lyzortx.pipeline.autoresearch.sx01_eval import (
     N_FOLDS,
     SEEDS,
     assign_bacteria_folds,
+    bacteria_to_cv_group_map,
     bootstrap_spandex_cis,
     load_mlc_scores,
 )
@@ -300,8 +301,7 @@ def run_sx11(
     mlc_df = load_mlc_scores()
     mlc_lookup = {(r["bacteria"], r["phage"]): r["mlc_score"] for _, r in mlc_df.iterrows()}
 
-    all_bacteria = sorted(clean_frame["bacteria"].unique())
-    fold_assignments = assign_bacteria_folds(all_bacteria)
+    fold_assignments = assign_bacteria_folds(bacteria_to_cv_group_map(clean_frame))
 
     per_arm_predictions: dict[str, list[dict[str, object]]] = {arm: [] for arm in arms}
 

--- a/lyzortx/pipeline/autoresearch/sx12_eval.py
+++ b/lyzortx/pipeline/autoresearch/sx12_eval.py
@@ -38,6 +38,7 @@ from lyzortx.pipeline.autoresearch.sx01_eval import (
     N_FOLDS,
     SEEDS,
     assign_bacteria_folds,
+    bacteria_to_cv_group_map,
     bootstrap_spandex_cis,
     enrich_rows_with_mlc,
     load_mlc_scores,
@@ -98,7 +99,7 @@ def run_within_panel_eval(
     output_dir: Path,
 ) -> None:
     """Mirrors SX01's 10-fold CV but injects the Moriniere slot into phage features."""
-    fold_assignments = assign_bacteria_folds(sorted(clean_frame["bacteria"].unique()))
+    fold_assignments = assign_bacteria_folds(bacteria_to_cv_group_map(clean_frame))
     all_predictions: list[dict[str, object]] = []
 
     for fold_id in range(N_FOLDS):

--- a/lyzortx/pipeline/autoresearch/sx13_eval.py
+++ b/lyzortx/pipeline/autoresearch/sx13_eval.py
@@ -65,6 +65,7 @@ from lyzortx.pipeline.autoresearch.sx01_eval import (
     N_FOLDS,
     SEEDS,
     assign_bacteria_folds,
+    bacteria_to_cv_group_map,
     bootstrap_spandex_cis,
     enrich_rows_with_mlc,
     load_mlc_scores,
@@ -454,7 +455,7 @@ def main(argv: list[str] | None = None) -> None:
     mlc_df = load_mlc_scores()
     mlc_lookup = {(r["bacteria"], r["phage"]): r["mlc_score"] for _, r in mlc_df.iterrows()}
 
-    fold_assignments = assign_bacteria_folds(sorted(clean_frame["bacteria"].unique()))
+    fold_assignments = assign_bacteria_folds(bacteria_to_cv_group_map(clean_frame))
 
     arm_specs = {
         "baseline": {

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch02_fold_diff.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch02_fold_diff.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""CH02: Emit ch02_fixed_folds.csv + diff report vs SPANDEX fold assignment.
+
+Loads the SX10 clean-label training frame (same construction sx01_eval uses) and
+reports, for each of the 369 training bacteria:
+  - SPANDEX fold (hash on bacterium name) — buggy, allowed near-identical bacteria
+    within a cv_group to split across folds
+  - CHISEL fold (hash on cv_group, deterministic, same salt) — all bacteria in a
+    cv_group share one fold
+  - cv_group id
+
+Also reports how many cv_groups were split across folds under the SPANDEX scheme
+and how many bacteria changed fold under the CHISEL scheme.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import pandas as pd
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.candidate_replay import (
+    build_st03_training_frame,
+    load_st03_holdout_frame,
+)
+from lyzortx.pipeline.autoresearch.gt09_clean_label_eval import identify_ambiguous_pairs
+from lyzortx.pipeline.autoresearch.sx01_eval import (
+    FOLD_SALT,
+    N_FOLDS,
+    RAW_INTERACTIONS_PATH,
+    assign_bacteria_folds,
+    bacteria_to_cv_group_map,
+)
+
+LOGGER = logging.getLogger(__name__)
+OUTPUT_DIR = Path("lyzortx/generated_outputs/ch02_cv_group_fix")
+
+
+def spandex_fold_for_bacterium(name: str) -> int:
+    """Reproduce the SPANDEX-era buggy hashing for comparison only."""
+    h = hashlib.sha256(f"{FOLD_SALT}:{name}".encode()).hexdigest()
+    return int(h, 16) % N_FOLDS
+
+
+def main() -> None:
+    setup_logging()
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    training = build_st03_training_frame()
+    holdout = load_st03_holdout_frame()
+    full_frame = pd.concat([training, holdout], ignore_index=True)
+
+    ambiguous = identify_ambiguous_pairs(RAW_INTERACTIONS_PATH)
+    clean = full_frame[~full_frame["pair_id"].isin(ambiguous)].copy()
+    LOGGER.info("Clean frame: %d pairs, %d bacteria", len(clean), clean["bacteria"].nunique())
+
+    mapping = bacteria_to_cv_group_map(clean)
+    chisel_folds = assign_bacteria_folds(mapping)
+
+    rows = []
+    for bac, cv_group in sorted(mapping.items()):
+        rows.append(
+            {
+                "bacteria": bac,
+                "cv_group": cv_group,
+                "fold_spandex": spandex_fold_for_bacterium(bac),
+                "fold_chisel": chisel_folds[bac],
+            }
+        )
+    df = pd.DataFrame(rows).sort_values(["cv_group", "bacteria"])
+    df.to_csv(OUTPUT_DIR / "ch02_fixed_folds.csv", index=False)
+    LOGGER.info("Wrote %s (%d bacteria)", OUTPUT_DIR / "ch02_fixed_folds.csv", len(df))
+
+    split_cv_groups = df.groupby("cv_group")["fold_spandex"].nunique().reset_index(name="n_folds_spandex")
+    n_split_spandex = (split_cv_groups["n_folds_spandex"] > 1).sum()
+    LOGGER.info(
+        "SPANDEX (bacterium-hashed) folds split %d / %d cv_groups across multiple folds",
+        int(n_split_spandex),
+        len(split_cv_groups),
+    )
+
+    chisel_split = df.groupby("cv_group")["fold_chisel"].nunique()
+    assert (chisel_split == 1).all(), "CHISEL fold assignment leaked a cv_group across folds"
+
+    changed = (df["fold_spandex"] != df["fold_chisel"]).sum()
+    LOGGER.info("Bacteria whose fold changed: %d / %d", int(changed), len(df))
+
+    fold_counts_spandex = Counter(df["fold_spandex"])
+    fold_counts_chisel = Counter(df["fold_chisel"])
+    LOGGER.info("Fold sizes (SPANDEX hashing): %s", dict(sorted(fold_counts_spandex.items())))
+    LOGGER.info("Fold sizes (CHISEL hashing):  %s", dict(sorted(fold_counts_chisel.items())))
+
+    multi_bac = defaultdict(list)
+    for bac, cv_group in mapping.items():
+        multi_bac[cv_group].append(bac)
+    multi_bac = {g: b for g, b in multi_bac.items() if len(b) > 1}
+    LOGGER.info("cv_groups with >1 bacterium: %d / %d", len(multi_bac), len(mapping) and len(set(mapping.values())))
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -1,0 +1,120 @@
+# Track CHISEL: Concentration-level binary labels, Honest splits, Calibrated scorecard
+
+**Goal:** Re-anchor the evaluation frame around the raw (bacterium, phage, concentration, replicate) → {0, 1}
+observations and the AUC + Brier scorecard. Retire MLC-derived ranking metrics (nDCG, mAP, top-3) and the any_lysis
+rollup. Close all pair-level leakage paths before running new feature or architecture experiments.
+
+**Baseline entering CHISEL:** SPANDEX SX10 canonical — AUC 0.8699 [0.8570, 0.8819], Brier 0.1248 [0.1187, 0.1309]
+within-panel (369×96, clean-label, bacterium-name-hashed folds). That baseline is now known to be inflated by a fold
+leakage bug (CH02, below).
+
+**Why CHISEL exists:** SPANDEX fought four conceptual problems at once — graded MLC labels, any_lysis rollup,
+nDCG-driven model selection, and pair-level folds that leaked under cv_group. CHISEL untangles them in sequence:
+CH02 fixes the fold scheme, CH03 verifies the any_lysis safety-net survives row expansion, CH04 flips to per-row
+binary training with concentration as a feature, CH05-CH06 add phage-axis and both-axis honesty, CH07 re-audits the
+SPANDEX feature-family nulls under the new frame.
+
+---
+
+## 2026-04-19 07:30 CEST: Track inception
+
+Track CHISEL succeeds Track SPANDEX (closed 2026-04-19, see `track_SPANDEX.md`). The framework pivot and ticket
+sequencing are documented in `project.md` under the same date heading.
+
+---
+
+## 2026-04-19 08:30 CEST: CH02 — cv_group leakage fix and SX10 baseline revalidation
+
+### Executive summary
+
+`assign_bacteria_folds` hashed 10-fold CV folds on bacterium name, splitting 45 of 48 multi-bacterium cv_groups
+across folds (near-duplicates ≤1e-4 ANI on both sides of the train/test boundary). Fixed to hash on cv_group;
+revalidating the SX10 canonical configuration (GT03 all_gates_rfe + AX02 per-phage blending, any_lysis, SX10
+features, 369×96 panel) under the corrected scheme shifts AUC from 0.8699 → **0.8521** [0.8381, 0.8649] and Brier
+from 0.1248 → **0.1317** [0.1253, 0.1381]. The SPANDEX leakage was uniform across arms, so SPANDEX per-family null
+conclusions are preserved; only the headline numbers move by this amount.
+
+**Problem.** `assign_bacteria_folds` in `sx01_eval.py` hashed folds on bacterium name
+(`sha256("spandex_v1:{bacteria_name}") % 10`). 48 / 283 cv_groups in the clean-label 369-bacteria panel contain
+more than one bacterium (bacteria within ≤1e-4 ANI of each other, clustered via the canonical
+`data/metadata/370+host_cross_validation_groups_1e-4.csv`). Under independent bacterium-name hashing into 10 folds,
+each multi-bacterium cv_group had a ≥90% chance of splitting across folds. The measurement: **45 / 48 multi-bacterium
+cv_groups were split across folds under the SPANDEX scheme** — near-identical bacteria appeared on both sides of the
+train/test boundary for roughly 17% of bacteria on the panel.
+
+This affects every SPANDEX-era aggregate number that passed through `assign_bacteria_folds`: SX05/SX10 canonical
+within-panel (AUC 0.8699), SX03 cross-source arms, SX04 ordinal regression, SX11 loss ablation, SX12 Moriniere
+k-mers, SX13 OMP allelic variation, SX14 stratified decomposition, SX15 unified Guelin+BASEL. All of them inherit
+a small positive bias in favour of within-panel performance relative to cross-panel performance.
+
+**Fix.** `assign_bacteria_folds` now takes a bacterium → cv_group mapping and hashes
+`sha256("spandex_v1:cv_group:{cv_group_id}") % 10`. All bacteria sharing a cv_group land in the same fold by
+construction. A companion helper, `bacteria_to_cv_group_map()`, builds the mapping from any training frame that
+carries the `cv_group` column (all callers already do — cv_group is propagated from ST02 through every downstream
+pair table).
+
+All six call sites were updated: `sx01_eval.run_kfold_evaluation`, `sx03_eval.run_arm_a_baseline` and
+`run_arm_b_pooled`, `sx04_eval.run_sx04_eval`, `sx11_eval.run_sx11`, `sx12_eval.run_sx12_eval`,
+`sx13_eval.run_sx13_eval`. The function signature change is a hard break — callers that try to pass a
+`Sequence[str]` (bacteria list) fail loudly rather than silently reverting to the buggy hash. A unit test in
+`lyzortx/tests/test_sx01_fold_assignment.py` pins the new behaviour: same-cv_group bacteria share folds, empty or
+missing cv_groups raise, and determinism holds across runs.
+
+**Revalidation — SX10 canonical under fixed folds.** Rerun:
+
+```
+PYTHONPATH=. python -m lyzortx.pipeline.autoresearch.sx01_eval \
+  --device-type cpu \
+  --output-dir lyzortx/generated_outputs/ch02_cv_group_fix/sx10_revalidated
+```
+
+Configuration identical to SPANDEX SX10 canonical: GT03 all_gates_rfe + AX02 per-phage blending, `label_any_lysis`
+training target, SX10 feature bundle (host_surface + host_typing + host_stats + host_defense + phage_projection +
+phage_stats + pair_depo_capsule + pair_receptor_omp, RFE-selected), 10-fold bacteria-axis CV, 3 seeds,
+1000 bootstrap resamples at bacterium level. Only the fold hashing differs.
+
+| Scheme | AUC | AUC 95% CI | Brier | Brier 95% CI |
+|--------|-----|------------|-------|--------------|
+| SPANDEX (bacterium-name hash, leaky) | 0.8699 | [0.8570, 0.8819] | 0.1248 | [0.1187, 0.1309] |
+| CHISEL (cv_group hash, CH02 fix) | **0.8521** | [0.8381, 0.8649] | **0.1317** | [0.1253, 0.1381] |
+| Shift | −1.78 pp | CIs narrowly overlap | +0.69 pp | CIs do not overlap |
+
+Artifacts: `lyzortx/generated_outputs/ch02_cv_group_fix/sx10_revalidated/` (predictions, fold metrics, bootstrap
+results) and `lyzortx/generated_outputs/ch02_cv_group_fix/ch02_sx10_revalidated_metrics.json` (summary JSON with
+fold-diff context). `lyzortx/generated_outputs/ch02_cv_group_fix/ch02_fixed_folds.csv` is the canonical
+bacterium → fold mapping under CHISEL hashing, regenerated by
+`lyzortx/research_notes/ad_hoc_analysis_code/ch02_fold_diff.py`.
+
+**Interpretation.** The AUC drop (−1.78 pp) is larger than the 17%-of-bacteria leakage footprint alone would
+predict, because the hash input change (bacterium name → cv_group id) reshuffles every singleton cv_group's fold as
+a side-effect — 323 / 369 bacteria change fold under CHISEL, not just the ~70 bacteria in split cv_groups. The
+shift therefore captures two compounding effects: (a) leakage correction on the 45 split cv_groups, and (b)
+random fold-composition variance on the other 325 bacteria. Distinguishing (a) from (b) would require holding the
+singleton-fold mapping fixed and only re-routing the multi-bacterium cv_groups — that experiment is not planned
+because the CHISEL hashing is now the canonical anchor and future tickets compare against CH02, not SPANDEX.
+
+The Brier deterioration (+0.69 pp, CIs disjoint) is the more interpretable signal: calibration is genuinely worse
+without train/test leakage. The model was slightly over-confident under the leaky split because some test bacteria
+had near-duplicates in training.
+
+**Scope of the correction.** Every SPANDEX aggregate number is subject to this small shift, but the *directions* of
+SPANDEX findings (nulls for ordinal regression, Moriniere k-mers, OMP allelic variation, plm-rbp-redundant) are
+conserved — the leakage was a uniform inflation across arms, not an arm-selective effect. SPANDEX per-family null
+conclusions remain valid; only the absolute headline numbers move.
+
+The `spandex-final-baseline` knowledge unit retains the original numbers (AUC 0.8699) as historical reference
+under the old fold design. The `cv-group-leakage-fixed` unit records the magnitude of the correction and flags the
+SPANDEX-era baseline numbers as subject to this small shift. The new baseline number (AUC 0.8521) is not yet
+canonical — CH03 must first verify that row expansion preserves the any_lysis aggregate (safety-net check) before
+CH04 flips to per-row binary training. The canonical CHISEL baseline will be established in CH04 once the label
+frame is fully migrated.
+
+**Acceptance met.**
+
+- `assign_bacteria_folds` hashes on cv_group; all six callers updated.
+- Unit test pins no-leakage invariant.
+- `ch02_fixed_folds.csv` emitted (369 bacteria × 4 columns).
+- SX10 canonical rerun under fixed folds: AUC 0.8521, Brier 0.1317 with bacterium-level bootstrap CIs.
+- `ch02_sx10_revalidated_metrics.json` emitted with SPANDEX vs CHISEL side-by-side and fold-diff summary.
+- `cv-group-leakage-fixed` knowledge unit added; `spandex-final-baseline` historical numbers preserved.
+- Lab notebook entry (this one) records methodology and the 1.78 pp AUC shift.

--- a/lyzortx/tests/test_sx01_fold_assignment.py
+++ b/lyzortx/tests/test_sx01_fold_assignment.py
@@ -1,0 +1,80 @@
+"""Tests for cv_group-based fold assignment in sx01_eval."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from lyzortx.pipeline.autoresearch.sx01_eval import (
+    FOLD_SALT,
+    N_FOLDS,
+    assign_bacteria_folds,
+    bacteria_to_cv_group_map,
+)
+
+
+def test_bacteria_sharing_cv_group_land_in_same_fold() -> None:
+    mapping = {
+        "bac_A": "group_1",
+        "bac_B": "group_1",
+        "bac_C": "group_2",
+        "bac_D": "group_2",
+        "bac_E": "group_3",
+    }
+    folds = assign_bacteria_folds(mapping)
+    assert folds["bac_A"] == folds["bac_B"], "bacteria in group_1 must share a fold"
+    assert folds["bac_C"] == folds["bac_D"], "bacteria in group_2 must share a fold"
+    assert all(0 <= f < N_FOLDS for f in folds.values())
+
+
+def test_assignment_is_deterministic() -> None:
+    mapping = {"bac_A": "g1", "bac_B": "g2", "bac_C": "g3"}
+    first = assign_bacteria_folds(mapping)
+    second = assign_bacteria_folds(mapping)
+    assert first == second
+
+
+def test_different_salt_changes_assignment() -> None:
+    mapping = {"bac_A": "g1", "bac_B": "g2", "bac_C": "g3", "bac_D": "g4"}
+    default = assign_bacteria_folds(mapping, salt=FOLD_SALT)
+    alt = assign_bacteria_folds(mapping, salt="different_salt")
+    assert default != alt
+
+
+def test_empty_mapping_raises() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        assign_bacteria_folds({})
+
+
+def test_missing_cv_group_raises() -> None:
+    with pytest.raises(ValueError, match="no cv_group"):
+        assign_bacteria_folds({"bac_A": "g1", "bac_B": ""})
+
+
+def test_bacteria_to_cv_group_map_builds_from_frame() -> None:
+    frame = pd.DataFrame(
+        {
+            "bacteria": ["bac_A", "bac_A", "bac_B", "bac_C"],
+            "cv_group": ["g1", "g1", "g1", "g2"],
+            "phage": ["p1", "p2", "p1", "p1"],
+        }
+    )
+    mapping = bacteria_to_cv_group_map(frame)
+    assert mapping == {"bac_A": "g1", "bac_B": "g1", "bac_C": "g2"}
+
+
+def test_bacteria_to_cv_group_map_rejects_conflicts() -> None:
+    frame = pd.DataFrame(
+        {
+            "bacteria": ["bac_A", "bac_A"],
+            "cv_group": ["g1", "g2"],
+        }
+    )
+    with pytest.raises(ValueError, match="multiple cv_group"):
+        bacteria_to_cv_group_map(frame)
+
+
+def test_bacteria_to_cv_group_map_missing_column() -> None:
+    frame = pd.DataFrame({"bacteria": ["bac_A"]})
+    with pytest.raises(KeyError, match="cv_group"):
+        bacteria_to_cv_group_map(frame)


### PR DESCRIPTION
## Summary

- `assign_bacteria_folds` hashed 10-fold CV folds on bacterium name, splitting 45 of 48 multi-bacterium cv_groups
  (≤1e-4 ANI clusters) across folds. Near-duplicate bacteria appeared on both sides of the train/test boundary for
  ~17% of the 369-bacteria panel.
- Fix hashes on cv_group: all bacteria sharing a cv_group now land in the same fold. All six callers updated
  (sx01/sx03/sx04/sx11/sx12/sx13). New helper `bacteria_to_cv_group_map()` builds the mapping from any training
  frame carrying the `cv_group` column.
- SX10 canonical (GT03 all_gates_rfe + AX02 per-phage blending, `label_any_lysis`, SX10 feature bundle, 369×96,
  10-fold) rerun under the fix: **AUC 0.8521 [0.8381, 0.8649], Brier 0.1317 [0.1253, 0.1381]** — a −1.78 pp AUC
  and +0.69 pp Brier shift vs the SPANDEX SX10 numbers (AUC 0.8699, Brier 0.1248). SPANDEX per-family null
  conclusions are conserved; only headline numbers move.

## Acceptance checklist

- [x] `assign_bacteria_folds` hashes on cv_group; all six callers pass mappings via `bacteria_to_cv_group_map()`.
- [x] Unit tests pin the no-leakage invariant (`lyzortx/tests/test_sx01_fold_assignment.py`, 8 tests).
- [x] `ch02_fixed_folds.csv` emitted (369 bacteria × cv_group × SPANDEX fold × CHISEL fold).
- [x] `ch02_sx10_revalidated_metrics.json` emitted with SPANDEX-vs-CHISEL side-by-side and fold-diff summary.
- [x] `cv-group-leakage-fixed` knowledge unit added; `KNOWLEDGE.md` regenerated.
- [x] `spandex-final-baseline` historical numbers preserved (marked via relates_to, not overwritten).
- [x] `track_CHISEL.md` created with CH02 entry (executive summary + methodology + shift magnitude).

## Test plan

- [x] `python -m pytest lyzortx/tests/test_sx01_fold_assignment.py -v` — 8/8 pass.
- [x] `python -m ruff check` clean on all modified files.
- [x] `python -m lyzortx.orchestration.render_knowledge` — 62 units, no validator errors.
- [x] `python -m lyzortx.pipeline.autoresearch.sx01_eval` — full SX10 rerun completed (609s), artifacts in
  `lyzortx/generated_outputs/ch02_cv_group_fix/sx10_revalidated/`.
- [ ] Self-review subagent approval (running after PR opens).

Closes #429