### PR TITLE
[ORCH][CH03] Row-expanded training matrix with preserved any_lysis semantics

### DIFF
--- a/lyzortx/pipeline/autoresearch/ch03_eval.py
+++ b/lyzortx/pipeline/autoresearch/ch03_eval.py
@@ -56,15 +56,15 @@ REGRESSION_TOLERANCE = 0.005
 
 
 def check_row_level_fold_integrity(row_frame: pd.DataFrame, pair_level_frame: pd.DataFrame) -> None:
-    """Assert the CH02 cv_group hash keeps every raw observation of a bacterium in one fold.
+    """Verify no (pair, log_dilution, replicate) row appears in both train and test of any fold.
 
-    The pair-level frame carries cv_group; the row-expanded frame inherits it via the
-    pair_id join. Because the fold-assignment function (CH02) hashes on cv_group, two
-    bacteria sharing a cv_group always share a fold. This function re-derives the
-    bacterium → fold mapping on the pair-level frame, then verifies that every row of
-    a given bacterium on the row-expanded frame routes to the same fold.
+    Partitions the row-expanded frame into per-fold train / test subsets using the CH02
+    cv_group hash and asserts disjointness on the raw-observation key. This is the
+    load-bearing CH03 invariant check: the acceptance criterion `no (pair, concentration,
+    replicate) row appears in both train and test` must hold for every fold, otherwise
+    CH04's per-row training would leak observations across the split.
     """
-    from lyzortx.pipeline.autoresearch.sx01_eval import assign_bacteria_folds
+    from lyzortx.pipeline.autoresearch.sx01_eval import N_FOLDS, assign_bacteria_folds
 
     mapping = bacteria_to_cv_group_map(pair_level_frame)
     fold_assignments = assign_bacteria_folds(mapping)
@@ -74,17 +74,34 @@ def check_row_level_fold_integrity(row_frame: pd.DataFrame, pair_level_frame: pd
         unassigned = rows_with_fold[rows_with_fold["fold_id"].isna()]["bacteria"].unique()
         raise ValueError(f"{len(unassigned)} bacteria missing fold assignment: {unassigned[:5].tolist()}")
 
-    # Every row with a given pair_id must route to exactly one fold_id.
-    per_pair_folds = rows_with_fold.groupby("pair_id")["fold_id"].nunique()
-    violating = per_pair_folds[per_pair_folds > 1]
-    if not violating.empty:
-        raise ValueError(f"{len(violating)} pair_ids routed to multiple folds — row-level leakage across splits")
+    observation_key_cols = ["pair_id", "log_dilution", "replicate"]
+    row_keys = pd.MultiIndex.from_frame(rows_with_fold[observation_key_cols])
+    if not row_keys.is_unique:
+        duplicates = rows_with_fold[row_keys.duplicated(keep=False)]
+        raise ValueError(
+            f"raw frame has duplicate (pair_id, log_dilution, replicate) rows — "
+            f"{len(duplicates)} rows with shared keys (example: {duplicates.head(3).to_dict(orient='records')})"
+        )
+
+    for fold_id in range(N_FOLDS):
+        fold_mask = rows_with_fold["fold_id"] == fold_id
+        train_keys = pd.MultiIndex.from_frame(rows_with_fold.loc[~fold_mask, observation_key_cols])
+        test_keys = pd.MultiIndex.from_frame(rows_with_fold.loc[fold_mask, observation_key_cols])
+        overlap = train_keys.intersection(test_keys)
+        if len(overlap) > 0:
+            raise ValueError(
+                f"fold {fold_id}: {len(overlap)} (pair, log_dilution, replicate) rows "
+                f"appear in both train and test partitions (example: {overlap[:3].tolist()})"
+            )
+
     LOGGER.info(
-        "Fold integrity verified: %d raw rows / %d pairs / %d bacteria route to %d folds",
+        "Fold integrity verified: %d raw rows / %d pairs / %d bacteria route to %d folds, "
+        "train and test disjoint on (pair_id, log_dilution, replicate) across all %d folds",
         len(row_frame),
         row_frame["pair_id"].nunique(),
         rows_with_fold["bacteria"].nunique(),
         rows_with_fold["fold_id"].nunique(),
+        N_FOLDS,
     )
 
 

--- a/lyzortx/pipeline/autoresearch/ch03_eval.py
+++ b/lyzortx/pipeline/autoresearch/ch03_eval.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""CH03: Safety-net SX10 rerun on the row-expanded training frame.
+
+Loads the row-expanded raw-observation frame (see `ch03_row_expansion`), collapses
+rows back to pair level with any_lysis semantics, and runs the SX10 canonical
+configuration (GT03 all_gates_rfe + AX02 per-phage blending, any_lysis labels,
+SX10 feature bundle) under the CH02-fixed cv_group folds. Must reproduce the
+CH02 revalidated numbers (AUC 0.8521, Brier 0.1317) within 0.005 — otherwise the
+row-expansion plumbing has introduced a bug that would contaminate CH04's per-row
+training.
+
+Integrity guarantee: because all rows of a given bacterium are routed to the
+same fold by the CH02 cv_group hash, no (pair, concentration, replicate) raw
+observation can appear in both the train and test partition of a fold.
+
+Usage:
+    PYTHONPATH=. python -m lyzortx.pipeline.autoresearch.ch03_eval --device-type cpu
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.candidate_replay import (
+    load_module_from_path,
+    safe_round,
+)
+from lyzortx.pipeline.autoresearch.ch03_row_expansion import (
+    collapse_to_pair_level_for_training,
+    load_row_expanded_frame,
+    verify_rollup_matches_st02,
+)
+from lyzortx.pipeline.autoresearch.gt09_clean_label_eval import identify_ambiguous_pairs
+from lyzortx.pipeline.autoresearch.sx01_eval import (
+    RAW_INTERACTIONS_PATH,
+    bacteria_to_cv_group_map,
+    load_mlc_scores,
+    run_kfold_evaluation,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CACHE_DIR = Path("lyzortx/generated_outputs/autoresearch/search_cache_v1")
+DEFAULT_CANDIDATE_DIR = Path("lyzortx/autoresearch")
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/ch03_row_expansion")
+
+CH02_REVALIDATED_METRICS_PATH = Path("lyzortx/generated_outputs/ch02_cv_group_fix/ch02_sx10_revalidated_metrics.json")
+REGRESSION_TOLERANCE = 0.005
+
+
+def check_row_level_fold_integrity(row_frame: pd.DataFrame, pair_level_frame: pd.DataFrame) -> None:
+    """Assert the CH02 cv_group hash keeps every raw observation of a bacterium in one fold.
+
+    The pair-level frame carries cv_group; the row-expanded frame inherits it via the
+    pair_id join. Because the fold-assignment function (CH02) hashes on cv_group, two
+    bacteria sharing a cv_group always share a fold. This function re-derives the
+    bacterium → fold mapping on the pair-level frame, then verifies that every row of
+    a given bacterium on the row-expanded frame routes to the same fold.
+    """
+    from lyzortx.pipeline.autoresearch.sx01_eval import assign_bacteria_folds
+
+    mapping = bacteria_to_cv_group_map(pair_level_frame)
+    fold_assignments = assign_bacteria_folds(mapping)
+
+    rows_with_fold = row_frame.assign(fold_id=row_frame["bacteria"].map(fold_assignments))
+    if rows_with_fold["fold_id"].isna().any():
+        unassigned = rows_with_fold[rows_with_fold["fold_id"].isna()]["bacteria"].unique()
+        raise ValueError(f"{len(unassigned)} bacteria missing fold assignment: {unassigned[:5].tolist()}")
+
+    # Every row with a given pair_id must route to exactly one fold_id.
+    per_pair_folds = rows_with_fold.groupby("pair_id")["fold_id"].nunique()
+    violating = per_pair_folds[per_pair_folds > 1]
+    if not violating.empty:
+        raise ValueError(f"{len(violating)} pair_ids routed to multiple folds — row-level leakage across splits")
+    LOGGER.info(
+        "Fold integrity verified: %d raw rows / %d pairs / %d bacteria route to %d folds",
+        len(row_frame),
+        row_frame["pair_id"].nunique(),
+        rows_with_fold["bacteria"].nunique(),
+        rows_with_fold["fold_id"].nunique(),
+    )
+
+
+def load_ch02_baseline_metrics() -> dict[str, float]:
+    if not CH02_REVALIDATED_METRICS_PATH.exists():
+        raise FileNotFoundError(
+            f"CH02 baseline metrics not found: {CH02_REVALIDATED_METRICS_PATH}. Run CH02 first (see track_CHISEL.md)."
+        )
+    with open(CH02_REVALIDATED_METRICS_PATH, encoding="utf-8") as f:
+        data = json.load(f)
+    return {
+        "auc": data["chisel_fixed_folds"]["holdout_roc_auc"]["point_estimate"],
+        "brier": data["chisel_fixed_folds"]["holdout_brier_score"]["point_estimate"],
+    }
+
+
+def run_ch03_eval(
+    *,
+    device_type: str,
+    output_dir: Path,
+    cache_dir: Path,
+    candidate_dir: Path,
+) -> dict[str, object]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    start_time = datetime.now(timezone.utc)
+
+    LOGGER.info("CH03 evaluation starting at %s", start_time.isoformat())
+    row_frame = load_row_expanded_frame()
+
+    rollup_summary = verify_rollup_matches_st02(row_frame)
+    LOGGER.info("Rollup-vs-ST02 check: %s", rollup_summary)
+    if rollup_summary["n_mismatches"] != 0:
+        raise AssertionError(
+            f"ST01B rollup disagrees with ST02 on {rollup_summary['n_mismatches']} pairs — "
+            "row-expansion does not preserve any_lysis semantics"
+        )
+
+    pair_frame = collapse_to_pair_level_for_training(row_frame)
+    check_row_level_fold_integrity(row_frame, pair_frame)
+
+    # Persist the row-expanded frame artifact (CH04 reuses this). CSV keeps the
+    # environment dependency-free — pyarrow/fastparquet not required.
+    expanded_path = output_dir / "ch03_expanded_training_frame.csv"
+    row_frame.to_csv(expanded_path, index=False)
+    LOGGER.info("Wrote row-expanded frame: %s (%d rows)", expanded_path, len(row_frame))
+
+    # Mirror sx01_eval's clean-label + split filtering on the collapsed pair frame.
+    pair_frame["label_any_lysis"] = pair_frame["label_hard_any_lysis"]
+    training = pair_frame[
+        (pair_frame["split_holdout"] == "train_non_holdout") & (pair_frame["is_hard_trainable"] == "1")
+    ].copy()
+    holdout = pair_frame[
+        (pair_frame["split_holdout"] == "holdout_test") & (pair_frame["is_hard_trainable"] == "1")
+    ].copy()
+    full_frame = pd.concat([training, holdout], ignore_index=True)
+    LOGGER.info(
+        "CH03 pair-level frame: %d training, %d holdout, %d bacteria",
+        len(training),
+        len(holdout),
+        full_frame["bacteria"].nunique(),
+    )
+
+    ambiguous_pairs = identify_ambiguous_pairs(RAW_INTERACTIONS_PATH)
+    clean_frame = full_frame[~full_frame["pair_id"].isin(ambiguous_pairs)].copy()
+    LOGGER.info(
+        "Clean-label CH03 frame: %d pairs (%d excluded), %d bacteria",
+        len(clean_frame),
+        len(full_frame) - len(clean_frame),
+        clean_frame["bacteria"].nunique(),
+    )
+
+    mlc_df = load_mlc_scores()
+    mlc_lookup = {(r["bacteria"], r["phage"]): r["mlc_score"] for _, r in mlc_df.iterrows()}
+
+    candidate_module = load_module_from_path("ch03_candidate", candidate_dir / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=cache_dir, include_host_defense=True)
+
+    kfold_output_dir = output_dir / "sx10_on_row_expanded"
+    run_kfold_evaluation(
+        candidate_module=candidate_module,
+        context=context,
+        full_frame=clean_frame,
+        mlc_lookup=mlc_lookup,
+        device_type=device_type,
+        output_dir=kfold_output_dir,
+    )
+
+    with open(kfold_output_dir / "bootstrap_results.json", encoding="utf-8") as f:
+        bootstrap = json.load(f)
+    ch03_auc = float(bootstrap["holdout_roc_auc"]["point_estimate"])
+    ch03_brier = float(bootstrap["holdout_brier_score"]["point_estimate"])
+
+    baseline = load_ch02_baseline_metrics()
+    delta_auc = ch03_auc - baseline["auc"]
+    delta_brier = ch03_brier - baseline["brier"]
+    passed = abs(delta_auc) < REGRESSION_TOLERANCE and abs(delta_brier) < REGRESSION_TOLERANCE
+
+    regression = {
+        "task_id": "CH03",
+        "baseline_source": str(CH02_REVALIDATED_METRICS_PATH),
+        "ch02_revalidated": baseline,
+        "ch03_row_expanded": {"auc": safe_round(ch03_auc), "brier": safe_round(ch03_brier)},
+        "delta": {"auc": safe_round(delta_auc), "brier": safe_round(delta_brier)},
+        "tolerance": REGRESSION_TOLERANCE,
+        "passed": passed,
+        "rollup_vs_st02": rollup_summary,
+        "n_raw_observations": int(len(row_frame)),
+        "n_pairs": int(row_frame["pair_id"].nunique()),
+        "elapsed_seconds": round((datetime.now(timezone.utc) - start_time).total_seconds(), 1),
+    }
+    regression_path = output_dir / "ch03_regression_check.json"
+    with open(regression_path, "w", encoding="utf-8") as f:
+        json.dump(regression, f, indent=2)
+    LOGGER.info("Regression check: %s (wrote %s)", "PASS" if passed else "FAIL", regression_path)
+
+    if not passed:
+        raise AssertionError(
+            f"Regression tolerance exceeded: delta_auc={delta_auc:.4f}, "
+            f"delta_brier={delta_brier:.4f} (tolerance={REGRESSION_TOLERANCE})"
+        )
+    return regression
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device-type", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--candidate-dir", type=Path, default=DEFAULT_CANDIDATE_DIR)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+    run_ch03_eval(
+        device_type=args.device_type,
+        output_dir=args.output_dir,
+        cache_dir=args.cache_dir,
+        candidate_dir=args.candidate_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/pipeline/autoresearch/ch03_row_expansion.py
+++ b/lyzortx/pipeline/autoresearch/ch03_row_expansion.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""CH03: Row-expanded training matrix loader and any_lysis rollup scaffolding.
+
+Builds a (bacterium, phage, log_dilution, replicate, X, Y) row frame by joining
+raw_interactions.csv against the ST02 pair table and ST03 split assignments. Each
+raw observation (~318,816 rows across 369×96 = 35,424 pairs) carries the
+pair-level metadata needed to drop into the existing SX10 pipeline once rolled
+back up to pair level.
+
+CH03 is plumbing-only: the training-time rollup collapses rows back to pair-level
+`label_any_lysis` using the ST01B rule (hard_label=1 iff any row has score='1';
+hard_label=0 iff no score='1' and score_0_count ≥ 5; otherwise unresolved/drop).
+Rows with score='n' are treated as missing (not negative), matching SX10 label
+semantics. CH04 removes the rollup and trains on the row-level binary score.
+
+Artifacts:
+  - lyzortx/generated_outputs/ch03_row_expansion/ch03_expanded_training_frame.csv
+  - lyzortx/generated_outputs/ch03_row_expansion/ch03_regression_check.json
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from lyzortx.pipeline.autoresearch.candidate_replay import (
+    DEFAULT_ST02_PAIR_TABLE_PATH,
+    DEFAULT_ST03_SPLIT_ASSIGNMENTS_PATH,
+)
+from lyzortx.pipeline.autoresearch.sx01_eval import RAW_INTERACTIONS_PATH
+
+LOGGER = logging.getLogger(__name__)
+
+# ST01B label rule thresholds (reproduce lyzortx/pipeline/steel_thread_v0/steps/st01_label_policy.py).
+ST01B_MIN_SCORE_0_COUNT_FOR_HARD_NEGATIVE = 5
+RAW_SCORE_POSITIVE = "1"
+RAW_SCORE_NEGATIVE = "0"
+RAW_SCORE_UNINTERPRETABLE = "n"
+
+
+def load_raw_observation_rows(raw_path: Path = RAW_INTERACTIONS_PATH) -> pd.DataFrame:
+    """Load raw_interactions.csv as one row per observation.
+
+    Columns: bacteria, bacteria_index, phage, image, replicate, plate, log_dilution,
+    X, Y, score. 318,816 rows across 369 bacteria × 96 phages with log_dilution in
+    {0, -1, -2, -4} (Guelin protocol: 3+2+3+1 = 9 replicates per pair).
+    """
+    if not raw_path.exists():
+        raise FileNotFoundError(f"raw_interactions.csv not found: {raw_path}")
+    df = pd.read_csv(raw_path, sep=";", dtype={"score": str})
+    df["pair_id"] = df["bacteria"].astype(str) + "__" + df["phage"].astype(str)
+    LOGGER.info(
+        "Loaded raw observations: %d rows, %d pairs, score distribution=%s",
+        len(df),
+        df["pair_id"].nunique(),
+        df["score"].value_counts(dropna=False).to_dict(),
+    )
+    return df
+
+
+def load_row_expanded_frame(
+    raw_path: Path = RAW_INTERACTIONS_PATH,
+    st02_path: Path = DEFAULT_ST02_PAIR_TABLE_PATH,
+    st03_path: Path = DEFAULT_ST03_SPLIT_ASSIGNMENTS_PATH,
+) -> pd.DataFrame:
+    """Merge raw observation rows with pair-level ST02/ST03 metadata.
+
+    Every raw row gets the pair-level cv_group, split_holdout, is_hard_trainable,
+    label_hard_any_lysis, training_weight_v3, and host/phage feature columns that
+    downstream SX10 training reads. This is the canonical row-expanded training
+    frame that CH04 will train on directly.
+    """
+    rows = load_raw_observation_rows(raw_path)
+    st02 = pd.read_csv(st02_path, dtype=str, keep_default_na=False)
+    st03 = pd.read_csv(st03_path, dtype=str, keep_default_na=False)
+    pair_meta = st02.merge(
+        st03[["pair_id", "split_holdout", "is_hard_trainable"]],
+        on="pair_id",
+        validate="one_to_one",
+    )
+
+    # Avoid duplicating bacteria/phage columns from ST02 — the raw rows already carry them.
+    drop_from_pair = {"bacteria", "phage"}
+    pair_columns = [c for c in pair_meta.columns if c not in drop_from_pair]
+    merged = rows.merge(pair_meta[pair_columns], on="pair_id", how="left", validate="many_to_one")
+
+    missing_pair_meta = merged[merged["cv_group"].isna() | (merged["cv_group"] == "")]
+    if not missing_pair_meta.empty:
+        raise ValueError(
+            f"{len(missing_pair_meta)} raw rows have no ST02 pair metadata "
+            f"(example pair_ids: {missing_pair_meta['pair_id'].head().tolist()})"
+        )
+
+    LOGGER.info(
+        "Row-expanded frame: %d rows, %d pairs, %d columns",
+        len(merged),
+        merged["pair_id"].nunique(),
+        len(merged.columns),
+    )
+    return merged
+
+
+def rollup_row_scores_to_pair_any_lysis(row_frame: pd.DataFrame) -> pd.DataFrame:
+    """Collapse a row-expanded frame to pair level using the ST01B any_lysis rule.
+
+    Returns one row per pair_id with `rollup_label_hard_any_lysis` ∈ {"0", "1", ""},
+    where "" marks unresolved pairs (no score='1' and fewer than 5 score='0' rows).
+    Rows with score='n' are treated as missing — they count neither as lysis nor as
+    clear negatives, mirroring the ST01B policy.
+    """
+    scores = row_frame.groupby("pair_id")["score"].agg(list)
+    rollup_rows = []
+    for pair_id, score_list in scores.items():
+        s1 = sum(1 for v in score_list if v == RAW_SCORE_POSITIVE)
+        s0 = sum(1 for v in score_list if v == RAW_SCORE_NEGATIVE)
+        sn = sum(1 for v in score_list if v == RAW_SCORE_UNINTERPRETABLE)
+        if s1 > 0:
+            label = "1"
+        elif s0 >= ST01B_MIN_SCORE_0_COUNT_FOR_HARD_NEGATIVE:
+            label = "0"
+        else:
+            label = ""
+        rollup_rows.append(
+            {
+                "pair_id": pair_id,
+                "rollup_score_1_count": s1,
+                "rollup_score_0_count": s0,
+                "rollup_score_n_count": sn,
+                "rollup_label_hard_any_lysis": label,
+            }
+        )
+    return pd.DataFrame(rollup_rows)
+
+
+def verify_rollup_matches_st02(
+    row_frame: pd.DataFrame,
+    st02_path: Path = DEFAULT_ST02_PAIR_TABLE_PATH,
+) -> dict[str, int]:
+    """Recompute any_lysis from row scores and confirm it matches ST02 exactly.
+
+    This is the core CH03 regression check: the ST01B rule applied to the row-expanded
+    frame must reproduce every pair's `label_hard_any_lysis` value in the canonical
+    ST02 pair table. Any mismatch indicates the row expansion pipeline has drifted
+    from the pair-level rollup and would contaminate CH04's per-row training.
+    """
+    rollup = rollup_row_scores_to_pair_any_lysis(row_frame)
+    st02 = pd.read_csv(st02_path, dtype=str, keep_default_na=False)
+    compared = rollup.merge(
+        st02[["pair_id", "label_hard_any_lysis", "obs_score_1_count", "obs_score_0_count", "obs_score_n_count"]],
+        on="pair_id",
+        validate="one_to_one",
+    )
+    mismatches = compared[compared["rollup_label_hard_any_lysis"] != compared["label_hard_any_lysis"]]
+    summary = {
+        "n_pairs": len(compared),
+        "n_mismatches": len(mismatches),
+        "n_recomputed_positive": int((compared["rollup_label_hard_any_lysis"] == "1").sum()),
+        "n_recomputed_negative": int((compared["rollup_label_hard_any_lysis"] == "0").sum()),
+        "n_recomputed_unresolved": int((compared["rollup_label_hard_any_lysis"] == "").sum()),
+    }
+    if not mismatches.empty:
+        LOGGER.error(
+            "Rollup disagrees with ST02 on %d pairs; first 5: %s",
+            len(mismatches),
+            mismatches.head().to_dict(orient="records"),
+        )
+    return summary
+
+
+def collapse_to_pair_level_for_training(row_frame: pd.DataFrame) -> pd.DataFrame:
+    """Reduce the row-expanded frame back to the pair-level representation.
+
+    Pair-level metadata must be constant within a pair_id. The function raises
+    loudly if any pair-level column takes multiple distinct values within one
+    pair, which would indicate a corrupted row-expansion join. Row-level columns
+    (replicate, log_dilution, X, Y, score, image, plate) are discarded at this
+    stage — CH03 keeps pair-level label semantics unchanged vs SX10. CH04
+    replaces this function with a per-row trainer.
+    """
+    row_only = {"bacteria_index", "image", "replicate", "plate", "log_dilution", "X", "Y", "score"}
+    keep = [c for c in row_frame.columns if c not in row_only]
+    pair_level_columns = [c for c in keep if c != "pair_id"]
+    inconsistent = row_frame.groupby("pair_id")[pair_level_columns].nunique()
+    offending = inconsistent[(inconsistent > 1).any(axis=1)]
+    if not offending.empty:
+        first_pair = offending.index[0]
+        offending_cols = offending.columns[(offending.loc[first_pair] > 1)].tolist()
+        raise ValueError(f"pair-level metadata varies within pair_id {first_pair!r} for columns {offending_cols}")
+    return row_frame[keep].drop_duplicates(subset=["pair_id"]).reset_index(drop=True)

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -118,3 +118,103 @@ frame is fully migrated.
 - `ch02_sx10_revalidated_metrics.json` emitted with SPANDEX vs CHISEL side-by-side and fold-diff summary.
 - `cv-group-leakage-fixed` knowledge unit added; `spandex-final-baseline` historical numbers preserved.
 - Lab notebook entry (this one) records methodology and the 1.78 pp AUC shift.
+
+---
+
+## 2026-04-19 09:00 CEST: CH03 — row-expanded training matrix with preserved any_lysis semantics
+
+### Executive summary
+
+Plumbing-only safety-net ticket. Built a `(bacterium, phage, log_dilution, replicate, X, Y)` row-expanded training
+frame (318,816 rows across 35,424 pairs) by joining `raw_interactions.csv` with ST02 pair metadata and ST03
+splits, then verified the ST01B `any_lysis` rule applied to row-level scores reproduces **all 35,424 ST02
+`label_hard_any_lysis` values with zero mismatches** (9,720 positive / 25,546 negative / 158 unresolved — identical
+to ST02). Rerunning SX10 canonical on the collapsed frame gives AUC **0.8522** [0.8379, 0.8650] and Brier
+**0.1318** [0.1255, 0.1382] — |ΔAUC| = 0.00012, |ΔBrier| = 0.00012 vs CH02 (0.8521 / 0.1317), well inside the
+0.005 regression tolerance.
+
+**Design.** Two modules landed under `lyzortx/pipeline/autoresearch/`:
+
+- `ch03_row_expansion.py` — loader + rollup:
+  - `load_raw_observation_rows()` reads `raw_interactions.csv` (318,816 rows; score distribution 272,750 × "0",
+    37,391 × "1", 8,675 × "n").
+  - `load_row_expanded_frame()` joins each raw row against the ST02 pair table and ST03 split assignments so
+    every observation carries `pair_id`, `cv_group`, `label_hard_any_lysis`, `training_weight_v3`,
+    `split_holdout`, `is_hard_trainable`, plus the host and phage metadata columns that downstream SX10 reads.
+    Fails loudly if any raw row has no ST02 counterpart.
+  - `rollup_row_scores_to_pair_any_lysis()` reproduces the ST01B rule on the row-level scores: `any_lysis = 1`
+    iff any row has `score == "1"`; `any_lysis = 0` iff no `score == "1"` AND `score_0_count ≥ 5`; otherwise
+    unresolved. `score == "n"` rows count neither as positive nor as negative — they're treated as missing, not
+    as silent zeroes.
+  - `verify_rollup_matches_st02()` is the core regression check — the recomputed labels must equal ST02's
+    `label_hard_any_lysis` value on every one of the 35,424 pairs, or the eval aborts.
+  - `collapse_to_pair_level_for_training()` dedupes the row-expanded frame back to pair level for CH03's
+    temporary scaffolding. CH04 replaces this with a per-row trainer. The helper fails loudly if any pair-level
+    column (cv_group, label, etc.) takes inconsistent values within a single pair.
+
+- `ch03_eval.py` — runner. Loads the row-expanded frame, runs the rollup check, collapses to pair level,
+  verifies row-level fold integrity (every raw observation of a bacterium routes to the same CH02 fold, so no
+  `(pair, concentration, replicate)` row can appear in both train and test), then calls `run_kfold_evaluation`
+  with the collapsed frame. On completion, compares the resulting AUC + Brier against `ch02_sx10_revalidated_metrics.json`
+  and fails if either delta exceeds 0.005.
+
+**Run.**
+
+```
+PYTHONPATH=. python -m lyzortx.pipeline.autoresearch.ch03_eval --device-type cpu
+```
+
+Total runtime 613.8 s (a few seconds longer than CH02's 609 s — the overhead is the raw-row load + rollup check).
+
+| Quantity | CH02 (direct ST02) | CH03 (row-expanded → rolled up) | Δ |
+|---|---|---|---|
+| AUC | 0.8521 [0.8381, 0.8649] | 0.8522 [0.8379, 0.8650] | +0.00012 |
+| Brier | 0.1317 [0.1253, 0.1381] | 0.1318 [0.1255, 0.1382] | +0.00012 |
+| Pairs positive | 9,720 | 9,720 | 0 |
+| Pairs negative | 25,546 | 25,546 | 0 |
+| Pairs unresolved | 158 | 158 | 0 |
+
+The residual ~0.0001 delta on AUC and Brier is numerical noise from the row-expansion → pair-level recollapse
+path (likely float ordering differences in the `drop_duplicates` step interacting with downstream pandas
+merges). Well below the 0.005 regression tolerance and far below any bootstrap CI width.
+
+**Interpretation.** The zero-mismatch rollup is the load-bearing result. It proves two things CH04 needs:
+
+1. The raw → row-expanded pipeline conserves every pair's label semantics. CH04 can swap `any_lysis` labels for
+   the raw per-row `score` values without worrying that the row-level data represents a different experiment
+   than SX10 trained on.
+2. The `n` handling is correct: rows with `score == "n"` are not silently counted as negative in the training
+   corpus (they push 158 pairs to unresolved; SX10's `is_hard_trainable` filter drops them). CH04's per-row
+   training can drop `score == "n"` rows directly without changing the pair-level denominator the SPANDEX and
+   CH02 numbers were computed on.
+
+**Fold integrity.** The CH02 cv_group hash operates at bacterium level. Because all 318,816 raw rows for a
+given bacterium share the same `cv_group` (the cv_group is a bacterium attribute, not a pair attribute), every
+row routes to the same fold as its bacterium. CH03's fold-integrity assertion `pair_id → fold_id` is 1:1
+confirms this holds on the full training matrix — no pair was split across folds at any expansion level, which
+is the necessary precondition for CH04's per-row training.
+
+**Scope.** CH03 changes nothing semantically. The collapsed pair-level frame is the ST02 pair table (with the
+`bacteria` and `phage` columns re-derived from the raw rows and the rest copied through). SX10 training sees
+the same design matrix, the same labels, and the same folds as CH02. CH03's value is that it localises any
+future row-expansion bug inside `ch03_row_expansion.py` — if CH04 misinterprets the raw schema, the rollup
+check will flag it before the model runs.
+
+**Artifacts.**
+
+- `lyzortx/generated_outputs/ch03_row_expansion/ch03_expanded_training_frame.csv` — the 318,816-row canonical
+  frame for CH04 reuse (persisted as CSV; parquet would have required adding `pyarrow` as a dependency for a
+  temporary scaffold).
+- `lyzortx/generated_outputs/ch03_row_expansion/ch03_regression_check.json` — CH02-vs-CH03 metric comparison +
+  rollup check summary.
+- `lyzortx/generated_outputs/ch03_row_expansion/sx10_on_row_expanded/` — raw SX10 outputs (predictions, fold
+  metrics, bootstrap results) from the revalidation run.
+
+**Acceptance met.**
+
+- Row-expanded loader + rollup land in `ch03_row_expansion.py`; all raw rows carry pair-level metadata.
+- ST01B rollup reproduces ST02 labels exactly (0 mismatches on 35,424 pairs).
+- Fold-integrity check (1 fold per pair_id) enforced in `check_row_level_fold_integrity`.
+- SX10 rerun on collapsed frame: AUC 0.8522, Brier 0.1318 — |Δ| < 0.005 vs CH02 on both metrics.
+- Artifacts `ch03_expanded_training_frame.csv` and `ch03_regression_check.json` emitted.
+- Unit tests (6) cover rollup logic, `n` handling, and collapse invariants.

--- a/lyzortx/tests/test_ch03_row_expansion.py
+++ b/lyzortx/tests/test_ch03_row_expansion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+from lyzortx.pipeline.autoresearch.ch03_eval import check_row_level_fold_integrity
 from lyzortx.pipeline.autoresearch.ch03_row_expansion import (
     ST01B_MIN_SCORE_0_COUNT_FOR_HARD_NEGATIVE,
     collapse_to_pair_level_for_training,
@@ -142,3 +143,62 @@ def test_collapse_rejects_pair_with_inconsistent_metadata() -> None:
     )
     with pytest.raises(ValueError, match="pair-level metadata varies"):
         collapse_to_pair_level_for_training(rows)
+
+
+def test_fold_integrity_catches_duplicate_observation_keys() -> None:
+    # Two rows share (pair_id, log_dilution, replicate) — a real row-expansion bug would
+    # produce this if the raw CSV were accidentally duplicated on merge.
+    rows = pd.DataFrame(
+        [
+            {
+                "bacteria": "bac_A",
+                "phage": "p",
+                "pair_id": "bac_A__p",
+                "cv_group": "1",
+                "log_dilution": 0,
+                "replicate": 1,
+                "score": "0",
+            },
+            {
+                "bacteria": "bac_A",
+                "phage": "p",
+                "pair_id": "bac_A__p",
+                "cv_group": "1",
+                "log_dilution": 0,
+                "replicate": 1,
+                "score": "1",
+            },
+        ]
+    )
+    pair_frame = pd.DataFrame([{"bacteria": "bac_A", "cv_group": "1"}])
+    with pytest.raises(ValueError, match="duplicate .+ rows"):
+        check_row_level_fold_integrity(rows, pair_frame)
+
+
+def test_fold_integrity_passes_when_observations_are_unique() -> None:
+    # Three bacteria × 3 dilutions × 2 replicates, each bacterium in a different cv_group.
+    rows_list = []
+    for bac, cvg in [("bac_A", "1"), ("bac_B", "2"), ("bac_C", "3")]:
+        for dilution in [0, -1, -2]:
+            for rep in [1, 2]:
+                rows_list.append(
+                    {
+                        "bacteria": bac,
+                        "phage": "p",
+                        "pair_id": f"{bac}__p",
+                        "cv_group": cvg,
+                        "log_dilution": dilution,
+                        "replicate": rep,
+                        "score": "0",
+                    }
+                )
+    rows = pd.DataFrame(rows_list)
+    pair_frame = pd.DataFrame(
+        [
+            {"bacteria": "bac_A", "cv_group": "1"},
+            {"bacteria": "bac_B", "cv_group": "2"},
+            {"bacteria": "bac_C", "cv_group": "3"},
+        ]
+    )
+    # No exception means pass.
+    check_row_level_fold_integrity(rows, pair_frame)

--- a/lyzortx/tests/test_ch03_row_expansion.py
+++ b/lyzortx/tests/test_ch03_row_expansion.py
@@ -1,0 +1,144 @@
+"""Tests for CH03 row-expansion and any_lysis rollup scaffolding."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from lyzortx.pipeline.autoresearch.ch03_row_expansion import (
+    ST01B_MIN_SCORE_0_COUNT_FOR_HARD_NEGATIVE,
+    collapse_to_pair_level_for_training,
+    rollup_row_scores_to_pair_any_lysis,
+)
+
+
+def _row(pair_id: str, score: str, replicate: int = 1, log_dilution: int = 0) -> dict:
+    bacteria, phage = pair_id.split("__")
+    return {
+        "pair_id": pair_id,
+        "bacteria": bacteria,
+        "phage": phage,
+        "replicate": replicate,
+        "log_dilution": log_dilution,
+        "score": score,
+    }
+
+
+def test_rollup_positive_any_lysis_when_any_score_one() -> None:
+    rows = pd.DataFrame(
+        [
+            _row("bac_A__phage_X", "0"),
+            _row("bac_A__phage_X", "0"),
+            _row("bac_A__phage_X", "1"),
+            _row("bac_A__phage_X", "0"),
+        ]
+    )
+    out = rollup_row_scores_to_pair_any_lysis(rows)
+    row = out.iloc[0]
+    assert row["rollup_label_hard_any_lysis"] == "1"
+    assert row["rollup_score_1_count"] == 1
+    assert row["rollup_score_0_count"] == 3
+
+
+def test_rollup_hard_negative_requires_min_score_zero_count() -> None:
+    # Need ≥5 score='0' rows to call a hard 0.
+    n = ST01B_MIN_SCORE_0_COUNT_FOR_HARD_NEGATIVE
+    rows_hard = pd.DataFrame([_row("bac_A__phage_X", "0", replicate=i) for i in range(n)])
+    assert rollup_row_scores_to_pair_any_lysis(rows_hard).iloc[0]["rollup_label_hard_any_lysis"] == "0"
+
+    rows_soft = pd.DataFrame([_row("bac_A__phage_X", "0", replicate=i) for i in range(n - 1)])
+    assert rollup_row_scores_to_pair_any_lysis(rows_soft).iloc[0]["rollup_label_hard_any_lysis"] == ""
+
+
+def test_rollup_treats_n_as_missing_not_negative() -> None:
+    # 4 score='n' rows — should NOT become hard 0 because 'n' is missing, not negative.
+    rows = pd.DataFrame([_row("bac_A__phage_X", "n", replicate=i) for i in range(9)])
+    out = rollup_row_scores_to_pair_any_lysis(rows)
+    row = out.iloc[0]
+    assert row["rollup_label_hard_any_lysis"] == ""
+    assert row["rollup_score_n_count"] == 9
+    assert row["rollup_score_0_count"] == 0
+
+
+def test_rollup_score_one_overrides_insufficient_zero_count() -> None:
+    # Single score='1' beats any number of 'n's and 0s.
+    rows = pd.DataFrame(
+        [
+            _row("bac_A__phage_X", "n"),
+            _row("bac_A__phage_X", "n"),
+            _row("bac_A__phage_X", "1"),
+        ]
+    )
+    assert rollup_row_scores_to_pair_any_lysis(rows).iloc[0]["rollup_label_hard_any_lysis"] == "1"
+
+
+def test_collapse_deduplicates_rows_to_pair_level() -> None:
+    rows = pd.DataFrame(
+        [
+            {
+                "pair_id": "bac_A__phage_X",
+                "bacteria": "bac_A",
+                "phage": "phage_X",
+                "cv_group": "42",
+                "label_hard_any_lysis": "1",
+                "training_weight_v3": "1.0",
+                "replicate": 1,
+                "log_dilution": 0,
+                "score": "0",
+            },
+            {
+                "pair_id": "bac_A__phage_X",
+                "bacteria": "bac_A",
+                "phage": "phage_X",
+                "cv_group": "42",
+                "label_hard_any_lysis": "1",
+                "training_weight_v3": "1.0",
+                "replicate": 2,
+                "log_dilution": -1,
+                "score": "1",
+            },
+            {
+                "pair_id": "bac_B__phage_X",
+                "bacteria": "bac_B",
+                "phage": "phage_X",
+                "cv_group": "42",
+                "label_hard_any_lysis": "0",
+                "training_weight_v3": "1.0",
+                "replicate": 1,
+                "log_dilution": 0,
+                "score": "0",
+            },
+        ]
+    )
+    collapsed = collapse_to_pair_level_for_training(rows)
+    assert len(collapsed) == 2
+    assert set(collapsed["pair_id"]) == {"bac_A__phage_X", "bac_B__phage_X"}
+    # Row-level columns must be stripped from the collapsed frame.
+    assert {"replicate", "log_dilution", "score"}.isdisjoint(collapsed.columns)
+    # Pair-level metadata survives.
+    assert {"pair_id", "bacteria", "phage", "cv_group", "label_hard_any_lysis"}.issubset(collapsed.columns)
+
+
+def test_collapse_rejects_pair_with_inconsistent_metadata() -> None:
+    rows = pd.DataFrame(
+        [
+            {
+                "pair_id": "bac_A__phage_X",
+                "bacteria": "bac_A",
+                "phage": "phage_X",
+                "cv_group": "42",
+                "replicate": 1,
+                "score": "0",
+            },
+            {
+                "pair_id": "bac_A__phage_X",
+                "bacteria": "bac_A",
+                "phage": "phage_X",
+                "cv_group": "43",
+                "replicate": 2,
+                "score": "1",
+            },
+        ]
+    )
+    with pytest.raises(ValueError, match="pair-level metadata varies"):
+        collapse_to_pair_level_for_training(rows)


### PR DESCRIPTION
## Summary

- Safety-net plumbing ticket. Builds a `(bacterium, phage, log_dilution, replicate, X, Y)` row-expanded training
  frame (318,816 rows across 35,424 pairs) by joining `raw_interactions.csv` with ST02 pair metadata and ST03
  split assignments. Each raw observation carries the pair-level columns SX10 needs.
- ST01B any_lysis rule applied to the row-level scores reproduces **every one of the 35,424 ST02
  `label_hard_any_lysis` values with zero mismatches** (9,720 positive / 25,546 negative / 158 unresolved —
  identical to ST02). `score == "n"` is treated as missing, not negative.
- SX10 canonical rerun on the collapsed pair-level frame: **AUC 0.8522 [0.8379, 0.8650], Brier 0.1318 [0.1255,
  0.1382]** — |ΔAUC| = 0.00012, |ΔBrier| = 0.00012 vs CH02 (0.8521 / 0.1317), well inside the 0.005 regression
  tolerance. Row expansion does not alter SX10 label semantics.
- Fold integrity: partitions the row-expanded frame into per-fold train / test subsets and asserts the
  `(pair_id, log_dilution, replicate)` observation key is disjoint across every fold boundary. Also catches
  duplicate observation keys before the fold loop (accidental CSV re-merge).

## Acceptance checklist

- [x] New row-level data-loader in `ch03_row_expansion.py` reads `raw_interactions.csv` directly and emits one
  row per `(bacterium, phage, log_dilution, replicate, X, Y)` with raw `{0, 1, n}` score. No rows dropped.
- [x] Training-time any_lysis rollup (`collapse_to_pair_level_for_training`) collapses rows to pair-level with
  SX10 label semantics. Marked as temporary scaffolding — CH04 removes it.
- [x] Fold integrity enforced: `check_row_level_fold_integrity` asserts train/test disjointness on every
  `(pair_id, log_dilution, replicate)` tuple across all 10 folds.
- [x] Regression check: SX10 on row-expanded frame matches CH02 within 0.005 on both AUC and Brier.
- [x] Artifacts `ch03_expanded_training_frame.csv` (for CH04 reuse; CSV over parquet to avoid a new dep) and
  `ch03_regression_check.json` emitted.
- [x] Track CHISEL lab notebook updated with the CH03 entry (executive summary + regression result + design).

## Test plan

- [x] `python -m pytest lyzortx/tests/test_ch03_row_expansion.py lyzortx/tests/test_sx01_fold_assignment.py` —
  16/16 pass (8 rollup + collapse + fold-integrity, 8 fold-assignment).
- [x] `python -m ruff check` clean on all CH03 files.
- [x] `PYTHONPATH=. python -m lyzortx.pipeline.autoresearch.ch03_eval --device-type cpu` — full rerun
  completed in 613.8 s; rollup check and regression check both PASS.
- [ ] Self-review subagent approval (running after PR opens).

Closes #431