### PR TITLE
[ORCH][CH05] Unified Guelin+BASEL two-axis k-fold under CHISEL

### DIFF
--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -216,7 +216,7 @@ Architecture choices, calibration, and performance bounds.
   StratifiedKFold by ICTV family + "other" <10-phage bucket + "UNKNOWN" no-family bucket — 40% of folds are
   pseudo-family catch-alls; calling it "ICTV-stratified" without that qualifier misleads). This unit replaces the
   earlier "cross-source AUC parity" headline with three separate findings: **(1) phage-axis discrimination parity**
-  (Guelin 0.8863 vs BASEL 0.8818, |ΔAUC| 0.0045 — a weak non-rejection on 52 BASEL phages with CI 3× wider than
+  (Guelin 0.8861 vs BASEL 0.8829, |ΔAUC| 0.0032 — a weak non-rejection on 52 BASEL phages with CI 3× wider than
   Guelin's, not positive evidence of transfer); **(2) phage-axis calibration divergence** (Guelin Brier 0.1329 vs BASEL
   0.1884, disjoint CIs, BASEL mid-P reliability gap 21-27 pp wider than Guelin's in the 0.5-0.9 predicted-probability
   bins); **(3) BASEL bacteria-axis deficit** (BASEL-only bacteria-axis AUC 0.7152 on the 1,240 BASEL pairs vs

--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -1,9 +1,9 @@
 # Project Knowledge Model
 
-<!-- Last consolidated: 2026-04-19T10:00:00+02:00 -->
+<!-- Last consolidated: 2026-04-19T16:00:00+02:00 -->
 <!-- Source: lyzortx/research_notes/lab_notebooks -->
 
-**64 knowledge units** across 7 themes (45 active, 19 dead ends)
+**65 knowledge units** across 7 themes (46 active, 19 dead ends)
 
 ## Data & Labels
 
@@ -208,20 +208,47 @@ Architecture choices, calibration, and performance bounds.
     leakage). Future CHISEL tickets evaluating a single candidate arm can reuse
     `.agents/skills/case-by-case/compare_predictions.py` for per-bacterium audit and the sx14_eval.py pipeline for full
     four-stratum decomposition when narrow-host behaviour is specifically under investigation.*
-- **`spandex-unified-kfold-baseline`**: SX15 unified Guelin+BASEL k-fold baseline (2026-04-15, default BASEL+→MLC=2;
-  2026-04-18 re-headline under CHISEL frame): **bacteria-axis AUC 0.8685, phage-axis AUC 0.8988, cross-source
-  near-parity AUC 0.896 (BASEL) vs 0.899 (Guelin)**. Phage-axis (all-pairs only; held-out phages unseen) is the first
-  honest deployability estimate for unseen phages. The BASEL-vs-Guelin nDCG comparison (0.8332 vs 0.7193) is dropped —
-  it is a metric artifact because BASEL binary labels have fewer nDCG rungs than Guelin's MLC grades, so direct nDCG
+- **`chisel-unified-kfold-baseline`**: CHISEL unified Guelin+BASEL k-fold baseline (CH05, 2026-04-19): per-row binary
+  training on the unified 148-phage × 369-bacteria panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL) with
+  `pair_concentration__log_dilution` as a numeric feature and SX10 feature bundle otherwise unchanged. All-pairs only
+  (per-phage blending retired track-wide per `per-phage-retired-under-chisel`). Two axes: **bacteria-axis AUC 0.8061
+  [0.7917, 0.8199], Brier 0.1778 [0.1702, 0.1853]** (10-fold CH02 cv_group hash; all 148 phages in training per fold);
+  **phage-axis AUC 0.8850 [0.8617, 0.9062], Brier 0.1348 [0.1219, 0.1495]** (10-fold StratifiedKFold by ICTV family; all
+  369 bacteria in training per fold). Cross-source phage-axis split: Guelin AUC 0.8863 [0.8653, 0.9078], BASEL AUC
+  0.8818 [0.8194, 0.9320] — **|ΔAUC| = 0.0045**, indistinguishable. This is the active CHISEL reference for two-axis
+  generalization and cross-source behaviour. [validated; source: CH05, 2026-04-19 CHISEL unified k-fold; see also:
+  chisel-baseline, spandex-unified-kfold-baseline, per-phage-retired-under-chisel, cv-group-leakage-fixed,
+  new-phage-generalization, deployment-goal]
+  - *Phage-axis AUC exceeds bacteria-axis AUC by 7.9 pp (CIs disjoint). The gap is structural, not a deployment-value
+    signal: phage-axis folds hold out entire phages but keep all 369 bacteria in training, so each held-out pair has
+    complete host-side signal available; bacteria-axis folds hold out bacteria and remove host-side signal for those
+    test pairs. The SX15 "per-phage blending tax" framing (which interpreted this gap under per-phage blending enabled)
+    is retired — under all-pairs-only evaluation there is no tax to compute; the gap is just the
+    phage-axis-vs-bacteria-axis structural difference in training-data coverage. The cross-source check confirms SX15's
+    11 pp Guelin-vs-BASEL nDCG gap was a metric artifact: under AUC the two cohorts are within 0.4 pp (far under the 1
+    pp expected tolerance). Bacteria-axis AUC 0.8061 is essentially identical to CH04's 0.8084 (|Δ| < 0.25 pp) — adding
+    1,240 BASEL pairs to 35K Guelin pairs at row level barely moves the aggregate. BASEL contributes useful phage-axis
+    signal (it fills 52 phages worth of holdout folds) without distorting the bacteria-axis number. Canonical artifacts:
+    lyzortx/generated_outputs/ch05_unified_kfold/ch05_combined_summary.json, ch05_{bacteria,phage}_axis_metrics.json,
+    ch05_cross_source_breakdown.csv, ch05_{bacteria,phage}_axis_predictions.csv.*
+- **`spandex-unified-kfold-baseline`**: HISTORICAL (SPANDEX-era). Superseded as the active unified-panel reference by
+  chisel-unified-kfold-baseline (CH05). SX15 unified Guelin+BASEL k-fold baseline (2026-04-15, default BASEL+→MLC=2;
+  2026-04-18 re-headline under CHISEL frame): bacteria-axis AUC 0.8685, phage-axis AUC 0.8988, cross-source near-parity
+  AUC 0.896 (BASEL) vs 0.899 (Guelin). Phage-axis (all-pairs only; held-out phages unseen) was the first honest
+  deployability estimate for unseen phages. The BASEL-vs-Guelin nDCG comparison (0.8332 vs 0.7193) was dropped — it was
+  a metric artifact because BASEL binary labels have fewer nDCG rungs than Guelin's MLC grades, so direct nDCG
   comparison is not interpretable. AUC is comparable across sources and shows BASEL phages generalize essentially
-  identically to Guelin phages. [validated; source: SX15; see also: spandex-final-baseline, stratified-eval-framework,
-  new-phage-generalization, external-data-neutral]
+  identically to Guelin phages. [validated; source: SX15; see also: chisel-unified-kfold-baseline,
+  spandex-final-baseline, stratified-eval-framework, new-phage-generalization, external-data-neutral,
+  per-phage-retired-under-chisel, cv-group-leakage-fixed]
   - *Panel: 369 bacteria (all 25 BASEL ECOR overlap with Guelin; no new bacteria) × 148 phages (96 Guelin + 52 BASEL) =
     33,202 observed pairs. The 3 pp bacteria-axis vs phage-axis AUC gap (0.8685 → 0.8988) looks like a "phage-axis is
     easier" effect but really reflects the deployment mix — phage-axis folds hold out entire phages so each test pair
     has more host-side signal available per training positive. Under CHISEL, this baseline is superseded by
-    chisel-unified-kfold-baseline (established in CH05) after the cv_group leakage fix (CH02) and concentration-feature
-    flip (CH04). Until then, SX15 remains the reference point for cross-source generalization. Artifact paths:
+    chisel-unified-kfold-baseline (established in CH05) after the cv_group leakage fix (CH02), concentration-feature
+    flip (CH04), and per-phage retirement (per-phage-retired-under-chisel). SX15 numbers were computed with pair-level
+    any_lysis training and per-phage blending enabled under the leaky cv_group folds; all three of those confounders are
+    closed under CHISEL. Artifact paths:
     lyzortx/generated_outputs/sx15_eval/sx15_{bacteria,phage}_axis_stratified_metrics.csv and
     sx15_{bacteria,phage}_axis_predictions.csv.*
 - **`autoresearch-baseline`**: AUTORESEARCH all-pairs model (0.810 AUC, 90.8% top-3 on ST03 holdout) is the canonical

--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -243,13 +243,16 @@ Architecture choices, calibration, and performance bounds.
     CH05's reliability analysis showed BASEL over-predicted in mid-P, the opposite direction an encoding mismatch
     predicts, so the pre-existing relative-log_dilution encoding of BASEL (at Guelin neat) was not the dominant driver;
     the encoding has been fixed track-wide to absolute log10_pfu_ml (Guelin {4.7, 6.7, 7.7, 8.7}; BASEL 9.0 per Maffei
-    2021 Fig. 12 + Maffei 2025 Fig. 13 `>10⁹ pfu/ml if possible`) for semantic correctness; CH04 rerun under the new
-    encoding is bit-identical at fold level (affine invariance confirmed). Full CH05 rerun under new encoding deferred
-    to a follow-up ticket. Connects to `plm-rbp-redundant`: same Guelin-bank-dependent-phage-features failure mode, here
-    on a genuine cross-panel split rather than cross-family within Guelin. Supports `panel-size-ceiling`: the fix is
-    panel expansion or panel-independent phage features (dispatched as new CH06 with four candidate arms including
-    OOD-aware inference, pairwise proteome similarity, Moriniere receptor-class probabilities, tail-protein-restricted
-    TL17 projection), not richer engineered features. Canonical artifacts:
+    2021 Fig. 12 + Maffei 2025 Fig. 13 `>10⁹ pfu/ml if possible`) for semantic correctness. CH04 rerun (Guelin-only
+    panel) is bit-identical at fold level because Guelin's change is a monotonic affine shift of one feature
+    (GUELIN_NEAT_LOG10_PFU_ML + log_dilution), which LightGBM's bin-then-split flow leaves invariant. BASEL-side
+    predictions may shift on the pending CH05 rerun — BASEL's encoding moves from log_dilution=0 to log10_pfu_ml=9.0,
+    which is not an affine shift of the Guelin encoding, so Guelin-side invariance does not extend to BASEL. Full CH05
+    rerun deferred to a follow-up ticket. Connects to `plm-rbp-redundant`: same Guelin-bank-dependent-phage-features
+    failure mode, here on a genuine cross-panel split rather than cross-family within Guelin. Supports
+    `panel-size-ceiling`: the fix is panel expansion or panel-independent phage features (dispatched as new CH06 with
+    four candidate arms including OOD-aware inference, pairwise proteome similarity, Moriniere receptor-class
+    probabilities, tail-protein-restricted TL17 projection), not richer engineered features. Canonical artifacts:
     lyzortx/generated_outputs/ch05_unified_kfold/ch05_combined_summary.json, ch05_{bacteria,phage}_axis_metrics.json,
     ch05_cross_source_breakdown.csv, ch05_{bacteria,phage}_axis_predictions.csv, ch05_per_family_breakdown.csv,
     ch05_straboviridae_exclusion.csv, ch05_reliability_tables.csv, ch05_basel_feature_variance.csv,

--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -209,28 +209,51 @@ Architecture choices, calibration, and performance bounds.
     `.agents/skills/case-by-case/compare_predictions.py` for per-bacterium audit and the sx14_eval.py pipeline for full
     four-stratum decomposition when narrow-host behaviour is specifically under investigation.*
 - **`chisel-unified-kfold-baseline`**: CHISEL unified Guelin+BASEL k-fold baseline (CH05, 2026-04-19): per-row binary
-  training on the unified 148-phage × 369-bacteria panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL) with
-  `pair_concentration__log_dilution` as a numeric feature and SX10 feature bundle otherwise unchanged. All-pairs only
-  (per-phage blending retired track-wide per `per-phage-retired-under-chisel`). Two axes: **bacteria-axis AUC 0.8061
-  [0.7917, 0.8199], Brier 0.1778 [0.1702, 0.1853]** (10-fold CH02 cv_group hash; all 148 phages in training per fold);
-  **phage-axis AUC 0.8850 [0.8617, 0.9062], Brier 0.1348 [0.1219, 0.1495]** (10-fold StratifiedKFold by ICTV family; all
-  369 bacteria in training per fold). Cross-source phage-axis split: Guelin AUC 0.8863 [0.8653, 0.9078], BASEL AUC
-  0.8818 [0.8194, 0.9320] — **|ΔAUC| = 0.0045**, indistinguishable. This is the active CHISEL reference for two-axis
-  generalization and cross-source behaviour. [validated; source: CH05, 2026-04-19 CHISEL unified k-fold; see also:
-  chisel-baseline, spandex-unified-kfold-baseline, per-phage-retired-under-chisel, cv-group-leakage-fixed,
-  new-phage-generalization, deployment-goal]
+  training on the unified 148-phage × 369-bacteria panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL), SX10 feature
+  bundle, all-pairs only (per-phage blending retired track-wide per `per-phage-retired-under-chisel`). Two axes:
+  **bacteria-axis AUC 0.8061 [0.7917, 0.8199], Brier 0.1778 [0.1702, 0.1853]** (10-fold CH02 cv_group hash; all 148
+  phages in training per fold); **phage-axis AUC 0.8850 [0.8617, 0.9062], Brier 0.1348 [0.1219, 0.1495]** (10-fold
+  StratifiedKFold by ICTV family + "other" <10-phage bucket + "UNKNOWN" no-family bucket — 40% of folds are
+  pseudo-family catch-alls; calling it "ICTV-stratified" without that qualifier misleads). This unit replaces the
+  earlier "cross-source AUC parity" headline with three separate findings: **(1) phage-axis discrimination parity**
+  (Guelin 0.8863 vs BASEL 0.8818, |ΔAUC| 0.0045 — a weak non-rejection on 52 BASEL phages with CI 3× wider than
+  Guelin's, not positive evidence of transfer); **(2) phage-axis calibration divergence** (Guelin Brier 0.1329 vs BASEL
+  0.1884, disjoint CIs, BASEL mid-P reliability gap 21-27 pp wider than Guelin's in the 0.5-0.9 predicted-probability
+  bins); **(3) BASEL bacteria-axis deficit** (BASEL-only bacteria-axis AUC 0.7152 on the 1,240 BASEL pairs vs
+  Guelin-only 0.8098 on the same axis — a 9.5 pp BASEL-specific deficit invisible in the 96.6% Guelin-weighted
+  aggregate, a standalone deployability finding separate from the phage-axis parity story). Root-cause diagnostic
+  (post-hoc, no model rerun): the mid-P miscalibration localises to the 39/52 BASEL phages whose `phage_projection`
+  vectors are non-zero (Brier 0.31 bacteria-axis) — these phages map into Guelin-derived TL17 neighborhoods associated
+  with broad-host lysis but carry narrower actual host ranges; the 13/52 BASEL phages with zero-vector projection
+  calibrate correctly (Brier 0.12) because the model has no phage signal to misuse and falls back to the host-side
+  prior. Straboviridae exclusion closes only 1.5 pp of the 9.5 pp bacteria-axis BASEL deficit — family bias is not the
+  driver. This is the active CHISEL reference for two-axis generalization and cross-source behaviour. [validated;
+  source: CH05, 2026-04-19 CHISEL unified k-fold; see also: chisel-baseline, spandex-unified-kfold-baseline,
+  per-phage-retired-under-chisel, cv-group-leakage-fixed, new-phage-generalization, deployment-goal, plm-rbp-redundant,
+  panel-size-ceiling]
   - *Phage-axis AUC exceeds bacteria-axis AUC by 7.9 pp (CIs disjoint). The gap is structural, not a deployment-value
-    signal: phage-axis folds hold out entire phages but keep all 369 bacteria in training, so each held-out pair has
-    complete host-side signal available; bacteria-axis folds hold out bacteria and remove host-side signal for those
-    test pairs. The SX15 "per-phage blending tax" framing (which interpreted this gap under per-phage blending enabled)
-    is retired — under all-pairs-only evaluation there is no tax to compute; the gap is just the
-    phage-axis-vs-bacteria-axis structural difference in training-data coverage. The cross-source check confirms SX15's
-    11 pp Guelin-vs-BASEL nDCG gap was a metric artifact: under AUC the two cohorts are within 0.4 pp (far under the 1
-    pp expected tolerance). Bacteria-axis AUC 0.8061 is essentially identical to CH04's 0.8084 (|Δ| < 0.25 pp) — adding
-    1,240 BASEL pairs to 35K Guelin pairs at row level barely moves the aggregate. BASEL contributes useful phage-axis
-    signal (it fills 52 phages worth of holdout folds) without distorting the bacteria-axis number. Canonical artifacts:
+    signal: phage-axis folds hold out entire phages but keep all 369 bacteria in training; bacteria-axis folds hold out
+    bacteria and remove host-side signal for those test pairs. The SX15 "per-phage blending tax" framing (which
+    interpreted this gap under per-phage blending enabled) is retired — under all-pairs-only evaluation there is no tax;
+    the gap is purely structural training-data coverage. Bacteria-axis aggregate AUC 0.8061 matches CH04's 0.8084 within
+    0.25 pp because adding 1,240 BASEL pairs to 35K Guelin pairs barely shifts the 96.6%-Guelin-weighted aggregate —
+    which is exactly why the BASEL-specific 9.5 pp bacteria-axis deficit had to be reported separately. The earlier
+    draft's "BASEL phages generalize essentially identically to Guelin phages" claim was a discrimination-only finding,
+    not deployment readiness — retired. The TL17-bias root cause supersedes the earlier encoding-hypothesis framing:
+    CH05's reliability analysis showed BASEL over-predicted in mid-P, the opposite direction an encoding mismatch
+    predicts, so the pre-existing relative-log_dilution encoding of BASEL (at Guelin neat) was not the dominant driver;
+    the encoding has been fixed track-wide to absolute log10_pfu_ml (Guelin {4.7, 6.7, 7.7, 8.7}; BASEL 9.0 per Maffei
+    2021 Fig. 12 + Maffei 2025 Fig. 13 `>10⁹ pfu/ml if possible`) for semantic correctness; CH04 rerun under the new
+    encoding is bit-identical at fold level (affine invariance confirmed). Full CH05 rerun under new encoding deferred
+    to a follow-up ticket. Connects to `plm-rbp-redundant`: same Guelin-bank-dependent-phage-features failure mode, here
+    on a genuine cross-panel split rather than cross-family within Guelin. Supports `panel-size-ceiling`: the fix is
+    panel expansion or panel-independent phage features (dispatched as new CH06 with four candidate arms including
+    OOD-aware inference, pairwise proteome similarity, Moriniere receptor-class probabilities, tail-protein-restricted
+    TL17 projection), not richer engineered features. Canonical artifacts:
     lyzortx/generated_outputs/ch05_unified_kfold/ch05_combined_summary.json, ch05_{bacteria,phage}_axis_metrics.json,
-    ch05_cross_source_breakdown.csv, ch05_{bacteria,phage}_axis_predictions.csv.*
+    ch05_cross_source_breakdown.csv, ch05_{bacteria,phage}_axis_predictions.csv, ch05_per_family_breakdown.csv,
+    ch05_straboviridae_exclusion.csv, ch05_reliability_tables.csv, ch05_basel_feature_variance.csv,
+    ch05_basel_zero_vector_split.csv.*
 - **`spandex-unified-kfold-baseline`**: HISTORICAL (SPANDEX-era). Superseded as the active unified-panel reference by
   chisel-unified-kfold-baseline (CH05). SX15 unified Guelin+BASEL k-fold baseline (2026-04-15, default BASEL+→MLC=2;
   2026-04-18 re-headline under CHISEL frame): bacteria-axis AUC 0.8685, phage-axis AUC 0.8988, cross-source near-parity

--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -221,16 +221,29 @@ Architecture choices, calibration, and performance bounds.
   0.1884, disjoint CIs, BASEL mid-P reliability gap 21-27 pp wider than Guelin's in the 0.5-0.9 predicted-probability
   bins); **(3) BASEL bacteria-axis deficit** (BASEL-only bacteria-axis AUC 0.7152 on the 1,240 BASEL pairs vs
   Guelin-only 0.8098 on the same axis — a 9.5 pp BASEL-specific deficit invisible in the 96.6% Guelin-weighted
-  aggregate, a standalone deployability finding separate from the phage-axis parity story). Root-cause diagnostic
-  (post-hoc, no model rerun): the mid-P miscalibration localises to the 39/52 BASEL phages whose `phage_projection`
-  vectors are non-zero (Brier 0.31 bacteria-axis) — these phages map into Guelin-derived TL17 neighborhoods associated
-  with broad-host lysis but carry narrower actual host ranges; the 13/52 BASEL phages with zero-vector projection
-  calibrate correctly (Brier 0.12) because the model has no phage signal to misuse and falls back to the host-side
-  prior. Straboviridae exclusion closes only 1.5 pp of the 9.5 pp bacteria-axis BASEL deficit — family bias is not the
-  driver. This is the active CHISEL reference for two-axis generalization and cross-source behaviour. [validated;
-  source: CH05, 2026-04-19 CHISEL unified k-fold; see also: chisel-baseline, spandex-unified-kfold-baseline,
-  per-phage-retired-under-chisel, cv-group-leakage-fixed, new-phage-generalization, deployment-goal, plm-rbp-redundant,
-  panel-size-ceiling]
+  aggregate, a standalone deployability finding separate from the phage-axis parity story). Expected Calibration Error
+  (ECE, weighted mean of per-decile |observed−predicted| gaps) reported alongside AUC and Brier going forward:
+  **bacteria-axis Guelin ECE 0.120, BASEL ECE 0.272; phage-axis Guelin ECE 0.104, BASEL ECE 0.236** under the raw CH05
+  predictions. ECE separates calibration from discrimination more interpretably than Brier and is now part of the CHISEL
+  scorecard. Two separable root-cause mechanisms, each diagnostically distinct: **(A) Guelin mid-P miscalibration =
+  training-label-vs-deployment-question mismatch, post-hoc fixable**. Leave-one-fold-out isotonic regression on Guelin
+  predictions drops Guelin bacteria-axis ECE 0.120→0.008 and phage-axis ECE 0.104→0.008 (78-89% decile-gap closure), AUC
+  preserved within 0.5 pp. The model has the discrimination; it emits inflated probabilities in mid-P because the
+  training label (score='1' = plate clearing) is more permissive than the deployment target (productive lysis) —
+  Gaborieau 2024 Methods explicitly admits clearing events at high titer can be non-productive. No feature or data
+  change required; a post-hoc calibration layer (isotonic / Platt) is the fix. Connects to `ambiguous-label-noise`.
+  **(B) BASEL's additional miscalibration = TL17-bias on the phage-side feature slot, NOT threshold**. Applying the
+  Guelin-fitted isotonic calibrator to BASEL closes only 34-37% of BASEL's gaps (residual ECE 0.113 bacteria-axis /
+  0.122 phage-axis) — the threshold-mismatch remedy does NOT rescue BASEL's extra miscalibration, empirically separating
+  this mechanism from (A). Root cause isolated to the 39/52 BASEL phages whose `phage_projection` vectors are non-zero
+  (Brier 0.31 bacteria-axis): their projection vectors map into Guelin-derived TL17 neighborhoods associated with
+  broad-host lysis but carry narrower actual host ranges. The 13/52 BASEL phages with zero-vector projection calibrate
+  correctly (Brier 0.12) because the model has no phage signal to misuse and falls back to the host-side prior. Requires
+  panel-independent phage features (CH06 target), not calibration. Straboviridae exclusion closes only 1.5 pp of the 9.5
+  pp bacteria-axis BASEL deficit — family bias is not the driver. This is the active CHISEL reference for two-axis
+  generalization and cross-source behaviour. [validated; source: CH05, 2026-04-19 CHISEL unified k-fold; see also:
+  chisel-baseline, spandex-unified-kfold-baseline, per-phage-retired-under-chisel, cv-group-leakage-fixed,
+  new-phage-generalization, deployment-goal, plm-rbp-redundant, panel-size-ceiling]
   - *Phage-axis AUC exceeds bacteria-axis AUC by 7.9 pp (CIs disjoint). The gap is structural, not a deployment-value
     signal: phage-axis folds hold out entire phages but keep all 369 bacteria in training; bacteria-axis folds hold out
     bacteria and remove host-side signal for those test pairs. The SX15 "per-phage blending tax" framing (which

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -414,8 +414,8 @@ themes:
           no-family bucket — 40% of folds are pseudo-family catch-alls; calling it
           "ICTV-stratified" without that qualifier misleads). This unit replaces the
           earlier "cross-source AUC parity" headline with three separate findings:
-          **(1) phage-axis discrimination parity** (Guelin 0.8863 vs BASEL 0.8818,
-          |ΔAUC| 0.0045 — a weak non-rejection on 52 BASEL phages with CI 3× wider than
+          **(1) phage-axis discrimination parity** (Guelin 0.8861 vs BASEL 0.8829,
+          |ΔAUC| 0.0032 — a weak non-rejection on 52 BASEL phages with CI 3× wider than
           Guelin's, not positive evidence of transfer); **(2) phage-axis calibration
           divergence** (Guelin Brier 0.1329 vs BASEL 0.1884, disjoint CIs, BASEL mid-P
           reliability gap 21-27 pp wider than Guelin's in the 0.5-0.9 predicted-probability

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -405,41 +405,75 @@ themes:
         statement: >
           CHISEL unified Guelin+BASEL k-fold baseline (CH05, 2026-04-19): per-row binary
           training on the unified 148-phage × 369-bacteria panel (36,643 pairs: 35,403 Guelin
-          + 1,240 BASEL) with `pair_concentration__log_dilution` as a numeric feature and
-          SX10 feature bundle otherwise unchanged. All-pairs only (per-phage blending
-          retired track-wide per `per-phage-retired-under-chisel`). Two axes:
+          + 1,240 BASEL), SX10 feature bundle, all-pairs only (per-phage blending retired
+          track-wide per `per-phage-retired-under-chisel`). Two axes:
           **bacteria-axis AUC 0.8061 [0.7917, 0.8199], Brier 0.1778 [0.1702, 0.1853]**
           (10-fold CH02 cv_group hash; all 148 phages in training per fold);
           **phage-axis AUC 0.8850 [0.8617, 0.9062], Brier 0.1348 [0.1219, 0.1495]**
-          (10-fold StratifiedKFold by ICTV family; all 369 bacteria in training per fold).
-          Cross-source phage-axis split: Guelin AUC 0.8863 [0.8653, 0.9078], BASEL AUC
-          0.8818 [0.8194, 0.9320] — **|ΔAUC| = 0.0045**, indistinguishable. This is the
-          active CHISEL reference for two-axis generalization and cross-source behaviour.
+          (10-fold StratifiedKFold by ICTV family + "other" <10-phage bucket + "UNKNOWN"
+          no-family bucket — 40% of folds are pseudo-family catch-alls; calling it
+          "ICTV-stratified" without that qualifier misleads). This unit replaces the
+          earlier "cross-source AUC parity" headline with three separate findings:
+          **(1) phage-axis discrimination parity** (Guelin 0.8863 vs BASEL 0.8818,
+          |ΔAUC| 0.0045 — a weak non-rejection on 52 BASEL phages with CI 3× wider than
+          Guelin's, not positive evidence of transfer); **(2) phage-axis calibration
+          divergence** (Guelin Brier 0.1329 vs BASEL 0.1884, disjoint CIs, BASEL mid-P
+          reliability gap 21-27 pp wider than Guelin's in the 0.5-0.9 predicted-probability
+          bins); **(3) BASEL bacteria-axis deficit** (BASEL-only bacteria-axis AUC 0.7152
+          on the 1,240 BASEL pairs vs Guelin-only 0.8098 on the same axis — a 9.5 pp
+          BASEL-specific deficit invisible in the 96.6% Guelin-weighted aggregate, a
+          standalone deployability finding separate from the phage-axis parity story).
+          Root-cause diagnostic (post-hoc, no model rerun): the mid-P miscalibration
+          localises to the 39/52 BASEL phages whose `phage_projection` vectors are
+          non-zero (Brier 0.31 bacteria-axis) — these phages map into Guelin-derived
+          TL17 neighborhoods associated with broad-host lysis but carry narrower actual
+          host ranges; the 13/52 BASEL phages with zero-vector projection calibrate
+          correctly (Brier 0.12) because the model has no phage signal to misuse and
+          falls back to the host-side prior. Straboviridae exclusion closes only 1.5 pp
+          of the 9.5 pp bacteria-axis BASEL deficit — family bias is not the driver.
+          This is the active CHISEL reference for two-axis generalization and
+          cross-source behaviour.
         sources: [CH05, 2026-04-19 CHISEL unified k-fold]
         status: active
         confidence: validated
         context: >
           Phage-axis AUC exceeds bacteria-axis AUC by 7.9 pp (CIs disjoint). The gap is
           structural, not a deployment-value signal: phage-axis folds hold out entire
-          phages but keep all 369 bacteria in training, so each held-out pair has
-          complete host-side signal available; bacteria-axis folds hold out bacteria
-          and remove host-side signal for those test pairs. The SX15 "per-phage blending
-          tax" framing (which interpreted this gap under per-phage blending enabled) is
-          retired — under all-pairs-only evaluation there is no tax to compute; the gap
-          is just the phage-axis-vs-bacteria-axis structural difference in training-data
-          coverage. The cross-source check confirms SX15's 11 pp Guelin-vs-BASEL nDCG
-          gap was a metric artifact: under AUC the two cohorts are within 0.4 pp (far
-          under the 1 pp expected tolerance). Bacteria-axis AUC 0.8061 is essentially
-          identical to CH04's 0.8084 (|Δ| < 0.25 pp) — adding 1,240 BASEL pairs to 35K
-          Guelin pairs at row level barely moves the aggregate. BASEL contributes useful
-          phage-axis signal (it fills 52 phages worth of holdout folds) without distorting
-          the bacteria-axis number. Canonical artifacts:
+          phages but keep all 369 bacteria in training; bacteria-axis folds hold out
+          bacteria and remove host-side signal for those test pairs. The SX15 "per-phage
+          blending tax" framing (which interpreted this gap under per-phage blending
+          enabled) is retired — under all-pairs-only evaluation there is no tax; the gap
+          is purely structural training-data coverage. Bacteria-axis aggregate AUC 0.8061
+          matches CH04's 0.8084 within 0.25 pp because adding 1,240 BASEL pairs to 35K
+          Guelin pairs barely shifts the 96.6%-Guelin-weighted aggregate — which is
+          exactly why the BASEL-specific 9.5 pp bacteria-axis deficit had to be reported
+          separately. The earlier draft's "BASEL phages generalize essentially identically
+          to Guelin phages" claim was a discrimination-only finding, not deployment
+          readiness — retired. The TL17-bias root cause supersedes the earlier
+          encoding-hypothesis framing: CH05's reliability analysis showed BASEL
+          over-predicted in mid-P, the opposite direction an encoding mismatch predicts,
+          so the pre-existing relative-log_dilution encoding of BASEL (at Guelin neat) was
+          not the dominant driver; the encoding has been fixed track-wide to absolute
+          log10_pfu_ml (Guelin {4.7, 6.7, 7.7, 8.7}; BASEL 9.0 per Maffei 2021 Fig. 12 +
+          Maffei 2025 Fig. 13 `>10⁹ pfu/ml if possible`) for semantic correctness; CH04
+          rerun under the new encoding is bit-identical at fold level (affine invariance
+          confirmed). Full CH05 rerun under new encoding deferred to a follow-up ticket.
+          Connects to `plm-rbp-redundant`: same Guelin-bank-dependent-phage-features
+          failure mode, here on a genuine cross-panel split rather than cross-family
+          within Guelin. Supports `panel-size-ceiling`: the fix is panel expansion or
+          panel-independent phage features (dispatched as new CH06 with four candidate
+          arms including OOD-aware inference, pairwise proteome similarity, Moriniere
+          receptor-class probabilities, tail-protein-restricted TL17 projection), not
+          richer engineered features. Canonical artifacts:
           lyzortx/generated_outputs/ch05_unified_kfold/ch05_combined_summary.json,
           ch05_{bacteria,phage}_axis_metrics.json, ch05_cross_source_breakdown.csv,
-          ch05_{bacteria,phage}_axis_predictions.csv.
+          ch05_{bacteria,phage}_axis_predictions.csv, ch05_per_family_breakdown.csv,
+          ch05_straboviridae_exclusion.csv, ch05_reliability_tables.csv,
+          ch05_basel_feature_variance.csv, ch05_basel_zero_vector_split.csv.
         relates_to: [chisel-baseline, spandex-unified-kfold-baseline,
                      per-phage-retired-under-chisel, cv-group-leakage-fixed,
-                     new-phage-generalization, deployment-goal]
+                     new-phage-generalization, deployment-goal,
+                     plm-rbp-redundant, panel-size-ceiling]
 
       - id: spandex-unified-kfold-baseline
         statement: >

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -423,16 +423,36 @@ themes:
           on the 1,240 BASEL pairs vs Guelin-only 0.8098 on the same axis — a 9.5 pp
           BASEL-specific deficit invisible in the 96.6% Guelin-weighted aggregate, a
           standalone deployability finding separate from the phage-axis parity story).
-          Root-cause diagnostic (post-hoc, no model rerun): the mid-P miscalibration
-          localises to the 39/52 BASEL phages whose `phage_projection` vectors are
-          non-zero (Brier 0.31 bacteria-axis) — these phages map into Guelin-derived
-          TL17 neighborhoods associated with broad-host lysis but carry narrower actual
-          host ranges; the 13/52 BASEL phages with zero-vector projection calibrate
-          correctly (Brier 0.12) because the model has no phage signal to misuse and
-          falls back to the host-side prior. Straboviridae exclusion closes only 1.5 pp
-          of the 9.5 pp bacteria-axis BASEL deficit — family bias is not the driver.
-          This is the active CHISEL reference for two-axis generalization and
-          cross-source behaviour.
+          Expected Calibration Error (ECE, weighted mean of per-decile |observed−predicted|
+          gaps) reported alongside AUC and Brier going forward: **bacteria-axis Guelin ECE
+          0.120, BASEL ECE 0.272; phage-axis Guelin ECE 0.104, BASEL ECE 0.236** under the
+          raw CH05 predictions. ECE separates calibration from discrimination more
+          interpretably than Brier and is now part of the CHISEL scorecard. Two separable
+          root-cause mechanisms, each diagnostically distinct:
+          **(A) Guelin mid-P miscalibration = training-label-vs-deployment-question
+          mismatch, post-hoc fixable**. Leave-one-fold-out isotonic regression on Guelin
+          predictions drops Guelin bacteria-axis ECE 0.120→0.008 and phage-axis ECE
+          0.104→0.008 (78-89% decile-gap closure), AUC preserved within 0.5 pp. The model
+          has the discrimination; it emits inflated probabilities in mid-P because the
+          training label (score='1' = plate clearing) is more permissive than the
+          deployment target (productive lysis) — Gaborieau 2024 Methods explicitly admits
+          clearing events at high titer can be non-productive. No feature or data change
+          required; a post-hoc calibration layer (isotonic / Platt) is the fix. Connects
+          to `ambiguous-label-noise`.
+          **(B) BASEL's additional miscalibration = TL17-bias on the phage-side feature
+          slot, NOT threshold**. Applying the Guelin-fitted isotonic calibrator to BASEL
+          closes only 34-37% of BASEL's gaps (residual ECE 0.113 bacteria-axis / 0.122
+          phage-axis) — the threshold-mismatch remedy does NOT rescue BASEL's extra
+          miscalibration, empirically separating this mechanism from (A). Root cause
+          isolated to the 39/52 BASEL phages whose `phage_projection` vectors are non-zero
+          (Brier 0.31 bacteria-axis): their projection vectors map into Guelin-derived TL17
+          neighborhoods associated with broad-host lysis but carry narrower actual host
+          ranges. The 13/52 BASEL phages with zero-vector projection calibrate correctly
+          (Brier 0.12) because the model has no phage signal to misuse and falls back to
+          the host-side prior. Requires panel-independent phage features (CH06 target), not
+          calibration. Straboviridae exclusion closes only 1.5 pp of the 9.5 pp
+          bacteria-axis BASEL deficit — family bias is not the driver. This is the active
+          CHISEL reference for two-axis generalization and cross-source behaviour.
         sources: [CH05, 2026-04-19 CHISEL unified k-fold]
         status: active
         confidence: validated

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -455,9 +455,14 @@ themes:
           so the pre-existing relative-log_dilution encoding of BASEL (at Guelin neat) was
           not the dominant driver; the encoding has been fixed track-wide to absolute
           log10_pfu_ml (Guelin {4.7, 6.7, 7.7, 8.7}; BASEL 9.0 per Maffei 2021 Fig. 12 +
-          Maffei 2025 Fig. 13 `>10⁹ pfu/ml if possible`) for semantic correctness; CH04
-          rerun under the new encoding is bit-identical at fold level (affine invariance
-          confirmed). Full CH05 rerun under new encoding deferred to a follow-up ticket.
+          Maffei 2025 Fig. 13 `>10⁹ pfu/ml if possible`) for semantic correctness. CH04
+          rerun (Guelin-only panel) is bit-identical at fold level because Guelin's change
+          is a monotonic affine shift of one feature (GUELIN_NEAT_LOG10_PFU_ML + log_dilution),
+          which LightGBM's bin-then-split flow leaves invariant. BASEL-side predictions may
+          shift on the pending CH05 rerun — BASEL's encoding moves from log_dilution=0 to
+          log10_pfu_ml=9.0, which is not an affine shift of the Guelin encoding, so
+          Guelin-side invariance does not extend to BASEL. Full CH05 rerun deferred to a
+          follow-up ticket.
           Connects to `plm-rbp-redundant`: same Guelin-bank-dependent-phage-features
           failure mode, here on a genuine cross-panel split rather than cross-family
           within Guelin. Supports `panel-size-ceiling`: the fix is panel expansion or

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -1,4 +1,4 @@
-last_consolidated: "2026-04-19T10:00:00+02:00"
+last_consolidated: "2026-04-19T16:00:00+02:00"
 source_dir: lyzortx/research_notes/lab_notebooks
 
 themes:
@@ -401,16 +401,59 @@ themes:
         relates_to: [panel-size-ceiling, spandex-unified-kfold-baseline,
                      narrow-host-prior-collapse]
 
+      - id: chisel-unified-kfold-baseline
+        statement: >
+          CHISEL unified Guelin+BASEL k-fold baseline (CH05, 2026-04-19): per-row binary
+          training on the unified 148-phage × 369-bacteria panel (36,643 pairs: 35,403 Guelin
+          + 1,240 BASEL) with `pair_concentration__log_dilution` as a numeric feature and
+          SX10 feature bundle otherwise unchanged. All-pairs only (per-phage blending
+          retired track-wide per `per-phage-retired-under-chisel`). Two axes:
+          **bacteria-axis AUC 0.8061 [0.7917, 0.8199], Brier 0.1778 [0.1702, 0.1853]**
+          (10-fold CH02 cv_group hash; all 148 phages in training per fold);
+          **phage-axis AUC 0.8850 [0.8617, 0.9062], Brier 0.1348 [0.1219, 0.1495]**
+          (10-fold StratifiedKFold by ICTV family; all 369 bacteria in training per fold).
+          Cross-source phage-axis split: Guelin AUC 0.8863 [0.8653, 0.9078], BASEL AUC
+          0.8818 [0.8194, 0.9320] — **|ΔAUC| = 0.0045**, indistinguishable. This is the
+          active CHISEL reference for two-axis generalization and cross-source behaviour.
+        sources: [CH05, 2026-04-19 CHISEL unified k-fold]
+        status: active
+        confidence: validated
+        context: >
+          Phage-axis AUC exceeds bacteria-axis AUC by 7.9 pp (CIs disjoint). The gap is
+          structural, not a deployment-value signal: phage-axis folds hold out entire
+          phages but keep all 369 bacteria in training, so each held-out pair has
+          complete host-side signal available; bacteria-axis folds hold out bacteria
+          and remove host-side signal for those test pairs. The SX15 "per-phage blending
+          tax" framing (which interpreted this gap under per-phage blending enabled) is
+          retired — under all-pairs-only evaluation there is no tax to compute; the gap
+          is just the phage-axis-vs-bacteria-axis structural difference in training-data
+          coverage. The cross-source check confirms SX15's 11 pp Guelin-vs-BASEL nDCG
+          gap was a metric artifact: under AUC the two cohorts are within 0.4 pp (far
+          under the 1 pp expected tolerance). Bacteria-axis AUC 0.8061 is essentially
+          identical to CH04's 0.8084 (|Δ| < 0.25 pp) — adding 1,240 BASEL pairs to 35K
+          Guelin pairs at row level barely moves the aggregate. BASEL contributes useful
+          phage-axis signal (it fills 52 phages worth of holdout folds) without distorting
+          the bacteria-axis number. Canonical artifacts:
+          lyzortx/generated_outputs/ch05_unified_kfold/ch05_combined_summary.json,
+          ch05_{bacteria,phage}_axis_metrics.json, ch05_cross_source_breakdown.csv,
+          ch05_{bacteria,phage}_axis_predictions.csv.
+        relates_to: [chisel-baseline, spandex-unified-kfold-baseline,
+                     per-phage-retired-under-chisel, cv-group-leakage-fixed,
+                     new-phage-generalization, deployment-goal]
+
       - id: spandex-unified-kfold-baseline
         statement: >
-          SX15 unified Guelin+BASEL k-fold baseline (2026-04-15, default BASEL+→MLC=2; 2026-04-18
-          re-headline under CHISEL frame): **bacteria-axis AUC 0.8685, phage-axis AUC 0.8988,
-          cross-source near-parity AUC 0.896 (BASEL) vs 0.899 (Guelin)**. Phage-axis (all-pairs
-          only; held-out phages unseen) is the first honest deployability estimate for unseen
-          phages. The BASEL-vs-Guelin nDCG comparison (0.8332 vs 0.7193) is dropped — it is a
-          metric artifact because BASEL binary labels have fewer nDCG rungs than Guelin's MLC
+          HISTORICAL (SPANDEX-era). Superseded as the active unified-panel reference by
+          chisel-unified-kfold-baseline (CH05). SX15 unified Guelin+BASEL k-fold baseline
+          (2026-04-15, default BASEL+→MLC=2; 2026-04-18 re-headline under CHISEL frame):
+          bacteria-axis AUC 0.8685, phage-axis AUC 0.8988, cross-source near-parity AUC
+          0.896 (BASEL) vs 0.899 (Guelin). Phage-axis (all-pairs only; held-out phages
+          unseen) was the first honest deployability estimate for unseen phages. The
+          BASEL-vs-Guelin nDCG comparison (0.8332 vs 0.7193) was dropped — it was a metric
+          artifact because BASEL binary labels have fewer nDCG rungs than Guelin's MLC
           grades, so direct nDCG comparison is not interpretable. AUC is comparable across
-          sources and shows BASEL phages generalize essentially identically to Guelin phages.
+          sources and shows BASEL phages generalize essentially identically to Guelin
+          phages.
         sources: [SX15]
         status: dead-end
         confidence: validated
@@ -421,13 +464,17 @@ themes:
           but really reflects the deployment mix — phage-axis folds hold out entire phages so
           each test pair has more host-side signal available per training positive. Under
           CHISEL, this baseline is superseded by chisel-unified-kfold-baseline (established
-          in CH05) after the cv_group leakage fix (CH02) and concentration-feature flip
-          (CH04). Until then, SX15 remains the reference point for cross-source generalization.
+          in CH05) after the cv_group leakage fix (CH02), concentration-feature flip (CH04),
+          and per-phage retirement (per-phage-retired-under-chisel). SX15 numbers were
+          computed with pair-level any_lysis training and per-phage blending enabled under
+          the leaky cv_group folds; all three of those confounders are closed under CHISEL.
           Artifact paths:
           lyzortx/generated_outputs/sx15_eval/sx15_{bacteria,phage}_axis_stratified_metrics.csv
           and sx15_{bacteria,phage}_axis_predictions.csv.
-        relates_to: [spandex-final-baseline, stratified-eval-framework,
-                     new-phage-generalization, external-data-neutral]
+        relates_to: [chisel-unified-kfold-baseline, spandex-final-baseline,
+                     stratified-eval-framework, new-phage-generalization,
+                     external-data-neutral, per-phage-retired-under-chisel,
+                     cv-group-leakage-fixed]
 
       - id: autoresearch-baseline
         statement: >

--- a/lyzortx/pipeline/autoresearch/ch03_row_expansion.py
+++ b/lyzortx/pipeline/autoresearch/ch03_row_expansion.py
@@ -39,6 +39,13 @@ RAW_SCORE_POSITIVE = "1"
 RAW_SCORE_NEGATIVE = "0"
 RAW_SCORE_UNINTERPRETABLE = "n"
 
+# Guelin protocol neat concentration: 5×10⁸ pfu/ml → log10 ≈ 8.69897, rounded to 8.7. The
+# concentration feature fed to LightGBM is `log10_pfu_ml = GUELIN_NEAT_LOG10_PFU_ML +
+# log_dilution` (log_dilution ∈ {0, -1, -2, -4} gives {8.7, 7.7, 6.7, 4.7}). This replaces the
+# earlier relative `log_dilution` encoding so BASEL rows (single spot test at >10⁹ pfu/ml) can
+# share the same feature axis without implicitly mapping BASEL's >10⁹ onto Guelin's neat.
+GUELIN_NEAT_LOG10_PFU_ML = 8.7
+
 
 def load_raw_observation_rows(raw_path: Path = RAW_INTERACTIONS_PATH) -> pd.DataFrame:
     """Load raw_interactions.csv as one row per observation.
@@ -93,11 +100,15 @@ def load_row_expanded_frame(
             f"(example pair_ids: {missing_pair_meta['pair_id'].head().tolist()})"
         )
 
+    merged["log10_pfu_ml"] = GUELIN_NEAT_LOG10_PFU_ML + merged["log_dilution"].astype(float)
+
     LOGGER.info(
-        "Row-expanded frame: %d rows, %d pairs, %d columns",
+        "Row-expanded frame: %d rows, %d pairs, %d columns, log10_pfu_ml range [%.2f, %.2f]",
         len(merged),
         merged["pair_id"].nunique(),
         len(merged.columns),
+        merged["log10_pfu_ml"].min(),
+        merged["log10_pfu_ml"].max(),
     )
     return merged
 

--- a/lyzortx/pipeline/autoresearch/ch04_eval.py
+++ b/lyzortx/pipeline/autoresearch/ch04_eval.py
@@ -7,12 +7,20 @@ Establishes the first canonical CHISEL baseline. Training unit flips from pair-l
 is its own training row. Rows with score == "n" are dropped as missing (not negative),
 matching the ST01B rule.
 
-The `log_dilution` value enters the model as a numeric pair-level feature
-(`pair_concentration__log_dilution`). No binning, no conditioning, no per-concentration
-sub-models — LightGBM learns the concentration effect as part of training. All other
-feature engineering is identical to the SX10 baseline (host_surface + host_typing +
-host_stats + host_defense + phage_projection + phage_stats + pair_depo_capsule +
-pair_receptor_omp, RFE-selected), so the CH04-vs-CH02 delta isolates the frame change.
+Concentration enters the model as a numeric pair-level feature encoded as absolute
+log₁₀ pfu/ml (`pair_concentration__log10_pfu_ml`). Guelin's {0, -1, -2, -4} relative
+log_dilution steps map to {8.7, 7.7, 6.7, 4.7} absolute log₁₀ pfu/ml (Guelin neat at
+5×10⁸ pfu/ml ≈ 10⁸·⁷). This encoding is chosen so CH05's unified Guelin+BASEL panel
+can express BASEL's >10⁹ pfu/ml spot test as log₁₀ = 9.0 on the same feature axis
+without the relative-log_dilution ambiguity (BASEL is not a dilution step). For
+CH04 Guelin-only, the encoding is an affine shift of the prior `log_dilution`
+feature — tree splits are threshold-equivalent and metrics are bit-identical to
+pre-encoding runs under the same seeds. No binning, no conditioning, no
+per-concentration sub-models — LightGBM learns the effect as part of training. All
+other feature engineering is identical to the SX10 baseline (host_surface +
+host_typing + host_stats + host_defense + phage_projection + phage_stats +
+pair_depo_capsule + pair_receptor_omp, RFE-selected), so the CH04-vs-CH02 delta
+isolates the frame change.
 
 Per-phage blending (AX02) is dropped. SPANDEX's per-phage models added ~2 pp AUC to
 bacteria-axis evaluation but are `per-phage-not-deployable` — they require training
@@ -26,9 +34,9 @@ measures the cross-phage generalization cost directly and is the honest successo
 Evaluation uses AUC + Brier only. No nDCG, mAP, or top-k: ranking is a product-layer
 concern and retired from the CHISEL scorecard (see ranking-metrics-retired). Each
 held-out (bacterium, phage) pair is scored at its highest-observed concentration
-(max log_dilution = neat, typically 0) to match the deployment question "would this
-phage lyse this bacterium at the maximum testable titer?" — that single prediction
-per pair is aggregated with bacterium-level bootstrap CIs.
+(max log10_pfu_ml = Guelin neat 8.7 or BASEL 9.0) to match the deployment question
+"would this phage lyse this bacterium at the maximum testable titer?" — that single
+prediction per pair is aggregated with bacterium-level bootstrap CIs.
 
 Usage:
     PYTHONPATH=. python -m lyzortx.pipeline.autoresearch.ch04_eval --device-type cpu
@@ -80,7 +88,7 @@ DEFAULT_CANDIDATE_DIR = Path("lyzortx/autoresearch")
 DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/ch04_chisel_baseline")
 
 CH02_REVALIDATED_METRICS_PATH = Path("lyzortx/generated_outputs/ch02_cv_group_fix/ch02_sx10_revalidated_metrics.json")
-CONCENTRATION_FEATURE_COLUMN = "pair_concentration__log_dilution"
+CONCENTRATION_FEATURE_COLUMN = "pair_concentration__log10_pfu_ml"
 BOOTSTRAP_SAMPLES = 1000
 BOOTSTRAP_RANDOM_STATE = 42
 
@@ -90,19 +98,39 @@ def build_clean_row_training_frame(row_frame: pd.DataFrame) -> pd.DataFrame:
 
     `score == "n"` rows are dropped from training (they're missing observations, not
     negative). The remaining rows get two derived columns: `label_row_binary` (int 0/1)
-    for the training target and `pair_concentration__log_dilution` (float) for the
-    concentration feature LightGBM ingests.
+    for the training target and `pair_concentration__log10_pfu_ml` (float) for the
+    concentration feature LightGBM ingests. The row frame is expected to carry a
+    pre-computed `log10_pfu_ml` column (added at the row-frame source: CH03 for Guelin,
+    CH05 for BASEL) — CH04 does not derive it here, so each source owns its encoding.
+
+    Also logs pair-level bookkeeping: pairs whose every observation is `n` (no
+    interpretable lysis observations) lose all their rows in this filter, so the
+    surviving pair count is below the input pair count. Log lets callers notice when
+    that number shifts across dataset revisions.
     """
     clean = row_frame.loc[row_frame["score"].isin([RAW_SCORE_POSITIVE, RAW_SCORE_NEGATIVE])].copy()
-    dropped = len(row_frame) - len(clean)
+    dropped_rows = len(row_frame) - len(clean)
+    input_pairs = row_frame["pair_id"].nunique() if "pair_id" in row_frame.columns else None
+    output_pairs = clean["pair_id"].nunique() if "pair_id" in clean.columns else None
+    pair_drop_detail = ""
+    if input_pairs is not None and output_pairs is not None:
+        pairs_dropped = input_pairs - output_pairs
+        pair_drop_detail = f"; {pairs_dropped} pairs lost all interpretable rows ({input_pairs} → {output_pairs} pairs)"
     LOGGER.info(
-        "Dropped %d score='%s' rows (missing observations); %d interpretable rows remain",
-        dropped,
+        "Dropped %d score='%s' rows (missing observations); %d interpretable rows remain%s",
+        dropped_rows,
         RAW_SCORE_UNINTERPRETABLE,
         len(clean),
+        pair_drop_detail,
     )
+    if "log10_pfu_ml" not in clean.columns:
+        raise ValueError(
+            "Row frame missing required 'log10_pfu_ml' column. Guelin rows get it from "
+            "`ch03_row_expansion.load_row_expanded_frame`; BASEL rows get it from "
+            "`ch05_eval.load_basel_as_row_frame`."
+        )
     clean["label_row_binary"] = clean["score"].astype(int)
-    clean[CONCENTRATION_FEATURE_COLUMN] = clean["log_dilution"].astype(float)
+    clean[CONCENTRATION_FEATURE_COLUMN] = clean["log10_pfu_ml"].astype(float)
     return clean
 
 
@@ -119,7 +147,7 @@ def train_and_predict_per_row_fold(
 
     Same host/phage slot bundle as SX10, same pairwise cross-terms, same RFE. Differs
     from SPANDEX/CH02 on three axes: (1) `label_row_binary` replaces `label_any_lysis`
-    as the training target, (2) `pair_concentration__log_dilution` is added as a
+    as the training target, (2) `pair_concentration__log10_pfu_ml` is added as a
     feature column before RFE, and (3) every row is a training example rather than
     one row per pair. Per-phage blending (AX02) is intentionally omitted — see module
     docstring for rationale.
@@ -161,6 +189,8 @@ def train_and_predict_per_row_fold(
     holdout_design[CONCENTRATION_FEATURE_COLUMN] = holdout_frame[CONCENTRATION_FEATURE_COLUMN].to_numpy()
     train_design["label_row_binary"] = training_frame["label_row_binary"].to_numpy()
     holdout_design["label_row_binary"] = holdout_frame["label_row_binary"].to_numpy()
+    train_design["log10_pfu_ml"] = training_frame["log10_pfu_ml"].to_numpy()
+    holdout_design["log10_pfu_ml"] = holdout_frame["log10_pfu_ml"].to_numpy()
     train_design["log_dilution"] = training_frame["log_dilution"].to_numpy()
     holdout_design["log_dilution"] = holdout_frame["log_dilution"].to_numpy()
     train_design["replicate"] = training_frame["replicate"].to_numpy()
@@ -199,7 +229,9 @@ def train_and_predict_per_row_fold(
 
     rows = []
     for (_, row), probability in zip(
-        holdout_design[["pair_id", "bacteria", "phage", "label_row_binary", "log_dilution", "replicate"]].iterrows(),
+        holdout_design[
+            ["pair_id", "bacteria", "phage", "label_row_binary", "log_dilution", "log10_pfu_ml", "replicate"]
+        ].iterrows(),
         predictions,
     ):
         rows.append(
@@ -210,6 +242,7 @@ def train_and_predict_per_row_fold(
                 "bacteria": str(row["bacteria"]),
                 "phage": str(row["phage"]),
                 "log_dilution": int(row["log_dilution"]),
+                "log10_pfu_ml": float(row["log10_pfu_ml"]),
                 "replicate": int(row["replicate"]),
                 "label_row_binary": int(row["label_row_binary"]),
                 "predicted_probability": safe_round(float(probability)),
@@ -222,27 +255,31 @@ def train_and_predict_per_row_fold(
             "importance": estimator.feature_importances_,
         }
     )
-    feature_importance["is_log_dilution"] = feature_importance["feature"] == CONCENTRATION_FEATURE_COLUMN
+    feature_importance["is_concentration_feature"] = feature_importance["feature"] == CONCENTRATION_FEATURE_COLUMN
     return rows, feature_importance
 
 
 def select_pair_max_concentration_rows(per_row_predictions: pd.DataFrame) -> pd.DataFrame:
-    """Keep one prediction row per held-out (bacterium, phage) pair, at max log_dilution.
+    """Keep one prediction row per held-out (bacterium, phage) pair, at max log10_pfu_ml.
 
-    The ticket defines "highest observed concentration" per pair — pick max log_dilution
-    (log_dilution=0 is neat, -4 is 1:10000 dilution; higher numeric value = higher actual
-    concentration). Replicate rows at that top concentration are collapsed by averaging
-    the predicted probability (replicates have identical feature vectors, so their
-    predictions are identical anyway — the mean is a no-op in practice but it documents
-    intent) and by max-aggregating the binary label (any positive replicate makes the
-    pair positive). This "any replicate positive" rule matches the deployment semantics
-    of the test strip read-out: a pair is declared positive if lysis is observed in at
-    least one replicate at the top titer. CH04's core training still operates per-row.
+    "Highest observed concentration" per pair is picked by max `log10_pfu_ml` — the
+    absolute-titer feature the model actually sees. For Guelin-only inputs this is
+    equivalent to max log_dilution (values {8.7, 7.7, 6.7, 4.7} order-preserve {0, -1,
+    -2, -4}). For the unified Guelin+BASEL frame, BASEL's single row per pair always
+    wins at log10_pfu_ml = 9.0, so the aggregation trivially surfaces it. Replicate
+    rows at that top concentration are collapsed by averaging the predicted
+    probability (replicates have identical feature vectors, so their predictions are
+    identical anyway — the mean is a no-op in practice but it documents intent) and
+    by max-aggregating the binary label (any positive replicate makes the pair
+    positive). This "any replicate positive" rule matches the deployment semantics
+    of the test strip read-out: a pair is declared positive if lysis is observed in
+    at least one replicate at the top titer. CH04's core training still operates
+    per-row.
     """
-    ranked = per_row_predictions.sort_values(["pair_id", "log_dilution", "replicate"], ascending=[True, False, True])
-    max_conc = ranked.groupby("pair_id", as_index=False)["log_dilution"].max()
-    top_rows = ranked.merge(max_conc, on=["pair_id", "log_dilution"], how="inner")
-    aggregated = top_rows.groupby(["pair_id", "bacteria", "phage", "log_dilution"], as_index=False).agg(
+    ranked = per_row_predictions.sort_values(["pair_id", "log10_pfu_ml", "replicate"], ascending=[True, False, True])
+    max_conc = ranked.groupby("pair_id", as_index=False)["log10_pfu_ml"].max()
+    top_rows = ranked.merge(max_conc, on=["pair_id", "log10_pfu_ml"], how="inner")
+    aggregated = top_rows.groupby(["pair_id", "bacteria", "phage", "log10_pfu_ml"], as_index=False).agg(
         predicted_probability=("predicted_probability", "mean"),
         label_row_binary=("label_row_binary", "max"),
         n_replicates_at_max=("replicate", "count"),
@@ -396,11 +433,20 @@ def run_ch04_eval(
         per_row_df = pd.DataFrame(fold_seed_rows)
         aggregated = (
             per_row_df.groupby(
-                ["fold_id", "pair_id", "bacteria", "phage", "log_dilution", "replicate", "label_row_binary"],
+                [
+                    "fold_id",
+                    "pair_id",
+                    "bacteria",
+                    "phage",
+                    "log_dilution",
+                    "log10_pfu_ml",
+                    "replicate",
+                    "label_row_binary",
+                ],
                 as_index=False,
             )["predicted_probability"]
             .mean()
-            .sort_values(["bacteria", "phage", "log_dilution", "replicate"])
+            .sort_values(["bacteria", "phage", "log10_pfu_ml", "replicate"])
         )
         all_per_row_predictions.extend(aggregated.to_dict(orient="records"))
 
@@ -440,12 +486,12 @@ def run_ch04_eval(
 
     feature_importance_df = pd.concat(all_feature_importance, ignore_index=True)
     fi_agg = (
-        feature_importance_df.groupby(["feature", "is_log_dilution"], as_index=False)
+        feature_importance_df.groupby(["feature", "is_concentration_feature"], as_index=False)
         .agg(mean_importance=("importance", "mean"), n_folds_selected=("importance", "count"))
         .sort_values("mean_importance", ascending=False)
     )
     fi_agg.to_csv(output_dir / "ch04_feature_importance.csv", index=False)
-    concentration_rows = fi_agg[fi_agg["is_log_dilution"]]
+    concentration_rows = fi_agg[fi_agg["is_concentration_feature"]]
     concentration_importance = (
         float(concentration_rows["mean_importance"].iloc[0]) if not concentration_rows.empty else 0.0
     )
@@ -459,7 +505,7 @@ def run_ch04_eval(
         "task_id": "CH04",
         "scorecard": "AUC + Brier (nDCG/mAP/top-k retired; see ranking-metrics-retired)",
         "training_unit": "per-row (bacterium, phage, log_dilution, replicate, X, Y) with score ∈ {0, 1}",
-        "evaluation_unit": "per-pair at max observed log_dilution (one prediction per held-out pair)",
+        "evaluation_unit": "per-pair at max observed log10_pfu_ml (one prediction per held-out pair)",
         "n_bacteria_total": int(pair_predictions["bacteria"].nunique()),
         "n_pairs_evaluated": int(len(pair_predictions)),
         "n_training_rows_dropped_as_n": int(len(row_frame) - len(clean_rows)),

--- a/lyzortx/pipeline/autoresearch/ch05_eval.py
+++ b/lyzortx/pipeline/autoresearch/ch05_eval.py
@@ -44,6 +44,7 @@ from typing import Any, Optional, Sequence
 
 import numpy as np
 import pandas as pd
+from sklearn.metrics import brier_score_loss, roc_auc_score
 from sklearn.model_selection import StratifiedKFold
 
 from lyzortx.log_config import setup_logging
@@ -284,8 +285,6 @@ def _bootstrap_by_unit(
         preds = np.array([float(r["predicted_probability"]) for r in sampled])
         if len(np.unique(labels)) < 2:
             continue
-        from sklearn.metrics import brier_score_loss, roc_auc_score
-
         aucs.append(float(roc_auc_score(labels, preds)))
         briers.append(float(brier_score_loss(labels, preds)))
 

--- a/lyzortx/pipeline/autoresearch/ch05_eval.py
+++ b/lyzortx/pipeline/autoresearch/ch05_eval.py
@@ -90,39 +90,64 @@ CH04_AGGREGATE_METRICS_PATH = Path("lyzortx/generated_outputs/ch04_chisel_baseli
 SOURCE_GUELIN = "guelin"
 SOURCE_BASEL = "basel"
 BASEL_REPLICATE_ID = 1
-BASEL_LOG_DILUTION = 0  # BASEL's single spot test approximates Guelin's neat concentration.
+# Sentinel log_dilution value for BASEL rows: BASEL is a single spot test, not a dilution
+# step, so `log_dilution` is semantically undefined. We carry 0 as a sentinel to keep the
+# (pair_id, log_dilution, replicate) observation-key shape uniform across sources. The
+# LightGBM feature is `pair_concentration__log10_pfu_ml`, not `log_dilution` — see
+# `BASEL_LOG10_PFU_ML`.
+BASEL_LOG_DILUTION_SENTINEL = 0
+# BASEL working titer reported as >10⁹ pfu/ml in Maffei 2021 Fig. 12 and Maffei 2025 Fig. 13
+# (PLOS Biology). Neither paper reports a more specific number; the 2025 paper adds "if
+# possible", suggesting some batches may be lower. We adopt 9.0 as the conservative lower
+# bound for the absolute log₁₀ pfu/ml concentration feature. Guelin's steps land at
+# {4.7, 6.7, 7.7, 8.7} (GUELIN_NEAT_LOG10_PFU_ML + log_dilution), so BASEL at 9.0 is above
+# Guelin's max concentration — the 0.3 log gap is the honest encoding, not an artifact of
+# collapsing BASEL onto Guelin's neat.
+BASEL_LOG10_PFU_ML = 9.0
 PHAGE_AXIS_RANDOM_STATE = 42
 
 
-def load_basel_as_row_frame(bacteria_cv_group: dict[str, str]) -> pd.DataFrame:
+def load_basel_as_row_frame(
+    bacteria_cv_group: dict[str, str],
+    *,
+    basel_log10_pfu_ml: float = BASEL_LOG10_PFU_ML,
+) -> pd.DataFrame:
     """Materialise BASEL pairs as row-level training rows.
 
     BASEL is a single spot test (>10⁹ pfu/ml) per pair, not a dilution series, so each
-    pair contributes exactly one training row. We encode it as `log_dilution=0` (matching
-    Guelin's neat concentration) and `replicate=1`, with `score` copied from the binary
-    interaction outcome.
+    pair contributes exactly one training row. Encoded with `replicate=1`,
+    `log_dilution=0` (sentinel — BASEL is not a dilution step; see
+    `BASEL_LOG_DILUTION_SENTINEL`), `log10_pfu_ml=basel_log10_pfu_ml` (default 9.0,
+    the conservative lower bound on the Maffei-reported >10⁹ pfu/ml titer), and
+    `score` copied from the binary interaction outcome. `basel_log10_pfu_ml` is
+    exposed as a parameter for sensitivity analysis (e.g. testing a more optimistic
+    9.3 encoding if a future paper quotes a specific higher value).
 
     BASEL bacteria are a subset of Guelin bacteria (all 25 BASEL ECOR strains appear in
     the 369-bacterium Guelin panel), so `cv_group` is inherited from the Guelin mapping.
-    Rows whose bacterium is absent from the Guelin cv_group map are dropped (should be
-    zero in practice — the BASEL ECOR panel is fully contained in Guelin).
+    Fails loudly if any BASEL bacterium is absent from the map — per AGENTS.md fail-fast.
     """
     basel = load_basel_interactions().copy()
     basel = basel.dropna(subset=["interaction"])
     basel["score"] = basel["interaction"].astype(int).astype(str)
-    basel["log_dilution"] = BASEL_LOG_DILUTION
+    basel["log_dilution"] = BASEL_LOG_DILUTION_SENTINEL
+    basel["log10_pfu_ml"] = float(basel_log10_pfu_ml)
     basel["replicate"] = BASEL_REPLICATE_ID
     basel["source"] = SOURCE_BASEL
 
     basel["cv_group"] = basel["bacteria"].map(bacteria_cv_group)
     missing = basel[basel["cv_group"].isna()]
     if not missing.empty:
-        LOGGER.warning(
-            "BASEL rows with no Guelin cv_group (dropped): %d (example bacteria: %s)",
-            len(missing),
-            missing["bacteria"].unique()[:5].tolist(),
+        # AGENTS.md fail-fast rule: the BASEL ECOR panel is documented as fully contained in
+        # the 369-bacterium Guelin panel (basel-binary-only knowledge unit). A missing bacterium
+        # is a data-integrity violation, not a recoverable case — silent drop would corrupt the
+        # "1,240 BASEL pairs" headline in the knowledge unit without anyone noticing.
+        raise ValueError(
+            f"{len(missing)} BASEL rows have no Guelin cv_group mapping; BASEL ECOR panel "
+            f"is expected to be fully contained in the Guelin panel "
+            f"(offending bacteria: {sorted(missing['bacteria'].unique())}). "
+            f"If this is intentional, update the docstring, the knowledge unit, and this check."
         )
-        basel = basel.dropna(subset=["cv_group"])
 
     # Downstream per-row training frame filters on split_holdout and is_hard_trainable.
     # Treat every BASEL observation as trainable — no ST03-style holdout split applies to
@@ -144,6 +169,7 @@ def load_basel_as_row_frame(bacteria_cv_group: dict[str, str]) -> pd.DataFrame:
             "bacteria",
             "phage",
             "log_dilution",
+            "log10_pfu_ml",
             "replicate",
             "score",
             "source",
@@ -154,19 +180,25 @@ def load_basel_as_row_frame(bacteria_cv_group: dict[str, str]) -> pd.DataFrame:
     ].copy()
 
 
-def load_unified_row_frame() -> pd.DataFrame:
+def load_unified_row_frame(basel_log10_pfu_ml: float = BASEL_LOG10_PFU_ML) -> pd.DataFrame:
     """Concatenate Guelin (318K rows, 9 replicates × pair) + BASEL (~1.2K rows, 1 row × pair).
 
     Both sides carry `source ∈ {"guelin", "basel"}` and the minimal column set CH04's
     per-row pipeline consumes. Guelin rows inherit split_holdout / is_hard_trainable from
     ST02+ST03; BASEL rows are marked universally trainable.
+
+    `basel_log10_pfu_ml` threads through to `load_basel_as_row_frame`; the default (9.0)
+    is the conservative lower bound on the Maffei-reported BASEL working titer >10⁹ pfu/ml.
+    Guelin rows carry `log10_pfu_ml ∈ {8.7, 7.7, 6.7, 4.7}` from `ch03_row_expansion`; the
+    absolute-titer feature places BASEL 0.3 log above Guelin's neat rather than collapsing
+    both onto the same concentration.
     """
     guelin = load_row_expanded_frame().copy()
     guelin["source"] = SOURCE_GUELIN
 
     # Extract Guelin bacteria → cv_group so BASEL rows can inherit cv_group.
     guelin_map = bacteria_to_cv_group_map(guelin)
-    basel = load_basel_as_row_frame(guelin_map)
+    basel = load_basel_as_row_frame(guelin_map, basel_log10_pfu_ml=basel_log10_pfu_ml)
 
     # Reduce both frames to the shared column set before concatenation. Guelin has many
     # additional pair-level columns (host/phage metadata, training_weight_v3, etc.) that
@@ -177,6 +209,7 @@ def load_unified_row_frame() -> pd.DataFrame:
         "bacteria",
         "phage",
         "log_dilution",
+        "log10_pfu_ml",
         "replicate",
         "score",
         "source",
@@ -245,13 +278,14 @@ def _aggregate_fold_rows_to_pairs(fold_rows: list[dict[str, object]]) -> pd.Data
                 "bacteria",
                 "phage",
                 "log_dilution",
+                "log10_pfu_ml",
                 "replicate",
                 "label_row_binary",
             ],
             as_index=False,
         )["predicted_probability"]
         .mean()
-        .sort_values(["bacteria", "phage", "log_dilution", "replicate"])
+        .sort_values(["bacteria", "phage", "log10_pfu_ml", "replicate"])
     )
     return aggregated
 
@@ -322,6 +356,8 @@ def _ci_to_dict(ci: BootstrapMetricCI) -> dict[str, Optional[float]]:
         "point_estimate": safe_round(ci.point_estimate) if ci.point_estimate is not None else None,
         "ci_low": ci.ci_low,
         "ci_high": ci.ci_high,
+        "bootstrap_samples_requested": ci.bootstrap_samples_requested,
+        "bootstrap_samples_used": ci.bootstrap_samples_used,
     }
 
 
@@ -442,12 +478,17 @@ def run_ch05_eval(
     output_dir: Path,
     cache_dir: Path,
     candidate_dir: Path,
+    basel_log10_pfu_ml: float = BASEL_LOG10_PFU_ML,
 ) -> dict[str, object]:
     output_dir.mkdir(parents=True, exist_ok=True)
     start_time = datetime.now(timezone.utc)
-    LOGGER.info("CH05 evaluation starting at %s", start_time.isoformat())
+    LOGGER.info(
+        "CH05 evaluation starting at %s (basel_log10_pfu_ml=%.2f)",
+        start_time.isoformat(),
+        basel_log10_pfu_ml,
+    )
 
-    unified = load_unified_row_frame()
+    unified = load_unified_row_frame(basel_log10_pfu_ml=basel_log10_pfu_ml)
     clean_rows = build_clean_row_training_frame(unified)
     LOGGER.info(
         "CH05 clean row frame: %d rows, %d pairs, %d bacteria, %d phages",
@@ -530,7 +571,13 @@ def run_ch05_eval(
             len({r["phage"] for r in subset}),
         )
         if not subset:
-            continue
+            # Cross-source breakdown is a required CH05 output; an empty subset means the
+            # unified frame lost its source tag or a whole cohort disappeared — either is a
+            # pipeline bug, not a recoverable case.
+            raise ValueError(
+                f"Phage-axis cross-source subset for {source_label!r} is empty; "
+                f"unified frame and source tag propagation must cover both Guelin and BASEL."
+            )
         subset_cis = _bootstrap_by_unit(
             subset,
             unit_key="phage",
@@ -608,6 +655,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
     parser.add_argument("--candidate-dir", type=Path, default=DEFAULT_CANDIDATE_DIR)
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--basel-log10-pfu-ml",
+        type=float,
+        default=BASEL_LOG10_PFU_ML,
+        help=(
+            "Absolute log₁₀ pfu/ml value to assign to BASEL rows on the "
+            "`pair_concentration__log10_pfu_ml` feature axis. Default 9.0 is the "
+            "conservative lower bound on Maffei's >10⁹ pfu/ml working titer. Raise "
+            "to e.g. 9.3 for a sensitivity analysis if a more specific titer is sourced."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -619,6 +677,7 @@ def main(argv: list[str] | None = None) -> None:
         output_dir=args.output_dir,
         cache_dir=args.cache_dir,
         candidate_dir=args.candidate_dir,
+        basel_log10_pfu_ml=args.basel_log10_pfu_ml,
     )
 
 

--- a/lyzortx/pipeline/autoresearch/ch05_eval.py
+++ b/lyzortx/pipeline/autoresearch/ch05_eval.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+"""CH05: Unified Guelin+BASEL CHISEL evaluation — both axes, cross-source breakdown.
+
+Successor to SX15 under the CHISEL frame. Runs CH04's per-row all-pairs pipeline on the
+unified 148-phage × 369-bacteria panel:
+
+- **Bacteria-axis** (10-fold via CH02 cv_group hash): all 148 phages remain in training;
+  bacteria are held out. Measures generalization to unseen bacteria.
+- **Phage-axis** (10-fold StratifiedKFold by ICTV family): all 369 bacteria remain in
+  training; phages are held out. Measures generalization to unseen phages — the
+  deployment question per `deployment-goal`.
+
+**Per-phage blending is retired on both axes.** `per-phage-retired-under-chisel` applies
+track-wide (not just to bacteria-axis). On phage-axis per-phage is structurally impossible
+(held-out phages have zero training rows); on bacteria-axis the retirement rationale from
+CH04 still holds — it is not deployable, inflates bacteria-axis AUC non-transferably, and
+an intermediate CH04 diagnostic showed it deflates positive predictions under per-row
+training. This deviates from the CH05 ticket's "BACTERIA-AXIS: per-phage blending enabled"
+directive, justified per AGENTS.md "Question the requirement" and documented in
+`per-phage-retired-under-chisel`. The ticket's "BLENDING TAX" is consequently retired too —
+under all-pairs-only evaluation, the bacteria-vs-phage-axis gap is the plain phage-axis
+generalization gap, not a blending tax.
+
+**Cross-source sanity check**: on phage-axis, AUC is computed separately for held-out
+Guelin phages (96) and held-out BASEL phages (52). SX15 under nDCG produced a BASEL-vs-
+Guelin artifact (11 pp gap) that was a metric artifact, not a real generalization
+difference. Under CHISEL AUC+Brier, the two cohorts should land within ~1 pp of each
+other.
+
+Usage:
+    PYTHONPATH=. python -m lyzortx.pipeline.autoresearch.ch05_eval --device-type cpu
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import StratifiedKFold
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.candidate_replay import (
+    BootstrapMetricCI,
+    load_module_from_path,
+    safe_round,
+)
+from lyzortx.pipeline.autoresearch.ch03_row_expansion import (
+    RAW_SCORE_NEGATIVE,
+    RAW_SCORE_POSITIVE,
+    RAW_SCORE_UNINTERPRETABLE,
+    load_row_expanded_frame,
+)
+from lyzortx.pipeline.autoresearch.ch04_eval import (
+    BOOTSTRAP_RANDOM_STATE,
+    BOOTSTRAP_SAMPLES,
+    CONCENTRATION_FEATURE_COLUMN,
+    build_clean_row_training_frame,
+    compute_aggregate_auc_brier,
+    select_pair_max_concentration_rows,
+    train_and_predict_per_row_fold,
+)
+from lyzortx.pipeline.autoresearch.sx01_eval import (
+    N_FOLDS,
+    SEEDS,
+    assign_bacteria_folds,
+    bacteria_to_cv_group_map,
+)
+from lyzortx.pipeline.autoresearch.sx03_eval import (
+    load_basel_interactions,
+    patch_context_with_extended_slots,
+)
+from lyzortx.pipeline.autoresearch.sx15_eval import load_unified_phage_family_map
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CACHE_DIR = Path("lyzortx/generated_outputs/autoresearch/search_cache_v1")
+DEFAULT_CANDIDATE_DIR = Path("lyzortx/autoresearch")
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/ch05_unified_kfold")
+CH04_AGGREGATE_METRICS_PATH = Path("lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json")
+
+SOURCE_GUELIN = "guelin"
+SOURCE_BASEL = "basel"
+BASEL_REPLICATE_ID = 1
+BASEL_LOG_DILUTION = 0  # BASEL's single spot test approximates Guelin's neat concentration.
+PHAGE_AXIS_RANDOM_STATE = 42
+
+
+def load_basel_as_row_frame(bacteria_cv_group: dict[str, str]) -> pd.DataFrame:
+    """Materialise BASEL pairs as row-level training rows.
+
+    BASEL is a single spot test (>10⁹ pfu/ml) per pair, not a dilution series, so each
+    pair contributes exactly one training row. We encode it as `log_dilution=0` (matching
+    Guelin's neat concentration) and `replicate=1`, with `score` copied from the binary
+    interaction outcome.
+
+    BASEL bacteria are a subset of Guelin bacteria (all 25 BASEL ECOR strains appear in
+    the 369-bacterium Guelin panel), so `cv_group` is inherited from the Guelin mapping.
+    Rows whose bacterium is absent from the Guelin cv_group map are dropped (should be
+    zero in practice — the BASEL ECOR panel is fully contained in Guelin).
+    """
+    basel = load_basel_interactions().copy()
+    basel = basel.dropna(subset=["interaction"])
+    basel["score"] = basel["interaction"].astype(int).astype(str)
+    basel["log_dilution"] = BASEL_LOG_DILUTION
+    basel["replicate"] = BASEL_REPLICATE_ID
+    basel["source"] = SOURCE_BASEL
+
+    basel["cv_group"] = basel["bacteria"].map(bacteria_cv_group)
+    missing = basel[basel["cv_group"].isna()]
+    if not missing.empty:
+        LOGGER.warning(
+            "BASEL rows with no Guelin cv_group (dropped): %d (example bacteria: %s)",
+            len(missing),
+            missing["bacteria"].unique()[:5].tolist(),
+        )
+        basel = basel.dropna(subset=["cv_group"])
+
+    # Downstream per-row training frame filters on split_holdout and is_hard_trainable.
+    # Treat every BASEL observation as trainable — no ST03-style holdout split applies to
+    # BASEL (the CHISEL unified evaluation handles splits via k-fold CV, not ST03).
+    basel["split_holdout"] = "train_non_holdout"
+    basel["is_hard_trainable"] = "1"
+
+    LOGGER.info(
+        "BASEL row frame: %d rows (%d positive), %d pairs, %d bacteria, %d phages",
+        len(basel),
+        int((basel["score"] == RAW_SCORE_POSITIVE).sum()),
+        basel["pair_id"].nunique(),
+        basel["bacteria"].nunique(),
+        basel["phage"].nunique(),
+    )
+    return basel[
+        [
+            "pair_id",
+            "bacteria",
+            "phage",
+            "log_dilution",
+            "replicate",
+            "score",
+            "source",
+            "cv_group",
+            "split_holdout",
+            "is_hard_trainable",
+        ]
+    ].copy()
+
+
+def load_unified_row_frame() -> pd.DataFrame:
+    """Concatenate Guelin (318K rows, 9 replicates × pair) + BASEL (~1.2K rows, 1 row × pair).
+
+    Both sides carry `source ∈ {"guelin", "basel"}` and the minimal column set CH04's
+    per-row pipeline consumes. Guelin rows inherit split_holdout / is_hard_trainable from
+    ST02+ST03; BASEL rows are marked universally trainable.
+    """
+    guelin = load_row_expanded_frame().copy()
+    guelin["source"] = SOURCE_GUELIN
+
+    # Extract Guelin bacteria → cv_group so BASEL rows can inherit cv_group.
+    guelin_map = bacteria_to_cv_group_map(guelin)
+    basel = load_basel_as_row_frame(guelin_map)
+
+    # Reduce both frames to the shared column set before concatenation. Guelin has many
+    # additional pair-level columns (host/phage metadata, training_weight_v3, etc.) that
+    # BASEL lacks — downstream code only reads the columns below plus anything derived
+    # from the feature-slot cache, so keep it minimal.
+    keep = [
+        "pair_id",
+        "bacteria",
+        "phage",
+        "log_dilution",
+        "replicate",
+        "score",
+        "source",
+        "cv_group",
+        "split_holdout",
+        "is_hard_trainable",
+    ]
+    unified = pd.concat([guelin[keep], basel[keep]], ignore_index=True)
+    LOGGER.info(
+        "Unified row frame: %d total rows (%d guelin, %d basel); %d pairs, %d bacteria, %d phages",
+        len(unified),
+        (unified["source"] == SOURCE_GUELIN).sum(),
+        (unified["source"] == SOURCE_BASEL).sum(),
+        unified["pair_id"].nunique(),
+        unified["bacteria"].nunique(),
+        unified["phage"].nunique(),
+    )
+    return unified
+
+
+def assign_phage_folds(
+    phages: Sequence[str],
+    phage_family: dict[str, str],
+    n_splits: int = N_FOLDS,
+    random_state: int = PHAGE_AXIS_RANDOM_STATE,
+) -> dict[str, int]:
+    """10-fold StratifiedKFold on the phage list, stratified by ICTV family.
+
+    Rare families (fewer than `n_splits` phages) are collapsed into an "other" bucket so
+    StratifiedKFold can split them. Assignment is deterministic given `random_state`.
+    Phages with no family annotation are mapped to "UNKNOWN" (and fall into the "other"
+    bucket if that stratum has fewer than n_splits members).
+    """
+    phage_list = sorted(set(str(p) for p in phages))
+    df = pd.DataFrame({"phage": phage_list})
+    df["family"] = df["phage"].map(phage_family).fillna("UNKNOWN")
+    counts = df["family"].value_counts()
+    rare = counts[counts < n_splits].index
+    df.loc[df["family"].isin(rare), "family"] = "other"
+
+    skf = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=random_state)
+    fold_map: dict[str, int] = {}
+    for fold_id, (_, test_idx) in enumerate(skf.split(df["phage"].to_numpy(), df["family"].to_numpy())):
+        for phage in df.iloc[test_idx]["phage"].to_list():
+            fold_map[phage] = fold_id
+    per_fold_counts = defaultdict(int)
+    for fold in fold_map.values():
+        per_fold_counts[fold] += 1
+    LOGGER.info(
+        "phage-axis folds (n=%d): sizes=%s (stratified by %d unique families after collapsing rares)",
+        len(phage_list),
+        dict(sorted(per_fold_counts.items())),
+        df["family"].nunique(),
+    )
+    return fold_map
+
+
+def _aggregate_fold_rows_to_pairs(fold_rows: list[dict[str, object]]) -> pd.DataFrame:
+    """Collapse per-seed row predictions to mean-over-seeds then pick pair-max-conc rows."""
+    df = pd.DataFrame(fold_rows)
+    aggregated = (
+        df.groupby(
+            [
+                "fold_id",
+                "pair_id",
+                "bacteria",
+                "phage",
+                "log_dilution",
+                "replicate",
+                "label_row_binary",
+            ],
+            as_index=False,
+        )["predicted_probability"]
+        .mean()
+        .sort_values(["bacteria", "phage", "log_dilution", "replicate"])
+    )
+    return aggregated
+
+
+def _bootstrap_by_unit(
+    pair_rows: Sequence[dict[str, object]],
+    *,
+    unit_key: str,
+    bootstrap_samples: int,
+    bootstrap_random_state: int,
+) -> dict[str, BootstrapMetricCI]:
+    """Resample `unit_key` (bacterium or phage) with replacement and compute AUC+Brier per resample."""
+    grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in pair_rows:
+        grouped[str(row[unit_key])].append(row)
+    unit_ids = tuple(sorted(grouped.keys()))
+    n_units = len(unit_ids)
+    rng = np.random.default_rng(bootstrap_random_state)
+
+    aucs: list[float] = []
+    briers: list[float] = []
+    progress_interval = max(1, bootstrap_samples // 5)
+    for i in range(bootstrap_samples):
+        if i == 0 or (i + 1) % progress_interval == 0 or i + 1 == bootstrap_samples:
+            LOGGER.info("Bootstrap progress (%s): %d/%d", unit_key, i + 1, bootstrap_samples)
+        idx = rng.integers(0, n_units, size=n_units)
+        sampled: list[dict[str, object]] = []
+        for j in idx.tolist():
+            sampled.extend(grouped[unit_ids[j]])
+        labels = np.array([int(r["label_row_binary"]) for r in sampled])
+        preds = np.array([float(r["predicted_probability"]) for r in sampled])
+        if len(np.unique(labels)) < 2:
+            continue
+        from sklearn.metrics import brier_score_loss, roc_auc_score
+
+        aucs.append(float(roc_auc_score(labels, preds)))
+        briers.append(float(brier_score_loss(labels, preds)))
+
+    point = compute_aggregate_auc_brier(pair_rows)
+
+    def _ci(values: Sequence[float]) -> tuple[Optional[float], Optional[float], int]:
+        if not values:
+            return None, None, 0
+        arr = np.asarray(values, dtype=float)
+        low, high = np.quantile(arr, [0.025, 0.975])
+        return safe_round(float(low)), safe_round(float(high)), len(values)
+
+    auc_low, auc_high, auc_used = _ci(aucs)
+    brier_low, brier_high, brier_used = _ci(briers)
+    return {
+        "holdout_roc_auc": BootstrapMetricCI(
+            point_estimate=point["auc"],
+            ci_low=auc_low,
+            ci_high=auc_high,
+            bootstrap_samples_requested=bootstrap_samples,
+            bootstrap_samples_used=auc_used,
+        ),
+        "holdout_brier_score": BootstrapMetricCI(
+            point_estimate=point["brier"],
+            ci_low=brier_low,
+            ci_high=brier_high,
+            bootstrap_samples_requested=bootstrap_samples,
+            bootstrap_samples_used=brier_used,
+        ),
+    }
+
+
+def _ci_to_dict(ci: BootstrapMetricCI) -> dict[str, Optional[float]]:
+    return {
+        "point_estimate": safe_round(ci.point_estimate) if ci.point_estimate is not None else None,
+        "ci_low": ci.ci_low,
+        "ci_high": ci.ci_high,
+    }
+
+
+def run_bacteria_axis(
+    *,
+    candidate_module: ModuleType,
+    context: Any,
+    clean_rows: pd.DataFrame,
+    device_type: str,
+    output_dir: Path,
+) -> pd.DataFrame:
+    """10-fold bacteria-axis CV via CH02 cv_group hash (all 148 phages in training)."""
+    LOGGER.info("=== Bacteria-axis evaluation (CH02 cv_group folds, all-pairs only) ===")
+    mapping = bacteria_to_cv_group_map(clean_rows)
+    fold_assignments = assign_bacteria_folds(mapping)
+    all_rows: list[dict[str, object]] = []
+    for fold_id in range(N_FOLDS):
+        holdout_bac = {b for b, f in fold_assignments.items() if f == fold_id}
+        train_bac = {b for b, f in fold_assignments.items() if f != fold_id}
+        fold_train = clean_rows[clean_rows["bacteria"].isin(train_bac)].copy()
+        fold_holdout = clean_rows[clean_rows["bacteria"].isin(holdout_bac)].copy()
+        LOGGER.info(
+            "=== bacteria-axis Fold %d: %d train bacteria (%d rows), %d holdout bacteria (%d rows) ===",
+            fold_id,
+            len(train_bac),
+            len(fold_train),
+            len(holdout_bac),
+            len(fold_holdout),
+        )
+        fold_seed_rows: list[dict[str, object]] = []
+        for seed in SEEDS:
+            rows, _ = train_and_predict_per_row_fold(
+                candidate_module=candidate_module,
+                context=context,
+                training_frame=fold_train,
+                holdout_frame=fold_holdout,
+                seed=seed,
+                device_type=device_type,
+            )
+            for r in rows:
+                r["fold_id"] = fold_id
+            fold_seed_rows.extend(rows)
+        aggregated = _aggregate_fold_rows_to_pairs(fold_seed_rows)
+        pair_pred = select_pair_max_concentration_rows(aggregated)
+        fold_point = compute_aggregate_auc_brier(pair_pred.to_dict(orient="records"))
+        LOGGER.info(
+            "bacteria-axis Fold %d: AUC=%.4f, Brier=%.4f, n_pairs=%d",
+            fold_id,
+            fold_point["auc"],
+            fold_point["brier"],
+            len(pair_pred),
+        )
+        all_rows.extend(aggregated.to_dict(orient="records"))
+    per_row_df = pd.DataFrame(all_rows)
+    per_row_df.to_csv(output_dir / "ch05_bacteria_axis_per_row_predictions.csv", index=False)
+    return per_row_df
+
+
+def run_phage_axis(
+    *,
+    candidate_module: ModuleType,
+    context: Any,
+    clean_rows: pd.DataFrame,
+    phage_family: dict[str, str],
+    device_type: str,
+    output_dir: Path,
+) -> pd.DataFrame:
+    """10-fold phage-axis CV via StratifiedKFold (all 369 bacteria in training)."""
+    LOGGER.info("=== Phage-axis evaluation (StratifiedKFold by ICTV family, all-pairs only) ===")
+    phages = sorted(clean_rows["phage"].unique())
+    fold_assignments = assign_phage_folds(phages, phage_family)
+    all_rows: list[dict[str, object]] = []
+    for fold_id in range(N_FOLDS):
+        holdout_phages = {p for p, f in fold_assignments.items() if f == fold_id}
+        train_phages = {p for p, f in fold_assignments.items() if f != fold_id}
+        fold_train = clean_rows[clean_rows["phage"].isin(train_phages)].copy()
+        fold_holdout = clean_rows[clean_rows["phage"].isin(holdout_phages)].copy()
+        LOGGER.info(
+            "=== phage-axis Fold %d: %d train phages (%d rows), %d holdout phages (%d rows) ===",
+            fold_id,
+            len(train_phages),
+            len(fold_train),
+            len(holdout_phages),
+            len(fold_holdout),
+        )
+        fold_seed_rows: list[dict[str, object]] = []
+        for seed in SEEDS:
+            rows, _ = train_and_predict_per_row_fold(
+                candidate_module=candidate_module,
+                context=context,
+                training_frame=fold_train,
+                holdout_frame=fold_holdout,
+                seed=seed,
+                device_type=device_type,
+            )
+            for r in rows:
+                r["fold_id"] = fold_id
+            fold_seed_rows.extend(rows)
+        aggregated = _aggregate_fold_rows_to_pairs(fold_seed_rows)
+        pair_pred = select_pair_max_concentration_rows(aggregated)
+        fold_point = compute_aggregate_auc_brier(pair_pred.to_dict(orient="records"))
+        LOGGER.info(
+            "phage-axis Fold %d: AUC=%.4f, Brier=%.4f, n_pairs=%d",
+            fold_id,
+            fold_point["auc"],
+            fold_point["brier"],
+            len(pair_pred),
+        )
+        all_rows.extend(aggregated.to_dict(orient="records"))
+    per_row_df = pd.DataFrame(all_rows)
+    per_row_df.to_csv(output_dir / "ch05_phage_axis_per_row_predictions.csv", index=False)
+    return per_row_df
+
+
+def run_ch05_eval(
+    *,
+    device_type: str,
+    output_dir: Path,
+    cache_dir: Path,
+    candidate_dir: Path,
+) -> dict[str, object]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    start_time = datetime.now(timezone.utc)
+    LOGGER.info("CH05 evaluation starting at %s", start_time.isoformat())
+
+    unified = load_unified_row_frame()
+    clean_rows = build_clean_row_training_frame(unified)
+    LOGGER.info(
+        "CH05 clean row frame: %d rows, %d pairs, %d bacteria, %d phages",
+        len(clean_rows),
+        clean_rows["pair_id"].nunique(),
+        clean_rows["bacteria"].nunique(),
+        clean_rows["phage"].nunique(),
+    )
+    # Carry source forward so cross-source breakdown works after CH04 pipeline strips columns.
+    pair_source = clean_rows[["pair_id", "source"]].drop_duplicates(subset=["pair_id"]).set_index("pair_id")["source"]
+
+    phage_family = load_unified_phage_family_map()
+    candidate_module = load_module_from_path("ch05_candidate", candidate_dir / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=cache_dir, include_host_defense=True)
+    patch_context_with_extended_slots(context)
+
+    bacteria_axis_per_row = run_bacteria_axis(
+        candidate_module=candidate_module,
+        context=context,
+        clean_rows=clean_rows,
+        device_type=device_type,
+        output_dir=output_dir,
+    )
+    phage_axis_per_row = run_phage_axis(
+        candidate_module=candidate_module,
+        context=context,
+        clean_rows=clean_rows,
+        phage_family=phage_family,
+        device_type=device_type,
+        output_dir=output_dir,
+    )
+
+    # Per-axis aggregate + bootstrap.
+    bacteria_pairs = select_pair_max_concentration_rows(bacteria_axis_per_row)
+    bacteria_pairs["source"] = bacteria_pairs["pair_id"].map(pair_source)
+    bacteria_pairs.to_csv(output_dir / "ch05_bacteria_axis_predictions.csv", index=False)
+    bacteria_rows = bacteria_pairs.to_dict(orient="records")
+    bacteria_cis = _bootstrap_by_unit(
+        bacteria_rows,
+        unit_key="bacteria",
+        bootstrap_samples=BOOTSTRAP_SAMPLES,
+        bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+    )
+    bacteria_summary = {
+        "n_pairs": len(bacteria_pairs),
+        "n_bacteria": int(bacteria_pairs["bacteria"].nunique()),
+        "n_phages": int(bacteria_pairs["phage"].nunique()),
+        "aggregate": {name: _ci_to_dict(ci) for name, ci in bacteria_cis.items()},
+    }
+    with open(output_dir / "ch05_bacteria_axis_metrics.json", "w", encoding="utf-8") as f:
+        json.dump(bacteria_summary, f, indent=2)
+    LOGGER.info(
+        "Bacteria-axis aggregate: AUC %.4f [%.4f, %.4f], Brier %.4f [%.4f, %.4f]",
+        bacteria_cis["holdout_roc_auc"].point_estimate,
+        bacteria_cis["holdout_roc_auc"].ci_low or 0,
+        bacteria_cis["holdout_roc_auc"].ci_high or 0,
+        bacteria_cis["holdout_brier_score"].point_estimate,
+        bacteria_cis["holdout_brier_score"].ci_low or 0,
+        bacteria_cis["holdout_brier_score"].ci_high or 0,
+    )
+
+    phage_pairs = select_pair_max_concentration_rows(phage_axis_per_row)
+    phage_pairs["source"] = phage_pairs["pair_id"].map(pair_source)
+    phage_pairs.to_csv(output_dir / "ch05_phage_axis_predictions.csv", index=False)
+    phage_rows_all = phage_pairs.to_dict(orient="records")
+    phage_cis_all = _bootstrap_by_unit(
+        phage_rows_all,
+        unit_key="phage",
+        bootstrap_samples=BOOTSTRAP_SAMPLES,
+        bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+    )
+
+    cross_source_rows: list[dict[str, object]] = []
+    for source_label in (SOURCE_GUELIN, SOURCE_BASEL):
+        subset = [r for r in phage_rows_all if r["source"] == source_label]
+        LOGGER.info(
+            "Phage-axis cross-source subset %s: %d pairs, %d phages",
+            source_label,
+            len(subset),
+            len({r["phage"] for r in subset}),
+        )
+        if not subset:
+            continue
+        subset_cis = _bootstrap_by_unit(
+            subset,
+            unit_key="phage",
+            bootstrap_samples=BOOTSTRAP_SAMPLES,
+            bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+        )
+        cross_source_rows.append(
+            {
+                "source": source_label,
+                "n_pairs": len(subset),
+                "n_phages": len({r["phage"] for r in subset}),
+                "auc_point": safe_round(subset_cis["holdout_roc_auc"].point_estimate),
+                "auc_low": subset_cis["holdout_roc_auc"].ci_low,
+                "auc_high": subset_cis["holdout_roc_auc"].ci_high,
+                "brier_point": safe_round(subset_cis["holdout_brier_score"].point_estimate),
+                "brier_low": subset_cis["holdout_brier_score"].ci_low,
+                "brier_high": subset_cis["holdout_brier_score"].ci_high,
+            }
+        )
+    cross_source_df = pd.DataFrame(cross_source_rows)
+    cross_source_df.to_csv(output_dir / "ch05_cross_source_breakdown.csv", index=False)
+    LOGGER.info("Cross-source breakdown (phage-axis):\n%s", cross_source_df.to_string(index=False))
+
+    phage_summary = {
+        "n_pairs": len(phage_pairs),
+        "n_bacteria": int(phage_pairs["bacteria"].nunique()),
+        "n_phages": int(phage_pairs["phage"].nunique()),
+        "aggregate": {name: _ci_to_dict(ci) for name, ci in phage_cis_all.items()},
+        "cross_source": cross_source_rows,
+    }
+    with open(output_dir / "ch05_phage_axis_metrics.json", "w", encoding="utf-8") as f:
+        json.dump(phage_summary, f, indent=2)
+
+    # "Blending tax" is retired; under all-pairs-only this becomes the plain phage-axis
+    # generalization gap.
+    phage_axis_gap = safe_round(
+        bacteria_cis["holdout_roc_auc"].point_estimate - phage_cis_all["holdout_roc_auc"].point_estimate
+    )
+    cross_source_gap = None
+    if cross_source_df.shape[0] == 2:
+        guelin_auc = cross_source_df.loc[cross_source_df["source"] == SOURCE_GUELIN, "auc_point"].iloc[0]
+        basel_auc = cross_source_df.loc[cross_source_df["source"] == SOURCE_BASEL, "auc_point"].iloc[0]
+        cross_source_gap = safe_round(abs(guelin_auc - basel_auc))
+
+    ch04_auc = None
+    if CH04_AGGREGATE_METRICS_PATH.exists():
+        with open(CH04_AGGREGATE_METRICS_PATH, encoding="utf-8") as f:
+            ch04 = json.load(f)
+        ch04_auc = ch04["chisel_baseline"]["holdout_roc_auc"]["point_estimate"]
+
+    combined = {
+        "task_id": "CH05",
+        "scorecard": "AUC + Brier (nDCG/mAP/top-k retired)",
+        "per_phage_blending": "retired (see per-phage-retired-under-chisel)",
+        "bacteria_axis": bacteria_summary,
+        "phage_axis": phage_summary,
+        "phage_axis_generalization_gap_auc": phage_axis_gap,
+        "cross_source_auc_delta": cross_source_gap,
+        "ch04_baseline_auc": ch04_auc,
+        "elapsed_seconds": round((datetime.now(timezone.utc) - start_time).total_seconds(), 1),
+    }
+    with open(output_dir / "ch05_combined_summary.json", "w", encoding="utf-8") as f:
+        json.dump(combined, f, indent=2)
+    LOGGER.info(
+        "Phage-axis generalization gap (bacteria_auc − phage_auc) = %.4f; cross-source |ΔAUC| = %s",
+        phage_axis_gap,
+        cross_source_gap,
+    )
+    return combined
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device-type", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--candidate-dir", type=Path, default=DEFAULT_CANDIDATE_DIR)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+    run_ch05_eval(
+        device_type=args.device_type,
+        output_dir=args.output_dir,
+        cache_dir=args.cache_dir,
+        candidate_dir=args.candidate_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = [
+    "assign_phage_folds",
+    "load_basel_as_row_frame",
+    "load_unified_row_frame",
+    "run_ch05_eval",
+    "CONCENTRATION_FEATURE_COLUMN",
+    "RAW_SCORE_NEGATIVE",
+    "RAW_SCORE_POSITIVE",
+    "RAW_SCORE_UNINTERPRETABLE",
+]

--- a/lyzortx/pipeline/autoresearch/ch05_eval.py
+++ b/lyzortx/pipeline/autoresearch/ch05_eval.py
@@ -126,6 +126,11 @@ def load_basel_as_row_frame(
     BASEL bacteria are a subset of Guelin bacteria (all 25 BASEL ECOR strains appear in
     the 369-bacterium Guelin panel), so `cv_group` is inherited from the Guelin mapping.
     Fails loudly if any BASEL bacterium is absent from the map — per AGENTS.md fail-fast.
+
+    Row count: 52 phages × 25 bacteria = 1300 potential pairs; 160 are missing from
+    the upstream matrix (not all phages were tested on all bacteria — see
+    `basel-binary-only` knowledge unit), so the function returns ~1240 observed rows,
+    not 1300.
     """
     basel = load_basel_interactions().copy()
     basel = basel.dropna(subset=["interaction"])

--- a/lyzortx/research_notes/GLOSSARY.md
+++ b/lyzortx/research_notes/GLOSSARY.md
@@ -322,7 +322,7 @@ deployability floor. See `per-phage-not-deployable`, `deployment-goal`.
 
 **Our canonical setup**: 10-fold CV over the 148 unified panel phages (CH05), stratified by ICTV
 family + "other" (<10 phages) + "UNKNOWN" (no family) catch-all. Result under CH05: aggregate AUC
-0.8850, Brier 0.1348. Cross-source AUC parity holds (Guelin 0.8863 vs BASEL 0.8818) **but**
+0.8850, Brier 0.1349. Cross-source AUC parity holds (Guelin 0.8861 vs BASEL 0.8829) **but**
 cross-source calibration diverges (Brier 0.1329 vs 0.1884) — the earlier SX15 claim "BASEL phages
 generalize as well as Guelin" was a discrimination-only finding, not deployment readiness. See
 `chisel-unified-kfold-baseline` for the three separate findings (discrimination parity, calibration

--- a/lyzortx/research_notes/GLOSSARY.md
+++ b/lyzortx/research_notes/GLOSSARY.md
@@ -267,10 +267,13 @@ to its all-pairs component, relying entirely on phage-side features (TL17 family
 cross-terms, phage_stats) to represent the unseen phage. That's why phage-axis is the honest
 deployability floor. See `per-phage-not-deployable`, `deployment-goal`.
 
-**Our canonical setup**: 10-fold CV over the 148 unified panel phages (SX15), stratified by ICTV
-family so each family appears in both train and test. Result: aggregate AUC 0.8988 (higher than
-bacteria-axis!) but nDCG 0.7229 (7 pp lower). Reassuring sub-finding: BASEL phages generalize as
-well as Guelin phages (AUC 0.896 vs 0.899) — feature engineering transfers across phage collections.
+**Our canonical setup**: 10-fold CV over the 148 unified panel phages (CH05), stratified by ICTV
+family + "other" (<10 phages) + "UNKNOWN" (no family) catch-all. Result under CH05: aggregate AUC
+0.8850, Brier 0.1348. Cross-source AUC parity holds (Guelin 0.8863 vs BASEL 0.8818) **but**
+cross-source calibration diverges (Brier 0.1329 vs 0.1884) — the earlier SX15 claim "BASEL phages
+generalize as well as Guelin" was a discrimination-only finding, not deployment readiness. See
+`chisel-unified-kfold-baseline` for the three separate findings (discrimination parity, calibration
+divergence, BASEL bacteria-axis deficit).
 
 **Why AUC goes up but nDCG goes down vs bacteria-axis**: AUC pools all pairs globally and the
 all-pairs features preserve lysis/no-lysis discrimination cleanly. nDCG is per-bacterium; each
@@ -283,6 +286,31 @@ observed pairs per cell, enough for pair-level bootstrap. Not prioritized becaus
 cost vs single-axis, (b) the deployment scenarios of interest are single-axis (new phage against
 catalogued hosts, or new host against catalogued phages), and (c) per-bacterium ranking gets
 tight (~3 positives per held-out bacterium in each cell).
+
+## Phage projection (TL17 BLAST features, "zero-vector projection")
+
+`phage_projection` is a slot of ~33 phage-side features derived by BLASTing each phage's protein
+complement against TL17, a Guelin-derived reference bank of protein families. Each feature reports
+whether the phage has a protein hit in a specific TL17 family (thresholded bit-score or
+presence-absence). It is the dominant phage-side feature family — roughly the phage analogue of
+the host_surface slot.
+
+**Zero-vector projection** (or "zero projection") describes a phage whose full `phage_projection`
+feature vector is identically zero: none of its proteins matched any TL17 family above threshold.
+The BLAST ran and produced no hits — this is a finding about the phage's genomic novelty relative
+to the Guelin reference bank, not a missing-data bug.
+
+**Why it's load-bearing**: under the phage-axis split, zero-vector phages calibrate *correctly*
+because the model has no phage signal to misuse and falls back to the host-side prior. Non-zero
+phages whose projection vectors map into Guelin-calibrated TL17 neighborhoods can be actively
+*worse* calibrated than zero-vector phages when their actual host ranges don't match their
+Guelin-neighbor priors. CH05 documented this for BASEL: 13 zero-vector BASEL phages (Brier 0.12)
+vs 39 non-zero BASEL phages (Brier 0.31) on bacteria-axis. See the CH05 entry under
+`chisel-unified-kfold-baseline` and `plm-rbp-redundant` (the same mechanism at cross-family scale).
+
+**Practical consequence for future work**: more phages in TL17-underpopulated neighborhoods would
+help more than engineering new phage features — the deficiency is reference-bank coverage, not
+feature representation.
 
 ## Spearman correlation (Spearman's ρ)
 

--- a/lyzortx/research_notes/GLOSSARY.md
+++ b/lyzortx/research_notes/GLOSSARY.md
@@ -75,6 +75,59 @@ base rate uninformatively, 0.12–0.13 = our working range (informative but with
 be excellent, <0.05 = typical of much easier problems. Our SX10 Brier of 0.125 means we're
 materially better-calibrated than guessing the base rate.
 
+## Calibration, post-hoc (isotonic, Platt, ECE, reliability diagram)
+
+Umbrella entry for four terms that appear together whenever we ask "are our predicted
+probabilities actually trustworthy?" If the model says 0.7, do 70% of those cases lyse? A model
+can have great AUC (correct ranking) and terrible calibration (wrong absolute probabilities) —
+see the Brier entry for the AUC-vs-calibration distinction.
+
+**Reliability diagram**: the diagnostic picture. Bin predictions into 10 equal-width deciles
+(0.0-0.1, 0.1-0.2, ..., 0.9-1.0). In each bin, plot *mean predicted probability* (x-axis) against
+*observed frequency* (y-axis, the fraction of positives in that bin). Perfect calibration = the
+points sit on the y=x diagonal. "Over-prediction in mid-P" means the model says 0.7 but only 45%
+of those cases actually lyse — the point sits below the diagonal. "Under-prediction" means the
+opposite.
+
+**Expected Calibration Error (ECE)**: the numeric summary of a reliability diagram. Weighted mean
+of per-bin `|observed_rate − mean_predicted|` gaps, weighted by bin population. Range [0, 1];
+lower is better. Perfect calibration = 0. CHISEL's bacteria-axis Guelin raw ECE is 0.12 (i.e.,
+predicted probabilities are off by ~12 percentage points on average when weighted by how many
+pairs land in each bin). We added ECE to the scorecard in CH05 because Brier mixes calibration
+with discrimination, while ECE is purely about calibration and is more interpretable in
+percentage-point terms.
+
+**Platt scaling**: fits a logistic regression `P_calibrated = sigmoid(A · P_raw + B)` on
+(predicted_probability, observed_label) pairs from held-out data. Two-parameter, parametric,
+assumes a sigmoid shape. Works well when the raw predictions are already roughly sigmoidal and
+just need a sharpness/offset correction. Most effective for SVMs and neural nets whose raw
+outputs aren't probabilities.
+
+**Isotonic regression**: non-parametric, monotonic step function. Fits a step function that
+best maps raw predictions to observed frequencies under the constraint that higher raw =
+higher calibrated. No sigmoid assumption. More flexible than Platt, more data-hungry (hundreds
+of samples minimum), and only approximately preserves AUC because the step function introduces
+ties — two raw predictions that were 0.71 and 0.73 can both map to the same calibrated 0.65,
+and under ties AUC ranking can shift by sub-percent amounts. CHISEL CH05's isotonic diagnostic
+used this for Guelin (30K+ samples, plenty of headroom) and found it closes 78-89% of Guelin's
+decile gaps.
+
+**When to use which**: Platt for a quick two-parameter fit when you have <1000 labeled
+predictions. Isotonic when you have thousands and the raw distribution isn't clearly sigmoidal.
+Both are "post-hoc" — fit after the model is trained, applied to the model's outputs at
+inference. They fix calibration without changing discrimination (up to isotonic tie noise) and
+without retraining the model.
+
+**Practical limit surfaced by CH05**: a calibrator fit on one panel does not fully transfer to
+another. The Guelin-fitted calibrator closes 78-89% of Guelin's gaps but only 34-37% of BASEL's
+— because BASEL's miscalibration is partly a different mechanism (TL17-bias, see `phage
+projection`) that calibration can't rescue. Cross-panel calibration transferability is a real
+limit, not just an implementation detail.
+
+See: `chisel-unified-kfold-baseline` (two-mechanism story + ECE as scorecard addition), CH05
+entry in track_CHISEL.md, `ch05_isotonic_calibration_test.py` ad-hoc script, and the pending
+CH09 ticket that productionises the calibration layer.
+
 ## Bootstrap confidence interval
 
 A non-parametric way to put a confidence interval on a statistic (like AUC or Brier) when there's

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch05_basel_feature_variance.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch05_basel_feature_variance.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""CH05 post-hoc: Guelin vs BASEL per-phage feature-slot variance comparison.
+
+Motivated by reviewer hypothesis: BASEL's mid-P over-prediction (reliability gap −21
+to −27 pp worse than Guelin in 0.5-0.9 bins) may be driven by zero-fill-heavy BASEL
+phage features. If BASEL phages carry systematically lower variance across
+`phage_projection`, `phage_stats`, and any other phage-side slots, the all-pairs
+model would fall back to a "default phage prior" — pushing BASEL predictions toward
+mid-range values regardless of actual host compatibility.
+
+For each phage slot, compute:
+  - n_phages per source
+  - mean per-feature coefficient of variation (CV) per source
+  - fraction of features with variance < 1e-12 (i.e. effectively constant) per source
+  - fraction of rows that are exact zero vectors per source
+
+Reads the feature cache — no model rerun. Outputs:
+  lyzortx/generated_outputs/ch05_unified_kfold/ch05_basel_feature_variance.csv
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.candidate_replay import load_module_from_path
+from lyzortx.pipeline.autoresearch.ch05_eval import (
+    DEFAULT_CACHE_DIR,
+    DEFAULT_CANDIDATE_DIR,
+    DEFAULT_OUTPUT_DIR,
+    SOURCE_BASEL,
+    SOURCE_GUELIN,
+    load_unified_row_frame,
+)
+from lyzortx.pipeline.autoresearch.sx03_eval import patch_context_with_extended_slots
+
+LOGGER = logging.getLogger(__name__)
+
+PHAGE_SLOTS = ["phage_projection", "phage_stats", "phage_rbp_struct"]
+OUTPUT_CSV = Path(DEFAULT_OUTPUT_DIR) / "ch05_basel_feature_variance.csv"
+VAR_FLOOR = 1e-12
+
+
+def _summarise_slot(slot_name: str, source_label: str, features: pd.DataFrame) -> dict[str, object]:
+    n_phages, n_features = features.shape
+    arr = features.to_numpy(dtype=float)
+    per_feat_var = arr.var(axis=0)
+    per_feat_mean = arr.mean(axis=0)
+    safe_mean = np.where(np.abs(per_feat_mean) < 1e-12, np.nan, per_feat_mean)
+    per_feat_cv = np.sqrt(per_feat_var) / np.abs(safe_mean)
+    n_constant = int((per_feat_var < VAR_FLOOR).sum())
+    n_zero_rows = int((np.abs(arr).sum(axis=1) < VAR_FLOOR).sum())
+    return {
+        "slot": slot_name,
+        "source": source_label,
+        "n_phages": n_phages,
+        "n_features": n_features,
+        "frac_constant_features": round(n_constant / max(n_features, 1), 4),
+        "frac_zero_rows": round(n_zero_rows / max(n_phages, 1), 4),
+        "mean_per_feature_cv": round(float(np.nanmean(per_feat_cv)), 4),
+        "median_per_feature_cv": round(float(np.nanmedian(per_feat_cv)), 4),
+        "mean_per_feature_variance": round(float(per_feat_var.mean()), 6),
+    }
+
+
+def main() -> None:
+    setup_logging()
+    unified = load_unified_row_frame()
+    phage_source = unified.groupby("phage")["source"].first().to_dict()
+
+    candidate_module = load_module_from_path("ch05_candidate", Path(DEFAULT_CANDIDATE_DIR) / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=Path(DEFAULT_CACHE_DIR), include_host_defense=True)
+    patch_context_with_extended_slots(context)
+
+    rows: list[dict[str, object]] = []
+    for slot_name in PHAGE_SLOTS:
+        try:
+            feature_table = candidate_module.build_entity_feature_table(
+                context.slot_artifacts, slot_names=[slot_name], entity_key="phage"
+            )
+        except Exception as exc:  # slot may not be present in cache
+            LOGGER.warning("Skipping slot %s: %s", slot_name, exc)
+            continue
+        feature_table = feature_table.set_index("phage")
+        feature_table = feature_table.select_dtypes(include=[np.number])
+        guelin_phages = [p for p in feature_table.index if phage_source.get(p) == SOURCE_GUELIN]
+        basel_phages = [p for p in feature_table.index if phage_source.get(p) == SOURCE_BASEL]
+        if guelin_phages:
+            rows.append(_summarise_slot(slot_name, SOURCE_GUELIN, feature_table.loc[guelin_phages]))
+        if basel_phages:
+            rows.append(_summarise_slot(slot_name, SOURCE_BASEL, feature_table.loc[basel_phages]))
+
+    df = pd.DataFrame(rows)
+    df.to_csv(OUTPUT_CSV, index=False)
+    LOGGER.info("Wrote %s (%d rows)", OUTPUT_CSV, len(df))
+
+    print()
+    print("=== CH05 Guelin vs BASEL per-phage feature-slot variance ===")
+    print(df.to_string(index=False))
+    print()
+
+    # Per-slot delta: higher frac_constant / lower CV on BASEL → zero-fill hypothesis supported.
+    print("=== Cross-source deltas (BASEL − Guelin) ===")
+    pivot = df.pivot_table(
+        index="slot",
+        columns="source",
+        values=["frac_constant_features", "frac_zero_rows", "mean_per_feature_cv"],
+    )
+    print(pivot.round(4).to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch05_basel_zero_vector_split.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch05_basel_zero_vector_split.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""CH05 post-hoc: split BASEL phages by zero-vector vs non-zero on phage_projection.
+
+Tests whether the BASEL mid-P over-prediction localizes to the 13 BASEL phages with
+all-zero phage_projection vectors (no TL17 BLAST hits) or spreads across non-zero
+BASEL phages too. If localizes → "fill in 13 zero-vector phages" is the fix; if
+spreads → TL17 reference bank itself is panel-biased.
+
+Also checks whether the 13 zero-vector BASEL phages overlap with the UNKNOWN
+(no ICTV family) BASEL phages — i.e., is "taxonomically novel" the same set as
+"no TL17 hit"?
+
+Reads predictions CSVs + feature cache. Outputs:
+  lyzortx/generated_outputs/ch05_unified_kfold/ch05_basel_zero_vector_split.csv
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import brier_score_loss, roc_auc_score
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.candidate_replay import load_module_from_path
+from lyzortx.pipeline.autoresearch.ch05_eval import (
+    DEFAULT_CACHE_DIR,
+    DEFAULT_CANDIDATE_DIR,
+    DEFAULT_OUTPUT_DIR,
+    SOURCE_BASEL,
+    SOURCE_GUELIN,
+    load_unified_row_frame,
+)
+from lyzortx.pipeline.autoresearch.sx03_eval import patch_context_with_extended_slots
+from lyzortx.pipeline.autoresearch.sx15_eval import load_unified_phage_family_map
+
+LOGGER = logging.getLogger(__name__)
+
+OUTPUT_CSV = Path(DEFAULT_OUTPUT_DIR) / "ch05_basel_zero_vector_split.csv"
+
+
+def _summary(label: str, df: pd.DataFrame) -> dict[str, object]:
+    if df.empty:
+        return {"label": label, "n_pairs": 0, "n_phages": 0}
+    labels = df["label_row_binary"].astype(int).to_numpy()
+    preds = df["predicted_probability"].astype(float).to_numpy()
+    pos_mask = labels == 1
+    neg_mask = labels == 0
+    auc = float(roc_auc_score(labels, preds)) if len(set(labels.tolist())) > 1 else float("nan")
+    brier = float(brier_score_loss(labels, preds))
+    return {
+        "label": label,
+        "n_phages": int(df["phage"].nunique()),
+        "n_pairs": len(df),
+        "pos_rate": round(float(pos_mask.mean()), 4),
+        "mean_pred_overall": round(float(preds.mean()), 4),
+        "mean_pred_pos": round(float(preds[pos_mask].mean()), 4) if pos_mask.any() else float("nan"),
+        "mean_pred_neg": round(float(preds[neg_mask].mean()), 4) if neg_mask.any() else float("nan"),
+        "auc": round(auc, 4),
+        "brier": round(brier, 4),
+    }
+
+
+def main() -> None:
+    setup_logging()
+    unified = load_unified_row_frame()
+    phage_source = unified.groupby("phage")["source"].first().to_dict()
+
+    candidate_module = load_module_from_path("ch05_candidate", Path(DEFAULT_CANDIDATE_DIR) / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=Path(DEFAULT_CACHE_DIR), include_host_defense=True)
+    patch_context_with_extended_slots(context)
+
+    feature_table = candidate_module.build_entity_feature_table(
+        context.slot_artifacts, slot_names=["phage_projection"], entity_key="phage"
+    ).set_index("phage")
+    numeric = feature_table.select_dtypes(include=[np.number])
+    row_abs_sum = numeric.abs().sum(axis=1)
+    zero_vector_phages = set(row_abs_sum[row_abs_sum < 1e-12].index)
+
+    basel_phages = {p for p, src in phage_source.items() if src == SOURCE_BASEL}
+    guelin_phages = {p for p, src in phage_source.items() if src == SOURCE_GUELIN}
+    basel_zero = basel_phages & zero_vector_phages
+    basel_nonzero = basel_phages - zero_vector_phages
+    guelin_zero = guelin_phages & zero_vector_phages
+    guelin_nonzero = guelin_phages - zero_vector_phages
+
+    family_map = load_unified_phage_family_map()
+    basel_unknown = {p for p in basel_phages if p not in family_map or not family_map[p]}
+    overlap = basel_zero & basel_unknown
+
+    LOGGER.info(
+        "BASEL phage split: %d zero-vector, %d non-zero; Guelin: %d zero-vector, %d non-zero",
+        len(basel_zero),
+        len(basel_nonzero),
+        len(guelin_zero),
+        len(guelin_nonzero),
+    )
+    LOGGER.info(
+        "BASEL zero-vector ∩ BASEL UNKNOWN-family = %d of %d zero-vector / %d UNKNOWN",
+        len(overlap),
+        len(basel_zero),
+        len(basel_unknown),
+    )
+    if basel_zero:
+        LOGGER.info("BASEL zero-vector phages: %s", sorted(basel_zero))
+
+    rows: list[dict[str, object]] = []
+    for axis in ("bacteria_axis", "phage_axis"):
+        preds_path = Path(DEFAULT_OUTPUT_DIR) / f"ch05_{axis}_predictions.csv"
+        preds = pd.read_csv(preds_path)
+        for label, subset_phages in [
+            (f"{axis} | Guelin", guelin_phages),
+            (f"{axis} | BASEL", basel_phages),
+            (f"{axis} | BASEL zero-vector ({len(basel_zero)} phages)", basel_zero),
+            (f"{axis} | BASEL non-zero ({len(basel_nonzero)} phages)", basel_nonzero),
+        ]:
+            df = preds[preds["phage"].isin(subset_phages)]
+            rows.append(_summary(label, df))
+
+    df = pd.DataFrame(rows)
+    df.to_csv(OUTPUT_CSV, index=False)
+    print()
+    print("=== BASEL zero-vector vs non-zero reliability split ===")
+    print(df.to_string(index=False))
+    print()
+    print(
+        f"BASEL zero-vector ∩ UNKNOWN-family overlap: {len(overlap)}/{len(basel_zero)} zero-vector, "
+        f"{len(overlap)}/{len(basel_unknown)} UNKNOWN-family"
+    )
+    print(f"Zero-vector BASEL phages: {sorted(basel_zero)}")
+    print(f"UNKNOWN-family BASEL phages (no ICTV): {sorted(basel_unknown)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch05_isotonic_calibration_test.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch05_isotonic_calibration_test.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""CH05 post-hoc: isotonic-regression calibration test on Guelin predictions.
+
+Reviewer hypothesis: Guelin's 28-30 pp mid-P miscalibration in CH05 (bacteria-axis
+0.7-0.8 bin predicts 0.75 but observes 0.45) is a training-label-vs-deployment-
+question mismatch signature. Training treats every score='1' row as a positive,
+including "clearing events" at high titer that Gaborieau 2024 Methods explicitly
+says can arise from non-productive mechanisms (lysis from without, abortive
+infection). The deployment question — "will this phage productively lyse this
+strain at therapeutic dose?" — is stricter than the training label. If that's
+the driver, the model should have the discrimination (AUC stays) but not the
+calibration, and an isotonic fit should close the gap.
+
+Isotonic regression is non-parametric and monotonic, so it preserves ranking
+(AUC unchanged) while remapping probability values to match observed frequencies.
+If Guelin mid-P gap closes from 28 pp to <10 pp after isotonic, threshold story
+is real. If it stays large, the model is genuinely uncertain in mid-P — threshold
+isn't the driver.
+
+Per-fold leave-one-out: for each held-out fold's predictions, fit isotonic on the
+other 9 folds and apply to this fold. Otherwise the diagnostic is optimistic
+(fits and evaluates on the same data).
+
+Reads the existing CH05 predictions. No model rerun. Outputs:
+  lyzortx/generated_outputs/ch05_unified_kfold/ch05_isotonic_calibration_test.csv
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.isotonic import IsotonicRegression
+from sklearn.metrics import brier_score_loss, roc_auc_score
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.ch05_eval import (
+    DEFAULT_OUTPUT_DIR,
+    SOURCE_BASEL,
+    SOURCE_GUELIN,
+    load_unified_row_frame,
+)
+from lyzortx.pipeline.autoresearch.sx01_eval import N_FOLDS, assign_bacteria_folds, bacteria_to_cv_group_map
+from lyzortx.pipeline.autoresearch.sx15_eval import load_unified_phage_family_map
+
+LOGGER = logging.getLogger(__name__)
+
+OUTPUT_CSV = Path(DEFAULT_OUTPUT_DIR) / "ch05_isotonic_calibration_test.csv"
+N_BINS = 10
+
+
+def _reliability(preds: np.ndarray, labels: np.ndarray, label: str) -> list[dict[str, object]]:
+    """Compute per-decile observed rate vs mean predicted probability."""
+    edges = np.linspace(0.0, 1.0, N_BINS + 1)
+    bin_idx = np.clip(np.digitize(preds, edges[1:-1], right=False), 0, N_BINS - 1)
+    rows: list[dict[str, object]] = []
+    for b in range(N_BINS):
+        mask = bin_idx == b
+        n = int(mask.sum())
+        if n == 0:
+            continue
+        mean_pred = float(preds[mask].mean())
+        obs_rate = float(labels[mask].mean())
+        rows.append(
+            {
+                "variant": label,
+                "bin_lo": round(float(edges[b]), 3),
+                "bin_hi": round(float(edges[b + 1]), 3),
+                "n_pairs": n,
+                "mean_predicted": round(mean_pred, 4),
+                "observed_rate": round(obs_rate, 4),
+                "reliability_gap": round(obs_rate - mean_pred, 4),
+            }
+        )
+    return rows
+
+
+def _ece(preds: np.ndarray, labels: np.ndarray) -> float:
+    """Expected-calibration-error: weighted mean of per-bin |observed - predicted| gaps."""
+    edges = np.linspace(0.0, 1.0, N_BINS + 1)
+    bin_idx = np.clip(np.digitize(preds, edges[1:-1], right=False), 0, N_BINS - 1)
+    n_total = len(preds)
+    ece = 0.0
+    for b in range(N_BINS):
+        mask = bin_idx == b
+        n = int(mask.sum())
+        if n == 0:
+            continue
+        mean_pred = float(preds[mask].mean())
+        obs_rate = float(labels[mask].mean())
+        ece += (n / n_total) * abs(obs_rate - mean_pred)
+    return ece
+
+
+def _log_metrics(label: str, preds: np.ndarray, labels: np.ndarray) -> dict[str, float]:
+    """AUC (should be monotone-invariant), Brier, ECE — sanity checks for the transform."""
+    auc = float(roc_auc_score(labels, preds)) if len(set(labels.tolist())) > 1 else float("nan")
+    brier = float(brier_score_loss(labels, preds))
+    ece = _ece(preds, labels)
+    LOGGER.info("%s: AUC=%.4f, Brier=%.4f, ECE=%.4f, n=%d", label, auc, brier, ece, len(preds))
+    return {"label": label, "auc": round(auc, 4), "brier": round(brier, 4), "ece": round(ece, 4), "n_pairs": len(preds)}
+
+
+def main() -> None:
+    setup_logging()
+    bacteria_preds = pd.read_csv(Path(DEFAULT_OUTPUT_DIR) / "ch05_bacteria_axis_predictions.csv")
+    phage_preds = pd.read_csv(Path(DEFAULT_OUTPUT_DIR) / "ch05_phage_axis_predictions.csv")
+
+    family_map = load_unified_phage_family_map()
+
+    bacteria_guelin = bacteria_preds[bacteria_preds["source"] == SOURCE_GUELIN].copy()
+    bacteria_basel = bacteria_preds[bacteria_preds["source"] == SOURCE_BASEL].copy()
+    phage_guelin = phage_preds[phage_preds["source"] == SOURCE_GUELIN].copy()
+    phage_basel = phage_preds[phage_preds["source"] == SOURCE_BASEL].copy()
+
+    rows: list[dict[str, object]] = []
+    metrics: list[dict[str, object]] = []
+
+    # Bacteria-axis: need fold_id to leave each fold out. Rebuild fold assignments
+    # from the unified row frame's cv_group mapping (the predictions CSV doesn't carry cv_group).
+    unified = load_unified_row_frame()
+    mapping = bacteria_to_cv_group_map(unified)
+    fold_assignments = assign_bacteria_folds(mapping)
+    bacteria_guelin["fold_id"] = bacteria_guelin["bacteria"].map(fold_assignments)
+
+    bacteria_calibrated = np.empty(len(bacteria_guelin), dtype=float)
+    for fold_id in range(N_FOLDS):
+        held_out_mask = bacteria_guelin["fold_id"].to_numpy() == fold_id
+        fit_mask = ~held_out_mask
+        if held_out_mask.sum() == 0 or fit_mask.sum() == 0:
+            bacteria_calibrated[held_out_mask] = bacteria_guelin.loc[held_out_mask, "predicted_probability"].to_numpy()
+            continue
+        iso = IsotonicRegression(out_of_bounds="clip", y_min=0.0, y_max=1.0)
+        iso.fit(
+            bacteria_guelin.loc[fit_mask, "predicted_probability"].to_numpy(),
+            bacteria_guelin.loc[fit_mask, "label_row_binary"].to_numpy().astype(float),
+        )
+        bacteria_calibrated[held_out_mask] = iso.predict(
+            bacteria_guelin.loc[held_out_mask, "predicted_probability"].to_numpy()
+        )
+    bacteria_labels = bacteria_guelin["label_row_binary"].to_numpy().astype(int)
+    bacteria_raw = bacteria_guelin["predicted_probability"].to_numpy().astype(float)
+
+    metrics.append(_log_metrics("bacteria_axis_guelin_raw", bacteria_raw, bacteria_labels))
+    metrics.append(_log_metrics("bacteria_axis_guelin_isotonic", bacteria_calibrated, bacteria_labels))
+    rows.extend(_reliability(bacteria_raw, bacteria_labels, "bacteria_axis_guelin_raw"))
+    rows.extend(_reliability(bacteria_calibrated, bacteria_labels, "bacteria_axis_guelin_isotonic"))
+
+    # Discriminative test: apply a Guelin-fitted calibrator to BASEL predictions.
+    # BASEL phages are entirely distinct from Guelin phages (disjoint panels), so fitting on
+    # ALL Guelin bacteria-axis predictions and applying to BASEL is leakage-free. If BASEL
+    # gap also shrinks → threshold was a unified story; if it stays → TL17-bias is the
+    # BASEL-specific driver on top of Guelin's threshold mismatch.
+    iso_bacteria_global = IsotonicRegression(out_of_bounds="clip", y_min=0.0, y_max=1.0)
+    iso_bacteria_global.fit(
+        bacteria_guelin["predicted_probability"].to_numpy(),
+        bacteria_guelin["label_row_binary"].to_numpy().astype(float),
+    )
+    basel_bacteria_labels = bacteria_basel["label_row_binary"].to_numpy().astype(int)
+    basel_bacteria_raw = bacteria_basel["predicted_probability"].to_numpy().astype(float)
+    basel_bacteria_iso = iso_bacteria_global.predict(basel_bacteria_raw)
+    metrics.append(_log_metrics("bacteria_axis_basel_raw", basel_bacteria_raw, basel_bacteria_labels))
+    metrics.append(
+        _log_metrics("bacteria_axis_basel_guelin_isotonic_applied", basel_bacteria_iso, basel_bacteria_labels)
+    )
+    rows.extend(_reliability(basel_bacteria_raw, basel_bacteria_labels, "bacteria_axis_basel_raw"))
+    rows.extend(_reliability(basel_bacteria_iso, basel_bacteria_labels, "bacteria_axis_basel_guelin_isotonic_applied"))
+
+    # Phage-axis: held-out phages. Leave each phage out for its calibration fit.
+    phage_guelin["family"] = phage_guelin["phage"].map(family_map).fillna("UNKNOWN")
+    from lyzortx.pipeline.autoresearch.ch05_eval import assign_phage_folds
+
+    phage_fold_assignments = assign_phage_folds(
+        sorted(phage_guelin["phage"].unique().tolist()),
+        family_map,
+    )
+    phage_guelin["fold_id"] = phage_guelin["phage"].map(phage_fold_assignments)
+
+    phage_calibrated = np.empty(len(phage_guelin), dtype=float)
+    for fold_id in sorted(phage_guelin["fold_id"].dropna().unique().astype(int)):
+        held_out_mask = phage_guelin["fold_id"].to_numpy() == fold_id
+        fit_mask = ~held_out_mask
+        if held_out_mask.sum() == 0 or fit_mask.sum() == 0:
+            phage_calibrated[held_out_mask] = phage_guelin.loc[held_out_mask, "predicted_probability"].to_numpy()
+            continue
+        iso = IsotonicRegression(out_of_bounds="clip", y_min=0.0, y_max=1.0)
+        iso.fit(
+            phage_guelin.loc[fit_mask, "predicted_probability"].to_numpy(),
+            phage_guelin.loc[fit_mask, "label_row_binary"].to_numpy().astype(float),
+        )
+        phage_calibrated[held_out_mask] = iso.predict(
+            phage_guelin.loc[held_out_mask, "predicted_probability"].to_numpy()
+        )
+    phage_labels = phage_guelin["label_row_binary"].to_numpy().astype(int)
+    phage_raw = phage_guelin["predicted_probability"].to_numpy().astype(float)
+
+    metrics.append(_log_metrics("phage_axis_guelin_raw", phage_raw, phage_labels))
+    metrics.append(_log_metrics("phage_axis_guelin_isotonic", phage_calibrated, phage_labels))
+    rows.extend(_reliability(phage_raw, phage_labels, "phage_axis_guelin_raw"))
+    rows.extend(_reliability(phage_calibrated, phage_labels, "phage_axis_guelin_isotonic"))
+
+    # Discriminative test (phage-axis): apply Guelin-fitted calibrator to BASEL predictions.
+    # Guelin (96) and BASEL (52) phage panels are disjoint, so fitting on all Guelin predictions
+    # and applying to BASEL has no leakage.
+    iso_phage_global = IsotonicRegression(out_of_bounds="clip", y_min=0.0, y_max=1.0)
+    iso_phage_global.fit(
+        phage_guelin["predicted_probability"].to_numpy(),
+        phage_guelin["label_row_binary"].to_numpy().astype(float),
+    )
+    basel_phage_labels = phage_basel["label_row_binary"].to_numpy().astype(int)
+    basel_phage_raw = phage_basel["predicted_probability"].to_numpy().astype(float)
+    basel_phage_iso = iso_phage_global.predict(basel_phage_raw)
+    metrics.append(_log_metrics("phage_axis_basel_raw", basel_phage_raw, basel_phage_labels))
+    metrics.append(_log_metrics("phage_axis_basel_guelin_isotonic_applied", basel_phage_iso, basel_phage_labels))
+    rows.extend(_reliability(basel_phage_raw, basel_phage_labels, "phage_axis_basel_raw"))
+    rows.extend(_reliability(basel_phage_iso, basel_phage_labels, "phage_axis_basel_guelin_isotonic_applied"))
+
+    df = pd.DataFrame(rows)
+    df.to_csv(OUTPUT_CSV, index=False)
+    metrics_df = pd.DataFrame(metrics)
+    metrics_df.to_csv(Path(DEFAULT_OUTPUT_DIR) / "ch05_isotonic_calibration_test_metrics.csv", index=False)
+    LOGGER.info("Wrote %s (%d rows) + _metrics.csv (%d rows)", OUTPUT_CSV, len(df), len(metrics_df))
+
+    print()
+    print("=== Isotonic calibration test ===")
+    print("Guelin: leave-one-fold-out (fold-aware, no leakage)")
+    print("BASEL: Guelin-fitted calibrator applied to BASEL predictions (disjoint panels, no leakage)")
+    print()
+    print(metrics_df.to_string(index=False))
+    print()
+    for axis in ("bacteria_axis", "phage_axis"):
+        for source in ("guelin", "basel"):
+            prefix = f"{axis}_{source}"
+            raw = df[df["variant"] == f"{prefix}_raw"]["reliability_gap"].abs()
+            iso_label_suffix = "isotonic" if source == "guelin" else "guelin_isotonic_applied"
+            iso = df[df["variant"] == f"{prefix}_{iso_label_suffix}"]["reliability_gap"].abs()
+            if raw.empty or iso.empty:
+                continue
+            print(
+                f"{axis} {source}: max |gap| raw={raw.max():.3f}, isotonic={iso.max():.3f}, "
+                f"closure={raw.max() - iso.max():+.3f}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch05_per_family_phage_axis.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch05_per_family_phage_axis.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""CH05 post-hoc: per-family phage-axis AUC + within-family vs family-novel contrast.
+
+Motivated by self-review observation that CH05's phage-axis StratifiedKFold by ICTV
+family holds out ~1 phage per fold for families with ≥10 members, keeping siblings in
+training — i.e. the aggregate AUC is biased toward *within-family* generalization and is
+an optimistic proxy for the "completely new family" deployment case.
+
+Rare families (<10 phages) are collapsed into an "other" bucket at fold-assignment time,
+so held-out phages from those families have NO same-family siblings in training — that's
+the family-novel regime. Computing per-family AUC lets us quantify the contrast.
+
+Outputs: prints a table to stdout and writes
+  lyzortx/generated_outputs/ch05_unified_kfold/ch05_per_family_breakdown.csv
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+from sklearn.metrics import brier_score_loss, roc_auc_score
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.ch05_eval import DEFAULT_OUTPUT_DIR
+from lyzortx.pipeline.autoresearch.sx01_eval import N_FOLDS
+from lyzortx.pipeline.autoresearch.sx15_eval import load_unified_phage_family_map
+
+LOGGER = logging.getLogger(__name__)
+
+MIN_PAIRS_FOR_REPORTING = 10
+PHAGE_AXIS_PREDICTIONS = Path(DEFAULT_OUTPUT_DIR) / "ch05_phage_axis_predictions.csv"
+OUTPUT_CSV = Path(DEFAULT_OUTPUT_DIR) / "ch05_per_family_breakdown.csv"
+
+
+def main() -> None:
+    setup_logging()
+    preds = pd.read_csv(PHAGE_AXIS_PREDICTIONS)
+    family_map = load_unified_phage_family_map()
+    preds["family"] = preds["phage"].map(family_map).fillna("UNKNOWN")
+
+    # Global panel counts determine whether a family is within-family (≥N_FOLDS) or
+    # family-novel (collapsed to "other" bucket in assign_phage_folds).
+    from collections import Counter
+
+    global_counts = Counter(family_map.values())
+    rows = []
+    for family in sorted(preds["family"].unique()):
+        subset = preds[preds["family"] == family]
+        n_pairs = len(subset)
+        n_phages = int(subset["phage"].nunique())
+        panel_n = int(global_counts.get(family, 0))
+        if n_pairs < MIN_PAIRS_FOR_REPORTING or subset["label_row_binary"].nunique() < 2:
+            continue
+        regime = "within-family" if panel_n >= N_FOLDS else "family-novel (rare, collapsed to 'other')"
+        auc = float(roc_auc_score(subset["label_row_binary"], subset["predicted_probability"]))
+        brier = float(brier_score_loss(subset["label_row_binary"], subset["predicted_probability"]))
+        rows.append(
+            {
+                "family": family,
+                "generalization_regime": regime,
+                "panel_phage_count": panel_n,
+                "n_phages_scored": n_phages,
+                "n_pairs": n_pairs,
+                "pos_rate": round(float(subset["label_row_binary"].mean()), 4),
+                "auc": round(auc, 4),
+                "brier": round(brier, 4),
+            }
+        )
+    df = pd.DataFrame(rows).sort_values(["generalization_regime", "panel_phage_count"], ascending=[True, False])
+    df.to_csv(OUTPUT_CSV, index=False)
+    LOGGER.info("Wrote %s (%d rows)", OUTPUT_CSV, len(df))
+
+    within_mask = df["generalization_regime"] == "within-family"
+    print()
+    print("=== Per-family phage-axis AUC/Brier ===")
+    print(df.to_string(index=False))
+    print()
+    if within_mask.any() and (~within_mask).any():
+        within_auc_weighted = (df.loc[within_mask, "auc"] * df.loc[within_mask, "n_pairs"]).sum() / df.loc[
+            within_mask, "n_pairs"
+        ].sum()
+        novel_auc_weighted = (df.loc[~within_mask, "auc"] * df.loc[~within_mask, "n_pairs"]).sum() / df.loc[
+            ~within_mask, "n_pairs"
+        ].sum()
+        print(
+            f"Pair-weighted AUC — within-family regime: {within_auc_weighted:.4f}; "
+            f"family-novel regime: {novel_auc_weighted:.4f}; "
+            f"gap: {within_auc_weighted - novel_auc_weighted:+.4f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch05_regenerate_metrics_json.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch05_regenerate_metrics_json.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""CH05 post-hoc: regenerate metrics JSONs from existing predictions CSVs.
+
+The initial CH05 artifacts were written before `_ci_to_dict` was updated to
+expose `bootstrap_samples_requested` / `bootstrap_samples_used`. Rather than
+rerun CH05 end-to-end (~3 hr), this script reads the existing predictions,
+reruns the bootstrap from scratch, and rewrites the three JSONs under HEAD
+code so they carry the new fields.
+
+Outputs (in place):
+  - ch05_bacteria_axis_metrics.json
+  - ch05_phage_axis_metrics.json
+  - ch05_combined_summary.json
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.candidate_replay import safe_round
+from lyzortx.pipeline.autoresearch.ch04_eval import BOOTSTRAP_RANDOM_STATE, BOOTSTRAP_SAMPLES
+from lyzortx.pipeline.autoresearch.ch05_eval import (
+    CH04_AGGREGATE_METRICS_PATH,
+    DEFAULT_OUTPUT_DIR,
+    SOURCE_BASEL,
+    SOURCE_GUELIN,
+    _bootstrap_by_unit,
+    _ci_to_dict,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def main() -> None:
+    setup_logging()
+    output_dir = Path(DEFAULT_OUTPUT_DIR)
+
+    bacteria_pairs = pd.read_csv(output_dir / "ch05_bacteria_axis_predictions.csv")
+    phage_pairs = pd.read_csv(output_dir / "ch05_phage_axis_predictions.csv")
+
+    bacteria_rows = bacteria_pairs.to_dict(orient="records")
+    phage_rows = phage_pairs.to_dict(orient="records")
+
+    LOGGER.info("Re-running bacteria-axis bootstrap on %d pairs", len(bacteria_rows))
+    bacteria_cis = _bootstrap_by_unit(
+        bacteria_rows,
+        unit_key="bacteria",
+        bootstrap_samples=BOOTSTRAP_SAMPLES,
+        bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+    )
+    LOGGER.info("Re-running phage-axis bootstrap on %d pairs", len(phage_rows))
+    phage_cis_all = _bootstrap_by_unit(
+        phage_rows,
+        unit_key="phage",
+        bootstrap_samples=BOOTSTRAP_SAMPLES,
+        bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+    )
+
+    bacteria_summary = {
+        "n_pairs": len(bacteria_pairs),
+        "n_bacteria": int(bacteria_pairs["bacteria"].nunique()),
+        "n_phages": int(bacteria_pairs["phage"].nunique()),
+        "aggregate": {name: _ci_to_dict(ci) for name, ci in bacteria_cis.items()},
+    }
+    with open(output_dir / "ch05_bacteria_axis_metrics.json", "w", encoding="utf-8") as f:
+        json.dump(bacteria_summary, f, indent=2)
+
+    cross_source_rows: list[dict[str, object]] = []
+    for source_label in (SOURCE_GUELIN, SOURCE_BASEL):
+        subset = [r for r in phage_rows if r["source"] == source_label]
+        LOGGER.info("Re-running phage-axis bootstrap on %s subset (%d pairs)", source_label, len(subset))
+        subset_cis = _bootstrap_by_unit(
+            subset,
+            unit_key="phage",
+            bootstrap_samples=BOOTSTRAP_SAMPLES,
+            bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+        )
+        cross_source_rows.append(
+            {
+                "source": source_label,
+                "n_pairs": len(subset),
+                "n_phages": len({r["phage"] for r in subset}),
+                "auc_point": safe_round(subset_cis["holdout_roc_auc"].point_estimate),
+                "auc_low": subset_cis["holdout_roc_auc"].ci_low,
+                "auc_high": subset_cis["holdout_roc_auc"].ci_high,
+                "brier_point": safe_round(subset_cis["holdout_brier_score"].point_estimate),
+                "brier_low": subset_cis["holdout_brier_score"].ci_low,
+                "brier_high": subset_cis["holdout_brier_score"].ci_high,
+                "bootstrap_samples_requested": subset_cis["holdout_roc_auc"].bootstrap_samples_requested,
+                "bootstrap_samples_used": subset_cis["holdout_roc_auc"].bootstrap_samples_used,
+            }
+        )
+    phage_summary = {
+        "n_pairs": len(phage_pairs),
+        "n_bacteria": int(phage_pairs["bacteria"].nunique()),
+        "n_phages": int(phage_pairs["phage"].nunique()),
+        "aggregate": {name: _ci_to_dict(ci) for name, ci in phage_cis_all.items()},
+        "cross_source": cross_source_rows,
+    }
+    with open(output_dir / "ch05_phage_axis_metrics.json", "w", encoding="utf-8") as f:
+        json.dump(phage_summary, f, indent=2)
+
+    phage_axis_gap = safe_round(
+        bacteria_cis["holdout_roc_auc"].point_estimate - phage_cis_all["holdout_roc_auc"].point_estimate
+    )
+    guelin_auc = cross_source_rows[0]["auc_point"]
+    basel_auc = cross_source_rows[1]["auc_point"]
+    cross_source_gap = safe_round(abs(float(guelin_auc) - float(basel_auc)))
+
+    ch04_auc = None
+    if CH04_AGGREGATE_METRICS_PATH.exists():
+        with open(CH04_AGGREGATE_METRICS_PATH, encoding="utf-8") as f:
+            ch04 = json.load(f)
+        ch04_auc = ch04["chisel_baseline"]["holdout_roc_auc"]["point_estimate"]
+
+    combined = {
+        "task_id": "CH05",
+        "scorecard": "AUC + Brier (nDCG/mAP/top-k retired)",
+        "per_phage_blending": "retired (see per-phage-retired-under-chisel)",
+        "bacteria_axis": bacteria_summary,
+        "phage_axis": phage_summary,
+        "phage_axis_generalization_gap_auc": phage_axis_gap,
+        "cross_source_auc_delta": cross_source_gap,
+        "ch04_baseline_auc": ch04_auc,
+        "regenerated_at": datetime.now(timezone.utc).isoformat(),
+        "regenerated_from": "existing predictions CSVs (model not rerun)",
+    }
+    with open(output_dir / "ch05_combined_summary.json", "w", encoding="utf-8") as f:
+        json.dump(combined, f, indent=2)
+    LOGGER.info("Regenerated 3 metric JSONs under %s", output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch05_reliability_diagrams.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch05_reliability_diagrams.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""CH05 post-hoc: per-decile reliability tables for Guelin + BASEL on both axes.
+
+Reads the existing CH05 bacteria-axis and phage-axis predictions, bins predicted
+probability into 10 deciles, and reports observed lysis rate vs mean predicted
+probability per decile per (source × axis). This quantifies the calibration
+divergence flagged by the second reviewer: BASEL mid-P reliability was 30-55 pp off
+vs Guelin, and the Brier gap survives Straboviridae exclusion.
+
+No model rerun — reads predictions CSVs. Outputs:
+  lyzortx/generated_outputs/ch05_unified_kfold/ch05_reliability_tables.csv
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.ch05_eval import DEFAULT_OUTPUT_DIR, SOURCE_BASEL, SOURCE_GUELIN
+
+LOGGER = logging.getLogger(__name__)
+
+N_BINS = 10
+OUTPUT_CSV = Path(DEFAULT_OUTPUT_DIR) / "ch05_reliability_tables.csv"
+
+
+def _reliability_rows(axis: str, source: str, df: pd.DataFrame) -> list[dict[str, object]]:
+    preds = df["predicted_probability"].astype(float).to_numpy()
+    labels = df["label_row_binary"].astype(int).to_numpy()
+    # Fixed decile edges on the [0, 1] predicted-probability range so Guelin and BASEL
+    # bins are comparable (quantile bins would recenter by source and obscure the gap).
+    edges = np.linspace(0.0, 1.0, N_BINS + 1)
+    bin_idx = np.clip(np.digitize(preds, edges[1:-1], right=False), 0, N_BINS - 1)
+    rows: list[dict[str, object]] = []
+    for b in range(N_BINS):
+        mask = bin_idx == b
+        n = int(mask.sum())
+        if n == 0:
+            continue
+        mean_pred = float(preds[mask].mean())
+        obs_rate = float(labels[mask].mean())
+        rows.append(
+            {
+                "axis": axis,
+                "source": source,
+                "bin_lo": round(float(edges[b]), 3),
+                "bin_hi": round(float(edges[b + 1]), 3),
+                "n_pairs": n,
+                "mean_predicted": round(mean_pred, 4),
+                "observed_rate": round(obs_rate, 4),
+                "reliability_gap": round(obs_rate - mean_pred, 4),
+            }
+        )
+    return rows
+
+
+def main() -> None:
+    setup_logging()
+    rows: list[dict[str, object]] = []
+    for axis in ("bacteria_axis", "phage_axis"):
+        preds = pd.read_csv(Path(DEFAULT_OUTPUT_DIR) / f"ch05_{axis}_predictions.csv")
+        for source in (SOURCE_GUELIN, SOURCE_BASEL):
+            subset = preds[preds["source"] == source]
+            if subset.empty:
+                continue
+            rows.extend(_reliability_rows(axis, source, subset))
+
+    df = pd.DataFrame(rows)
+    df.to_csv(OUTPUT_CSV, index=False)
+    LOGGER.info("Wrote %s (%d rows)", OUTPUT_CSV, len(df))
+
+    print()
+    print("=== CH05 reliability by decile (|gap| = |observed − predicted|) ===")
+    for axis in ("bacteria_axis", "phage_axis"):
+        print(f"\n--- {axis} ---")
+        subset = df[df["axis"] == axis]
+        print(subset.to_string(index=False))
+
+    print("\n--- Cross-source reliability delta per bin (BASEL − Guelin) ---")
+    for axis in ("bacteria_axis", "phage_axis"):
+        gue = df[(df["axis"] == axis) & (df["source"] == SOURCE_GUELIN)].set_index(["bin_lo", "bin_hi"])
+        bas = df[(df["axis"] == axis) & (df["source"] == SOURCE_BASEL)].set_index(["bin_lo", "bin_hi"])
+        joined = gue.join(bas, lsuffix="_g", rsuffix="_b", how="inner")
+        if joined.empty:
+            continue
+        joined["delta_observed"] = joined["observed_rate_b"] - joined["observed_rate_g"]
+        joined["delta_gap"] = joined["reliability_gap_b"] - joined["reliability_gap_g"]
+        print(f"\n{axis}:")
+        print(
+            joined[
+                [
+                    "n_pairs_g",
+                    "n_pairs_b",
+                    "observed_rate_g",
+                    "observed_rate_b",
+                    "delta_observed",
+                    "reliability_gap_g",
+                    "reliability_gap_b",
+                    "delta_gap",
+                ]
+            ]
+            .round(4)
+            .to_string()
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch05_straboviridae_exclusion.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch05_straboviridae_exclusion.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""CH05 post-hoc: Straboviridae-exclusion diagnostic on existing predictions.
+
+Motivated by reviewer observation that the CH05 cross-source BASEL AUC gap + BASEL
+calibration divergence may trace to Straboviridae prior collapse (family-bias-straboviridae):
+broad-host Straboviridae (62-71% lysis rate) dominate model rankings and may be over-predicted
+on BASEL panels that happen to carry different Straboviridae proportions than Guelin.
+
+Reads the existing CH05 phage-axis and bacteria-axis predictions + the unified ICTV family
+map. Recomputes aggregate AUC/Brier with and without Straboviridae for each (source × axis)
+combination. A material shrink in the BASEL-minus-Guelin delta after Straboviridae exclusion
+would flag the family as the operative confounder; a stable delta rules it out.
+
+No model rerun — reads predictions CSVs + family map. Outputs:
+  lyzortx/generated_outputs/ch05_unified_kfold/ch05_straboviridae_exclusion.csv
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+from sklearn.metrics import brier_score_loss, roc_auc_score
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.ch05_eval import DEFAULT_OUTPUT_DIR, SOURCE_BASEL, SOURCE_GUELIN
+from lyzortx.pipeline.autoresearch.sx15_eval import load_unified_phage_family_map
+
+LOGGER = logging.getLogger(__name__)
+
+STRABOVIRIDAE_FAMILY = "Straboviridae"
+OUTPUT_CSV = Path(DEFAULT_OUTPUT_DIR) / "ch05_straboviridae_exclusion.csv"
+
+
+def _auc_brier(df: pd.DataFrame) -> tuple[float, float, int, int, int]:
+    labels = df["label_row_binary"].astype(int).to_numpy()
+    preds = df["predicted_probability"].astype(float).to_numpy()
+    n_pairs = len(df)
+    n_pos = int(labels.sum())
+    n_phages = int(df["phage"].nunique())
+    auc = float(roc_auc_score(labels, preds)) if len(set(labels.tolist())) > 1 else float("nan")
+    brier = float(brier_score_loss(labels, preds))
+    return auc, brier, n_pairs, n_pos, n_phages
+
+
+def _row(axis: str, source: str | None, include_strabo: bool, df: pd.DataFrame) -> dict[str, object]:
+    auc, brier, n_pairs, n_pos, n_phages = _auc_brier(df)
+    return {
+        "axis": axis,
+        "source": source or "combined",
+        "straboviridae": "included" if include_strabo else "excluded",
+        "n_phages": n_phages,
+        "n_pairs": n_pairs,
+        "pos_rate": round(n_pos / n_pairs, 4) if n_pairs else float("nan"),
+        "auc": round(auc, 4),
+        "brier": round(brier, 4),
+    }
+
+
+def main() -> None:
+    setup_logging()
+    family_map = load_unified_phage_family_map()
+
+    rows: list[dict[str, object]] = []
+    for axis in ("bacteria_axis", "phage_axis"):
+        preds_path = Path(DEFAULT_OUTPUT_DIR) / f"ch05_{axis}_predictions.csv"
+        preds = pd.read_csv(preds_path)
+        preds["family"] = preds["phage"].map(family_map).fillna("UNKNOWN")
+
+        for source in (None, SOURCE_GUELIN, SOURCE_BASEL):
+            subset_all = preds if source is None else preds[preds["source"] == source]
+            if subset_all.empty:
+                continue
+            rows.append(_row(axis, source, True, subset_all))
+            subset_no_strabo = subset_all[subset_all["family"] != STRABOVIRIDAE_FAMILY]
+            if not subset_no_strabo.empty and subset_no_strabo["label_row_binary"].nunique() > 1:
+                rows.append(_row(axis, source, False, subset_no_strabo))
+
+    df = pd.DataFrame(rows)
+    df.to_csv(OUTPUT_CSV, index=False)
+    LOGGER.info("Wrote %s (%d rows)", OUTPUT_CSV, len(df))
+
+    print()
+    print("=== CH05 Straboviridae-exclusion diagnostic (existing predictions, no rerun) ===")
+    print(df.to_string(index=False))
+    print()
+
+    # Cross-source delta shift: does excluding Straboviridae close the BASEL-minus-Guelin AUC gap?
+    for axis in ("bacteria_axis", "phage_axis"):
+        pivot = df[df["axis"] == axis].pivot_table(
+            index="straboviridae", columns="source", values="auc", aggfunc="first"
+        )
+        if {"guelin", "basel"}.issubset(pivot.columns):
+            delta_incl = float(pivot.loc["included", "basel"] - pivot.loc["included", "guelin"])
+            delta_excl = float(pivot.loc["excluded", "basel"] - pivot.loc["excluded", "guelin"])
+            print(
+                f"{axis}: BASEL − Guelin AUC | Straboviridae included: {delta_incl:+.4f}, "
+                f"excluded: {delta_excl:+.4f}, shift: {delta_excl - delta_incl:+.4f}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -484,6 +484,62 @@ fine (+0.8 pp at 0.9–1.0), so the model *can* calibrate when features unambigu
 score; it miscalibrates specifically in the mid-P region where features push predictions upward
 but pairs don't actually lyse at the predicted rate.
 
+**Isotonic calibration diagnostic (two separable mechanisms, empirically confirmed).** The
+reviewer flagged that attributing all mid-P miscalibration to TL17-bias stretches the
+feature-failure-mode story to cover territory it doesn't explain — TL17-bias concerns
+cross-source generalization, but Guelin is also 28–30 pp off in mid-P despite the model being
+trained on these exact phages. Tested this via leave-one-fold-out isotonic regression on Guelin
+predictions (fold-aware, no leakage), then applied the Guelin-fitted calibrator to BASEL
+predictions as the discriminative test — Guelin/BASEL panels are disjoint so no leakage. Script:
+`ch05_isotonic_calibration_test.py`. Expected three outcomes (A: threshold story for both;
+B: threshold for Guelin, TL17-bias extra for BASEL; C: threshold wrong for both).
+
+| Subset | Raw ECE | Iso ECE | Raw max \|gap\| | Iso max \|gap\| | Closure |
+|---|---|---|---|---|---|
+| Guelin bacteria-axis | 0.120 | **0.008** | 30.4 pp | **6.6 pp** | 78% |
+| Guelin phage-axis | 0.104 | **0.008** | 26.3 pp | **2.9 pp** | 89% |
+| BASEL bacteria-axis | 0.272 | 0.113 | 51.6 pp | 32.6 pp | 37% |
+| BASEL phage-axis | 0.236 | 0.122 | 53.0 pp | 35.1 pp | 34% |
+
+**Outcome B confirmed.** Guelin mid-P is essentially fully fixable with an isotonic layer (ECE
+drops from 0.12 to 0.008, gap closure 78–89%). BASEL improves but retains a substantial residual
+(ECE stays at 0.11–0.12, gap closure only 34–37%) — the Guelin-fitted calibrator cannot rescue
+BASEL's full miscalibration because it comes from a different mechanism. AUC sanity: moves by ≤0.5
+pp on Guelin (isotonic produces ties that shift rank-based ordering slightly) and ≤0.001 pp on
+BASEL; the small Guelin movement is tie-breaking noise, not a bug — isotonic is monotone but not
+strictly monotone. Strict AUC invariance holds only for unclipped strictly-monotonic maps; under
+boundary clipping and ties in the fitted step function, ranking is preserved up to tie-breaking
+at the edges, which can produce sub-percent AUC movement. Worth flagging for transparency.
+
+**Two-driver story.** Guelin's mid-P gap is a training-label-vs-deployment-question mismatch.
+Gaborieau 2024 Methods (see `mlc-dilution-potency`) explicitly says clearing events at high titer
+"could result from productive lysis of the bacterial population by the phage, or from another
+mechanism such as lysis from without, or abortive infection." CHISEL's per-row binary training
+treats every score='1' row as a positive, including non-productive clearing. The deployment
+question — "will this phage productively lyse this strain at therapeutic dose?" — is stricter
+than the training label, and the model's inflated mid-P probabilities are the signature of that
+mismatch. This is fixable post-hoc without changing the underlying model (the discrimination is
+already there). Connected to `ambiguous-label-noise` (GT09 showed +3.1 pp top-3 from dropping 10%
+of noisy rows — same shape of mechanism, different regime).
+
+BASEL's residual after Guelin-fitted calibration (~12 pp ECE, ~33 pp max decile gap) is the part
+that threshold-mismatch cannot explain. It matches the `ch05_basel_zero_vector_split` diagnostic:
+miscalibration concentrates on the 39/52 non-zero-projection BASEL phages (Brier 0.31 bacteria-
+axis) whose phage_projection vectors map into Guelin-calibrated TL17 neighborhoods associated
+with broad-host lysis but whose actual host ranges are narrower. That is a feature-transfer
+problem that needs panel-independent phage features (CH06), not a calibration layer.
+
+**Implication for CH06 scope** (forward-looking, not a CH05 acceptance criterion): BASEL's
+bacteria-axis AUC 0.7152 vs Guelin 0.8098 is the 9.5 pp discrimination gap; no calibration layer
+can touch it (ranking is preserved under monotone transforms). CH06's acceptance criterion —
+"materially above 0.7152 on at least one arm" — still reads as written. The calibration component
+of BASEL's 0.1884 Brier vs Guelin's 0.1329 is now understood to be partially fixable post-hoc;
+the remaining discrimination gap is what CH06 must attack.
+
+**Follow-up** (deferred, out of CH05 scope): a dedicated CH-series ticket on "post-hoc
+calibration layer + label-threshold sensitivity" (likely CH09 after CH06 and CH07). Platt scaling
+or isotonic as a deployable calibration step is cheap and independent of CH06's feature work.
+
 **Per-family phage-axis breakdown (post-hoc).**
 
 | Family | Regime | Panel size | n_pairs | pos_rate | AUC | Brier |

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -392,128 +392,231 @@ sets `tm_isdst` correctly so `%z` picks `time.altzone` (`+0200`) during DST and 
 
 ### Executive summary
 
-Successor to SX15 under the CHISEL frame. Ran CH04's per-row all-pairs pipeline on the unified 148-phage × 369-
-bacterium panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL). **Bacteria-axis AUC 0.8061 [0.7917, 0.8199], Brier
-0.1778 [0.1702, 0.1853]** (10-fold CH02 cv_group hash); **phage-axis AUC 0.8850 [0.8617, 0.9062], Brier 0.1348
-[0.1219, 0.1495]** (10-fold StratifiedKFold by ICTV family). Bacteria-axis sits inside CH04's CI (|Δ| ~0.2 pp) —
-BASEL's 1,240 pairs barely move the aggregate on 35K Guelin pairs. Phage-axis beats bacteria-axis by 7.9 pp with
-disjoint CIs, a structural effect: holding out phages keeps all 369 bacteria in training, giving test pairs full
-host-side signal. Cross-source phage-axis split (Guelin 96 phages AUC 0.8863 vs BASEL 52 phages AUC 0.8818):
-**|ΔAUC| = 0.0045** — confirms SX15's 11 pp nDCG BASEL-vs-Guelin artifact is dead under AUC. **Per-phage blending
-is retired on both axes** (ticket deviation inheriting CH04 rationale per `per-phage-retired-under-chisel`);
-the "blending tax" metric is retired with it.
+CH05 measures two-axis generalization under all-pairs-only on the unified 148-phage × 369-bacterium
+panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL). Headline numbers (pre-encoding-fix run):
+**bacteria-axis AUC 0.8061 [0.7917, 0.8199]**; **phage-axis AUC 0.8850 [0.8617, 0.9062]**. Three
+substantive findings fall out, each separate from the others:
 
-**Design.**
+1. **Phage-axis discrimination parity**: Guelin AUC 0.8863 vs BASEL AUC 0.8818, |ΔAUC| 0.0045 — a
+   weak non-rejection on 52 BASEL phages (CI 3× wider than Guelin's), not positive evidence of
+   equivalence.
+2. **Phage-axis calibration divergence**: Guelin Brier 0.1329 vs BASEL Brier 0.1884 — 42% relative
+   degradation on BASEL with disjoint CIs. Per-decile reliability: BASEL mid-P buckets (predicted
+   probability 0.5-0.9) are 21-27 pp more miscalibrated than Guelin on phage-axis and 21-22 pp on
+   bacteria-axis. AUC parity does *not* imply calibration parity.
+3. **BASEL bacteria-axis deficit**: BASEL-only bacteria-axis AUC 0.7152 (1,240 pairs) sits 9.5 pp
+   below Guelin-only bacteria-axis AUC 0.8098 on the same axis. This is a BASEL-specific training
+   limitation invisible in the aggregate (which is 96.6% Guelin-weighted at row level).
 
-- `ch05_eval.py` reuses CH04's per-row training / pair-max-concentration evaluation / bacterium-bootstrap
-  infrastructure without modification. New pieces:
-  - `load_basel_as_row_frame` — BASEL pairs as row-level observations with `log_dilution=0`, `replicate=1`,
-    score ∈ {"0", "1"} copied from the binary interaction. BASEL bacteria are a subset of Guelin bacteria, so
-    `cv_group` is inherited from the Guelin mapping (no separate cv_group computation needed; the 25 BASEL
-    ECOR strains all appear in the 369-bacterium Guelin panel).
-  - `load_unified_row_frame` — concatenates Guelin's 318K-row frame (9 replicates × pair across 4 dilutions)
-    with BASEL's 1.2K-row frame (1 replicate × pair at log_dilution=0). Both carry `source ∈ {guelin, basel}`.
-  - `assign_phage_folds` — StratifiedKFold on 148 phages by ICTV family (rare families <10 phages collapsed
-    into "other" bucket). Deterministic seed. Reuses the SX15 pattern but as a standalone helper under CH05.
-  - `_bootstrap_by_unit(..., unit_key="bacteria" or "phage")` — parametric bootstrap that matches the
-    resampling unit to the held-out axis (bacteria-axis → resample bacteria, phage-axis → resample phages).
-    See the updated GLOSSARY.md bootstrap entry for why.
-  - BASEL phage features are patched into the cache context via
-    `sx03_eval.patch_context_with_extended_slots`.
-- Per-phage blending is **omitted on both axes**. On phage-axis it's structurally impossible (held-out phages
-  have zero training rows). On bacteria-axis it's omitted by design inheritance from CH04: the
-  `per-phage-retired-under-chisel` knowledge unit forbids re-enablement in CHISEL or successor tracks
-  (non-deployable, inflates bacteria-axis metrics non-transferably, collapses under per-row training).
-- The ticket's "BLENDING TAX" directive is moot under all-pairs-only — there is no blending to tax. The
-  bacteria-axis vs phage-axis AUC gap is reported as the **phage-axis generalization gap** instead; it's a
-  structural training-coverage effect, not a blending artifact.
+The wave-closing "BASEL phages generalize essentially identically to Guelin phages" claim from the
+earlier draft is retired — it conflates three separate findings into one headline that holds only
+along the discrimination-AUC axis on phage-axis folds. Under calibration, and on bacteria-axis,
+BASEL materially diverges.
 
-**Run.**
+**Design.** `ch05_eval.py` reuses CH04's per-row training / pair-max-concentration evaluation /
+cluster-bootstrap infrastructure. New helpers: `load_basel_as_row_frame` (BASEL pairs as row-level
+observations with parameterised `log10_pfu_ml` via `--basel-log10-pfu-ml`, replicate=1, fails loudly
+on missing Guelin cv_group per AGENTS.md fail-fast); `load_unified_row_frame` (concat);
+`assign_phage_folds` (StratifiedKFold on 148 phages by ICTV family + "other" catch-all for families
+<10 phages + "UNKNOWN" for the 20/52 BASEL phages with no ICTV assignment — the labeling in the
+earlier draft as "ICTV-stratified" was misleading given 40% of folds are pseudo-family buckets);
+`_bootstrap_by_unit(unit_key=...)` (cluster-bootstrap — resamples bacteria on bacteria-axis, phages
+on phage-axis). BASEL phage features patched via `sx03_eval.patch_context_with_extended_slots`.
+**Per-phage blending omitted on both axes** — on phage-axis structurally impossible (held-out phages
+have zero training rows), on bacteria-axis under `per-phage-retired-under-chisel`. The ticket's
+"BLENDING TAX" is consequently moot — replaced by the phage-axis generalization gap as a structural
+diagnostic. `build_clean_row_training_frame` now logs pair-level drops so the 21 IAI64 all-`n` pair
+drop is traceable across future dataset revisions.
 
-```
-PYTHONPATH=. python -m lyzortx.pipeline.autoresearch.ch05_eval --device-type cpu
-```
+**Audit confirms** (case-by-case): row counts exact (318,816 Guelin + 1,240 BASEL), Guelin drops
+exactly 8,675 `n` rows (2.7%), BASEL drops 0 (no `n` category), 96 Guelin + 52 BASEL phage IDs fully
+disjoint, all 25 BASEL ECOR bacteria resolve in the Guelin cv_group map, no train/test leakage,
+every pair_id has exactly one source tag, CSV metrics reproduce JSON exactly. **21 benign drops** are
+all on bacterium IAI64 (22% of IAI64's phage surface — any future IAI64 per-bacterium analysis needs
+this caveat).
 
-Total runtime 10,774 s (3 hours): 2 axes × 10 folds × 3 seeds = 60 LightGBM fits, each on ~270–290K rows.
+**Run.** `PYTHONPATH=. python -m lyzortx.pipeline.autoresearch.ch05_eval --device-type cpu` —
+10,774 s (3 hr): 2 axes × 10 folds × 3 seeds on ~270–290K rows per fit.
 
-**Results.**
+**Results (BASEL encoded at log_dilution=0).**
 
 | Quantity | Value | 95% CI |
 |---|---|---|
 | Bacteria-axis AUC | 0.8061 | [0.7917, 0.8199] |
 | Bacteria-axis Brier | 0.1778 | [0.1702, 0.1853] |
-| Phage-axis AUC | **0.8850** | [0.8617, 0.9062] |
+| Phage-axis AUC | 0.8850 | [0.8617, 0.9062] |
 | Phage-axis Brier | 0.1348 | [0.1219, 0.1495] |
-| Phage-axis Guelin-subset AUC (96 phages, 35,403 pairs) | 0.8863 | [0.8653, 0.9078] |
-| Phage-axis BASEL-subset AUC (52 phages, 1,240 pairs) | 0.8818 | [0.8194, 0.9320] |
-| Phage-axis generalization gap (bacteria − phage AUC) | **−0.0789** | CIs disjoint |
-| Cross-source \|ΔAUC\| (Guelin vs BASEL, phage-axis) | 0.0045 | well under 1 pp tolerance |
+| Phage-axis Guelin subset AUC | 0.8863 | [0.8653, 0.9078] |
+| Phage-axis BASEL subset AUC | 0.8818 | [0.8194, 0.9320] |
+| Phage-axis Guelin subset Brier | 0.1329 | [0.1191, 0.1472] |
+| Phage-axis BASEL subset Brier | **0.1884** | [0.1581, 0.2206] |
+| Phage-axis generalization gap (bacteria − phage AUC) | −0.0789 | CIs disjoint |
 
-Per-fold AUCs (bacteria-axis): 0.822, 0.783, 0.781, 0.835, 0.806, 0.816, 0.798, 0.840, 0.794, 0.781.
-Per-fold AUCs (phage-axis):    0.884, 0.938, 0.890, 0.900, 0.865, 0.914, 0.896, 0.895, 0.841, 0.875.
+Per-fold AUC bacteria-axis: 0.822, 0.783, 0.781, 0.835, 0.806, 0.816, 0.798, 0.840, 0.794, 0.781
+(std 0.023). Per-fold phage-axis: 0.884, 0.938, 0.890, 0.900, 0.865, 0.914, 0.896, 0.895, 0.841, 0.875
+(std 0.028).
 
-**Interpretation.**
+**BASEL bacteria-axis deficit** (first-order finding, separate from phage-axis parity). Filtering
+bacteria-axis predictions CSV by source: Guelin AUC 0.8098 (35,403 pairs), **BASEL AUC 0.7152**
+(1,240 pairs) — BASEL is 9.5 pp below Guelin on the same axis, and 17 pp below BASEL phage-axis on
+the same pairs. The aggregate bacteria-axis AUC 0.8061 is 96.6% Guelin-weighted at row level, which
+is why this finding is invisible in the headline. It is a separate deployability diagnostic from the
+cross-source phage-axis question and belongs in its own line on the knowledge model.
 
-*Bacteria-axis is CH04 plus BASEL bacteria in holdout folds.* Aggregate AUC 0.8061 sits inside CH04's CI
-(0.7944–0.8217), with a 0.25 pp point drop that is within-noise. BASEL adds 1,240 pairs against 35K Guelin
-pairs — too small a fraction to move the aggregate on its own, and all 25 BASEL ECOR strains were already in
-Guelin so no new bacterium-side signal is introduced. Brier moves 3 bp worse (0.1750 → 0.1778), also
-within-noise. **The bacteria-axis number is the same story as CH04**; adding BASEL does not change the
-deployability estimate for unseen bacteria.
+**Per-decile reliability** (observed lysis rate vs mean predicted probability; bins of width 0.1).
+Regenerable via `ad_hoc_analysis_code/ch05_reliability_diagrams.py`.
 
-*Phage-axis is ~8 pp higher than bacteria-axis, but this is not a deployment gain.* The 7.9 pp gap is a
-training-coverage effect, not a model-quality effect. On bacteria-axis, holding out bacterium X removes all
-~96 (bacterium X, phage p) pairs from training, so the model must predict for X's host features without ever
-having seen X in training. On phage-axis, holding out phage Y removes all (bacterium b, phage Y) pairs but
-every bacterium b remains in training on all 147 retained phages — the model has full host-side signal for
-every test pair. The phage-axis result answers "how well does the model predict for an unseen phage when we
-have complete bacterium-side data?" — a real deployability question, but a narrower one than the bacteria-
-axis question. Do NOT report phage-axis AUC 0.8850 as a better result than bacteria-axis AUC 0.8061;
-they measure different generalization axes.
+| Bin | Guelin bacteria-axis | BASEL bacteria-axis | Guelin phage-axis | BASEL phage-axis |
+|---|---|---|---|---|
+| 0.5–0.6 | −22.6 pp | −20.0 pp | −23.5 pp | **−48.3 pp** |
+| 0.6–0.7 | −28.1 pp | **−45.3 pp** | −26.3 pp | **−53.0 pp** |
+| 0.7–0.8 | −30.4 pp | **−51.6 pp** | −20.8 pp | **−46.1 pp** |
+| 0.8–0.9 | −27.6 pp | **−49.9 pp** | −17.0 pp | **−44.1 pp** |
+| 0.9–1.0 | −18.4 pp | −26.0 pp | −6.4 pp | +0.8 pp |
 
-The generalization gap concept is preserved but renamed. SX15 called this the "per-phage blending tax"
-because per-phage memorized bacterium priors on bacteria-axis and couldn't on phage-axis. Under CHISEL's
-all-pairs-only model, there is no blending to tax — the gap is purely the structural
-training-coverage difference between the two axes. `spandex-unified-kfold-baseline` retired its
-blending-tax number (2 pp in SX15 nDCG, 3 pp in SX15 AUC) as non-load-bearing under CHISEL.
+Both sources over-predict in mid-P bins (the model is systematically too confident at 0.5–0.9), but
+BASEL's reliability gap is 21–27 pp wider than Guelin's in those bins. BASEL's top-decile phage-axis
+calibration is fine (+0.8 pp at 0.9–1.0), so the model *can* calibrate on BASEL when features
+unambiguously drive a high score; it miscalibrates specifically in the mid-P region where features
+are driving predictions upward but BASEL pairs don't actually lyse.
 
-*Cross-source parity under AUC confirms SX15's metric-artifact diagnosis.* The Guelin-vs-BASEL AUC gap is
-0.0045 (with the BASEL CI heavily overlapping Guelin's), well under the 1 pp expected tolerance. SX15's
-BASEL-nDCG > Guelin-nDCG by 11 pp (0.8332 vs 0.7193) was a graded-vs-binary label artifact — nDCG rewards
-predictions that rank higher-relevance items higher, but BASEL is binary (relevance ∈ {0, 1}) while Guelin
-carries MLC 0–3 grades, so the nDCG denominators are not comparable across cohorts. Under AUC, both cohorts
-are indistinguishable. BASEL's Brier (0.1884) is worse than Guelin's (0.1329) but the BASEL CI [0.158,
-0.221] is wide enough that the difference is not load-bearing — 1,240 pairs vs 35,403 pairs, fewer phages
-so less fold-level averaging.
+**Per-family phage-axis breakdown (post-hoc).**
 
-**Artifacts.**
+| Family | Regime | Panel size | n_pairs | pos_rate | AUC | Brier |
+|---|---|---|---|---|---|---|
+| Autographiviridae | within-family | 47 | 14,101 | 0.162 | 0.8678 | 0.1088 |
+| Other | within-family | 40 | 14,757 | 0.345 | 0.8948 | 0.1400 |
+| Straboviridae | within-family | 24 | 4,261 | 0.502 | **0.7338** | 0.2400 |
+| Drexlerviridae | within-family | 17 | 1,770 | 0.080 | 0.9251 | 0.0629 |
+| Demerecviridae | family-novel (rare) | 9 | 148 | 0.122 | 0.7872 | 0.3286 |
+| Schitoviridae | family-novel (rare) | 5 | 1,131 | 0.118 | 0.8526 | 0.0830 |
 
-- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_combined_summary.json` — two-axis numbers, cross-source
-  breakdown, gap measurement.
-- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_bacteria_axis_metrics.json`,
-  `ch05_phage_axis_metrics.json` — per-axis bootstrap CIs.
-- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_cross_source_breakdown.csv` — phage-axis AUC+Brier with
-  CIs split by source.
-- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_{bacteria,phage}_axis_predictions.csv` — pair-level
-  predictions at max observed concentration.
-- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_{bacteria,phage}_axis_per_row_predictions.csv` —
-  per-row predictions for downstream per-concentration diagnostics.
+Aggregate 0.8850 mixes regimes. Straboviridae 0.7338 within-family is the striking weak case (narrow-
+host Straboviridae pattern from `family-bias-straboviridae` surviving the CHISEL frame change).
+Drexlerviridae 0.9251 is standout strong (easy-negative bias at 8% positive). Family-novel AUCs
+(0.7872 / 0.8526) sit inside the within-family spread, so "siblings-in-training boosts AUC" isn't
+clean — signal quality varies more by family identity than by generalization regime. CH06 both-axis
+double-CV is the cleaner test for deployability. Regenerable via
+`lyzortx/research_notes/ad_hoc_analysis_code/ch05_per_family_phage_axis.py`.
+
+**Cross-source parity is narrower than originally framed.**
+
+The earlier draft claimed AUC parity "confirms SX15's 11 pp nDCG gap was a metric artifact." That
+overclaims — AUC and nDCG responding differently does not *prove* one was an artifact; it shows the
+two metrics are sensitive to different aspects of the prediction distribution. CH05 data actually
+supports three separate findings, not a single parity statement:
+
+- **Phage-axis discrimination parity**: |AUC gap| 0.0045 << 1 pp. BASEL CI is 3× wider than Guelin's
+  on 52 phages vs 96 — "indistinguishable" is a weak non-rejection on small N, not positive evidence
+  of transfer.
+- **Phage-axis calibration divergence**: Guelin Brier 0.1329 vs BASEL 0.1884, disjoint CIs, 42%
+  relative calibration hit on BASEL. AUC parity does not imply calibration parity.
+- **Bacteria-axis cross-source asymmetry**: BASEL 0.7152 vs Guelin 0.8098 on the same axis (9.5 pp
+  deficit); BASEL transfers materially worse when held out as bacteria than when held out as phages.
+
+The nDCG-vs-AUC narrative narrows to: under AUC, cross-source discrimination parity holds *on
+phage-axis only*; the nDCG gap was likely a graded-vs-binary label artifact (BASEL has no MLC
+grades), not a deployment signal. Deeper interpretation is case-by-case post-hoc (below).
+
+**Straboviridae prior collapse ruled out as primary driver.** A post-hoc diagnostic
+(`ad_hoc_analysis_code/ch05_straboviridae_exclusion.py`) excluding Straboviridae phages from the
+predictions closes only 1.5 pp of the 9.5 pp bacteria-axis BASEL deficit, and near-zero on
+phage-axis. BASEL Brier still 6.3 pp worse than Guelin even with Straboviridae removed. Future
+tickets should not relitigate this hypothesis.
+
+**Root cause: cross-panel phage feature failure mode.** Under the phage-axis split,
+non-zero-projection BASEL phages (n=39) are substantially miscalibrated — mean P|y=0 = **0.55**
+(bacteria-axis) / 0.44 (phage-axis), Brier **0.31** / 0.21 — while zero-projection BASEL phages
+(n=13) calibrate well (mean P|y=0 = 0.17, Brier 0.12 bacteria-axis). The failure is
+distributional: non-zero BASEL phages map into TL17 projection neighborhoods populated by
+broader-host Guelin phages, and the model applies Guelin-calibrated host-range priors that don't
+fit BASEL's narrower actual host ranges. Zero-vector BASEL phages calibrate correctly precisely
+because the model has *no* phage signal to apply — it falls back to the host-side prior, which is
+roughly correct for their 9.7% positive rate. **Phage features from a Guelin-only reference bank
+are therefore actively harmful on out-of-distribution phages, not merely neutral.**
+
+This connects to `plm-rbp-redundant` (same mechanism, cross-family rather than cross-panel: PLM
+phage features hurt cross-family predictions by −1.22 pp nDCG because they inject within-family
+priors the model misapplies to unseen families — here we see the cross-panel version of the same
+effect). It also supports `panel-size-ceiling`: the fix is not "fill in 13 zero-vector phages" or
+"engineer richer phage features" — it is more training phages at currently-underpopulated TL17
+neighborhoods, so Guelin-calibrated priors aren't the only signal available for BASEL-like phages.
+Cheap diagnostic evidence: `ch05_basel_feature_variance.csv` shows 36.4% of `phage_projection`
+features are constant across all 52 BASEL phages vs 0% across Guelin (i.e., even the 39 non-zero
+BASEL phages occupy a narrower TL17 subregion than Guelin). Zero-vector ∩ UNKNOWN-family overlap is
+partial (8/13), so taxonomic novelty and TL17 coverage correlate but are not coincident —
+`ch05_basel_zero_vector_split.csv` documents the full phage list and per-subset metrics.
+
+**Hypothesis ruled weaker by pos-rate check**: label-semantics asymmetry (Guelin productive lysis
+vs BASEL spot clearing at >10⁹ pfu/ml, which Maffei 2021 says can include "lysis from without or
+abortive infection"). If BASEL's label were materially more permissive we'd expect its positivity
+rate to exceed Guelin's. Non-zero BASEL pos_rate 29.5% vs Guelin 27.3% — essentially equal. Label
+semantics may still contribute at the margin but is not a first-order driver. Not promoted to a
+live candidate without a label-remap experiment that is currently deprioritised.
+
+**Encoding correctness (addressed this ticket, not a driver).** BASEL's >10⁹ pfu/ml spot was
+previously encoded at `log_dilution=0` (= Guelin neat 5×10⁸ pfu/ml, i.e. ~2× below BASEL's actual
+titer) because the original `pair_concentration__log_dilution` feature only represented
+relative-dilution steps. CH05's reliability analysis shows BASEL is *over*-predicted in mid-P —
+the opposite direction the encoding hypothesis predicts — so the encoding was not the dominant
+driver. Regardless, the encoding has been fixed track-wide to absolute `log10_pfu_ml` (Guelin
+{4.7, 6.7, 7.7, 8.7}; BASEL 9.0, the Maffei-reported lower bound — Maffei 2021 Fig. 12 and
+Maffei 2025 Fig. 13 both quote >10⁹ pfu/ml as the working titer, 2025 adds "if possible"). Guelin
+neat at 10⁸·⁷ and BASEL at 10⁹·⁰ now coexist on one feature axis without implicitly mapping BASEL
+onto Guelin's neat. CH04 rerun under the new encoding is an affine-shift sanity check (metrics
+expected within ≤1e-6 of prior run — LightGBM pre-bins features before split search, so a monotonic
+affine shift on a single feature yields identical bin boundaries and tree structure). CH05 rerun
+under the new encoding is deferred to a follow-up ticket — the encoding fix is scientifically small
+but semantically load-bearing for future cross-source work.
+
+**Per-axis gap interpretation.** 7.9 pp bacteria → phage AUC advantage is a **training-coverage
+structural effect**, not a model-quality signal. Bacteria-axis holds out bacteria (loses host-side
+training signal for test pairs); phage-axis holds out phages but keeps all 369 bacteria in training
+(full host-side signal per test pair). Do NOT read phage-axis 0.8850 as "better" than bacteria-axis
+0.8061 — they answer different deployability questions. SX15 framed this as "per-phage blending tax";
+under CHISEL's all-pairs-only model there is no blending to tax and the gap is purely structural.
+
+**Artifacts** (all under `lyzortx/generated_outputs/ch05_unified_kfold/`):
+`ch05_combined_summary.json`, `ch05_{bacteria,phage}_axis_metrics.json`,
+`ch05_cross_source_breakdown.csv`, `ch05_{bacteria,phage}_axis_predictions.csv` (with source tag),
+`ch05_{bacteria,phage}_axis_per_row_predictions.csv`, `ch05_per_family_breakdown.csv`,
+`ch05_straboviridae_exclusion.csv`, `ch05_reliability_tables.csv`, `ch05_basel_feature_variance.csv`,
+`ch05_basel_zero_vector_split.csv`. Bootstrap JSON now exposes `bootstrap_samples_requested` and
+`bootstrap_samples_used` so degenerate-resample skips are visible in the output.
+
+**Follow-ups deferred to a dedicated ticket**: (a) rerun CH05 end-to-end under the new
+`log10_pfu_ml` encoding to replace headline numbers; (b) probe TL17 reference-bank bias on the 39
+non-zero BASEL phages (candidate driver #1); (c) pilot a label-remap experiment if Gibbs-style
+retest data becomes available for BASEL (candidate driver #2). CH06 both-axis double-CV remains the
+deployability test. Family-novel generalization is measured imperfectly here (rare-family collapse
+mixes regimes); IAI64 per-bacterium analysis carries the 22% phage-surface caveat. BASEL with a
+larger panel would tighten cross-source CI comparison.
 
 **Acceptance met.**
 
-- Unified 148-phage × 369-bacterium panel assembled at row level; BASEL embedded as log_dilution=0 rows with
-  cv_group inherited from Guelin.
-- Bacteria-axis CV under CH02 cv_group hash; phage-axis CV under ICTV-stratified 10-fold.
-- AUC + Brier only; no ranking metrics.
-- Cross-source AUC+Brier breakdown emitted with CIs.
-- Phage-axis generalization gap reported in place of the retired "blending tax"; cross-source AUC within
-  1 pp as expected (0.45 pp actual).
-- Artifacts `ch05_bacteria_axis_metrics.json`, `ch05_phage_axis_metrics.json`,
-  `ch05_cross_source_breakdown.csv` emitted.
-- `chisel-unified-kfold-baseline` knowledge unit added as active canonical;
-  `spandex-unified-kfold-baseline` marked HISTORICAL with forward reference.
-- **Ticket deviation**: per-phage blending retired on bacteria-axis (not enabled as the ticket requests).
-  Inherits CH04's `per-phage-retired-under-chisel` unit with explicit "do not re-enable" directive.
-  "Blending tax" concept retired with it.
-- 5 unit tests cover phage-fold determinism, rare-family collapse, missing-family handling, BASEL cv_group
-  inheritance, and source-constant invariance.
+- Unified 148 × 369 panel at row level; BASEL embedded with absolute `log10_pfu_ml` encoding (9.0,
+  Maffei lower bound), cv_group inherited (hard-fail on missing mapping).
+- Bacteria-axis CV under CH02 cv_group hash; phage-axis CV under ICTV family + "Other" (<10
+  phages) + "UNKNOWN" (no family) catch-all 10-fold stratification (40% of folds are pseudo-family
+  buckets; the earlier "ICTV-stratified" shorthand was misleading).
+- Cross-source AUC+Brier with CIs; discrimination parity, calibration divergence, AND BASEL
+  bacteria-axis deficit reported as three separate findings (not a single parity headline).
+- Per-decile reliability tables for both sources × both axes.
+- Straboviridae-exclusion diagnostic, per-phage feature-variance comparison, and BASEL zero-vector
+  vs non-zero split all regenerable from existing artifacts (no model rerun).
+- AUC + Brier only (top-3/nDCG retired under `ranking-metrics-retired`).
+- Per-family phage-axis breakdown post-hoc.
+- Pair-drop logging added (the 21 IAI64 all-`n` pair drop is visible across future dataset revisions).
+- `chisel-unified-kfold-baseline` knowledge unit active with narrower claims; `spandex-unified-kfold-baseline` HISTORICAL.
+- **Ticket scope change** (explicit): per-phage "blending tax" retired under
+  `per-phage-retired-under-chisel`; replaced by phage-axis generalization gap as a structural
+  diagnostic, not a quality metric.
+- 7 CH05 unit tests (phage-fold determinism, rare-family collapse, missing-family handling, BASEL
+  cv_group inheritance, fail-fast on missing map, cluster-bootstrap unit-level behavior,
+  degenerate-resample skip). Vacuous `test_source_constants_are_distinct` removed per self-review.
+- Bootstrap JSON exposes `bootstrap_samples_requested`/`bootstrap_samples_used`.
+- Concentration encoding reworked track-wide: `CONCENTRATION_FEATURE_COLUMN` is now
+  `pair_concentration__log10_pfu_ml`; CH03 derives the Guelin value; CH05 sets BASEL directly;
+  `--basel-log10-pfu-ml` CLI flag available for sensitivity analysis.
+- Full CH05 rerun under the new encoding deferred to a follow-up ticket (scientifically small
+  affine shift; notebook/knowledge headline numbers remain pre-encoding-fix and are flagged as such).

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -474,11 +474,15 @@ Regenerable via `ad_hoc_analysis_code/ch05_reliability_diagrams.py`.
 | 0.8–0.9 | −27.6 pp | **−49.9 pp** | −17.0 pp | **−44.1 pp** |
 | 0.9–1.0 | −18.4 pp | −26.0 pp | −6.4 pp | +0.8 pp |
 
-Both sources over-predict in mid-P bins (the model is systematically too confident at 0.5–0.9), but
-BASEL's reliability gap is 21–27 pp wider than Guelin's in those bins. BASEL's top-decile phage-axis
-calibration is fine (+0.8 pp at 0.9–1.0), so the model *can* calibrate on BASEL when features
-unambiguously drive a high score; it miscalibrates specifically in the mid-P region where features
-are driving predictions upward but BASEL pairs don't actually lyse.
+**Guelin is also substantially miscalibrated in mid-P — not just BASEL.** Guelin bacteria-axis
+predicts 0.75 but observes 0.45 in the 0.7–0.8 bin (−30.4 pp gap), and predicts 0.65 but observes
+0.37 in the 0.6–0.7 bin (−28.1 pp). The "BASEL 21–27 pp wider than Guelin" framing is accurate in
+relative terms, but Guelin is 20–30 pp off in absolute terms; BASEL is another 20 pp worse on top
+of that. Read both together: the model is systematically too confident in mid-P on **both**
+sources; BASEL just amplifies the same failure mode. BASEL's top-decile phage-axis calibration is
+fine (+0.8 pp at 0.9–1.0), so the model *can* calibrate when features unambiguously drive a high
+score; it miscalibrates specifically in the mid-P region where features push predictions upward
+but pairs don't actually lyse at the predicted rate.
 
 **Per-family phage-axis breakdown (post-hoc).**
 

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -385,3 +385,135 @@ sets `tm_isdst` correctly so `%z` picks `time.altzone` (`+0200`) during DST and 
 - 5 unit tests cover `n`-row dropping, concentration feature attachment, max-concentration selection,
   and replicate aggregation. 2 unit tests cover the log_config TZ fix with hardcoded DST probe
   timestamps.
+
+---
+
+## 2026-04-19 18:30 CEST: CH05 — unified Guelin+BASEL two-axis k-fold under CHISEL
+
+### Executive summary
+
+Successor to SX15 under the CHISEL frame. Ran CH04's per-row all-pairs pipeline on the unified 148-phage × 369-
+bacterium panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL). **Bacteria-axis AUC 0.8061 [0.7917, 0.8199], Brier
+0.1778 [0.1702, 0.1853]** (10-fold CH02 cv_group hash); **phage-axis AUC 0.8850 [0.8617, 0.9062], Brier 0.1348
+[0.1219, 0.1495]** (10-fold StratifiedKFold by ICTV family). Bacteria-axis sits inside CH04's CI (|Δ| ~0.2 pp) —
+BASEL's 1,240 pairs barely move the aggregate on 35K Guelin pairs. Phage-axis beats bacteria-axis by 7.9 pp with
+disjoint CIs, a structural effect: holding out phages keeps all 369 bacteria in training, giving test pairs full
+host-side signal. Cross-source phage-axis split (Guelin 96 phages AUC 0.8863 vs BASEL 52 phages AUC 0.8818):
+**|ΔAUC| = 0.0045** — confirms SX15's 11 pp nDCG BASEL-vs-Guelin artifact is dead under AUC. **Per-phage blending
+is retired on both axes** (ticket deviation inheriting CH04 rationale per `per-phage-retired-under-chisel`);
+the "blending tax" metric is retired with it.
+
+**Design.**
+
+- `ch05_eval.py` reuses CH04's per-row training / pair-max-concentration evaluation / bacterium-bootstrap
+  infrastructure without modification. New pieces:
+  - `load_basel_as_row_frame` — BASEL pairs as row-level observations with `log_dilution=0`, `replicate=1`,
+    score ∈ {"0", "1"} copied from the binary interaction. BASEL bacteria are a subset of Guelin bacteria, so
+    `cv_group` is inherited from the Guelin mapping (no separate cv_group computation needed; the 25 BASEL
+    ECOR strains all appear in the 369-bacterium Guelin panel).
+  - `load_unified_row_frame` — concatenates Guelin's 318K-row frame (9 replicates × pair across 4 dilutions)
+    with BASEL's 1.2K-row frame (1 replicate × pair at log_dilution=0). Both carry `source ∈ {guelin, basel}`.
+  - `assign_phage_folds` — StratifiedKFold on 148 phages by ICTV family (rare families <10 phages collapsed
+    into "other" bucket). Deterministic seed. Reuses the SX15 pattern but as a standalone helper under CH05.
+  - `_bootstrap_by_unit(..., unit_key="bacteria" or "phage")` — parametric bootstrap that matches the
+    resampling unit to the held-out axis (bacteria-axis → resample bacteria, phage-axis → resample phages).
+    See the updated GLOSSARY.md bootstrap entry for why.
+  - BASEL phage features are patched into the cache context via
+    `sx03_eval.patch_context_with_extended_slots`.
+- Per-phage blending is **omitted on both axes**. On phage-axis it's structurally impossible (held-out phages
+  have zero training rows). On bacteria-axis it's omitted by design inheritance from CH04: the
+  `per-phage-retired-under-chisel` knowledge unit forbids re-enablement in CHISEL or successor tracks
+  (non-deployable, inflates bacteria-axis metrics non-transferably, collapses under per-row training).
+- The ticket's "BLENDING TAX" directive is moot under all-pairs-only — there is no blending to tax. The
+  bacteria-axis vs phage-axis AUC gap is reported as the **phage-axis generalization gap** instead; it's a
+  structural training-coverage effect, not a blending artifact.
+
+**Run.**
+
+```
+PYTHONPATH=. python -m lyzortx.pipeline.autoresearch.ch05_eval --device-type cpu
+```
+
+Total runtime 10,774 s (3 hours): 2 axes × 10 folds × 3 seeds = 60 LightGBM fits, each on ~270–290K rows.
+
+**Results.**
+
+| Quantity | Value | 95% CI |
+|---|---|---|
+| Bacteria-axis AUC | 0.8061 | [0.7917, 0.8199] |
+| Bacteria-axis Brier | 0.1778 | [0.1702, 0.1853] |
+| Phage-axis AUC | **0.8850** | [0.8617, 0.9062] |
+| Phage-axis Brier | 0.1348 | [0.1219, 0.1495] |
+| Phage-axis Guelin-subset AUC (96 phages, 35,403 pairs) | 0.8863 | [0.8653, 0.9078] |
+| Phage-axis BASEL-subset AUC (52 phages, 1,240 pairs) | 0.8818 | [0.8194, 0.9320] |
+| Phage-axis generalization gap (bacteria − phage AUC) | **−0.0789** | CIs disjoint |
+| Cross-source \|ΔAUC\| (Guelin vs BASEL, phage-axis) | 0.0045 | well under 1 pp tolerance |
+
+Per-fold AUCs (bacteria-axis): 0.822, 0.783, 0.781, 0.835, 0.806, 0.816, 0.798, 0.840, 0.794, 0.781.
+Per-fold AUCs (phage-axis):    0.884, 0.938, 0.890, 0.900, 0.865, 0.914, 0.896, 0.895, 0.841, 0.875.
+
+**Interpretation.**
+
+*Bacteria-axis is CH04 plus BASEL bacteria in holdout folds.* Aggregate AUC 0.8061 sits inside CH04's CI
+(0.7944–0.8217), with a 0.25 pp point drop that is within-noise. BASEL adds 1,240 pairs against 35K Guelin
+pairs — too small a fraction to move the aggregate on its own, and all 25 BASEL ECOR strains were already in
+Guelin so no new bacterium-side signal is introduced. Brier moves 3 bp worse (0.1750 → 0.1778), also
+within-noise. **The bacteria-axis number is the same story as CH04**; adding BASEL does not change the
+deployability estimate for unseen bacteria.
+
+*Phage-axis is ~8 pp higher than bacteria-axis, but this is not a deployment gain.* The 7.9 pp gap is a
+training-coverage effect, not a model-quality effect. On bacteria-axis, holding out bacterium X removes all
+~96 (bacterium X, phage p) pairs from training, so the model must predict for X's host features without ever
+having seen X in training. On phage-axis, holding out phage Y removes all (bacterium b, phage Y) pairs but
+every bacterium b remains in training on all 147 retained phages — the model has full host-side signal for
+every test pair. The phage-axis result answers "how well does the model predict for an unseen phage when we
+have complete bacterium-side data?" — a real deployability question, but a narrower one than the bacteria-
+axis question. Do NOT report phage-axis AUC 0.8850 as a better result than bacteria-axis AUC 0.8061;
+they measure different generalization axes.
+
+The generalization gap concept is preserved but renamed. SX15 called this the "per-phage blending tax"
+because per-phage memorized bacterium priors on bacteria-axis and couldn't on phage-axis. Under CHISEL's
+all-pairs-only model, there is no blending to tax — the gap is purely the structural
+training-coverage difference between the two axes. `spandex-unified-kfold-baseline` retired its
+blending-tax number (2 pp in SX15 nDCG, 3 pp in SX15 AUC) as non-load-bearing under CHISEL.
+
+*Cross-source parity under AUC confirms SX15's metric-artifact diagnosis.* The Guelin-vs-BASEL AUC gap is
+0.0045 (with the BASEL CI heavily overlapping Guelin's), well under the 1 pp expected tolerance. SX15's
+BASEL-nDCG > Guelin-nDCG by 11 pp (0.8332 vs 0.7193) was a graded-vs-binary label artifact — nDCG rewards
+predictions that rank higher-relevance items higher, but BASEL is binary (relevance ∈ {0, 1}) while Guelin
+carries MLC 0–3 grades, so the nDCG denominators are not comparable across cohorts. Under AUC, both cohorts
+are indistinguishable. BASEL's Brier (0.1884) is worse than Guelin's (0.1329) but the BASEL CI [0.158,
+0.221] is wide enough that the difference is not load-bearing — 1,240 pairs vs 35,403 pairs, fewer phages
+so less fold-level averaging.
+
+**Artifacts.**
+
+- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_combined_summary.json` — two-axis numbers, cross-source
+  breakdown, gap measurement.
+- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_bacteria_axis_metrics.json`,
+  `ch05_phage_axis_metrics.json` — per-axis bootstrap CIs.
+- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_cross_source_breakdown.csv` — phage-axis AUC+Brier with
+  CIs split by source.
+- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_{bacteria,phage}_axis_predictions.csv` — pair-level
+  predictions at max observed concentration.
+- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_{bacteria,phage}_axis_per_row_predictions.csv` —
+  per-row predictions for downstream per-concentration diagnostics.
+
+**Acceptance met.**
+
+- Unified 148-phage × 369-bacterium panel assembled at row level; BASEL embedded as log_dilution=0 rows with
+  cv_group inherited from Guelin.
+- Bacteria-axis CV under CH02 cv_group hash; phage-axis CV under ICTV-stratified 10-fold.
+- AUC + Brier only; no ranking metrics.
+- Cross-source AUC+Brier breakdown emitted with CIs.
+- Phage-axis generalization gap reported in place of the retired "blending tax"; cross-source AUC within
+  1 pp as expected (0.45 pp actual).
+- Artifacts `ch05_bacteria_axis_metrics.json`, `ch05_phage_axis_metrics.json`,
+  `ch05_cross_source_breakdown.csv` emitted.
+- `chisel-unified-kfold-baseline` knowledge unit added as active canonical;
+  `spandex-unified-kfold-baseline` marked HISTORICAL with forward reference.
+- **Ticket deviation**: per-phage blending retired on bacteria-axis (not enabled as the ticket requests).
+  Inherits CH04's `per-phage-retired-under-chisel` unit with explicit "do not re-enable" directive.
+  "Blending tax" concept retired with it.
+- 5 unit tests cover phage-fold determinism, rare-family collapse, missing-family handling, BASEL cv_group
+  inheritance, and source-constant invariance.

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -393,11 +393,13 @@ sets `tm_isdst` correctly so `%z` picks `time.altzone` (`+0200`) during DST and 
 ### Executive summary
 
 CH05 measures two-axis generalization under all-pairs-only on the unified 148-phage × 369-bacterium
-panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL). Headline numbers (pre-encoding-fix run):
-**bacteria-axis AUC 0.8061 [0.7917, 0.8199]**; **phage-axis AUC 0.8850 [0.8617, 0.9062]**. Three
+panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL). Headline numbers (post-encoding-fix rerun under
+absolute log₁₀ pfu/ml; Guelin-side fold-level bit-identical, BASEL-side aggregate within sampling
+noise of the pre-fix run):
+**bacteria-axis AUC 0.8063 [0.7919, 0.8202]**; **phage-axis AUC 0.8849 [0.8616, 0.9059]**. Three
 substantive findings fall out, each separate from the others:
 
-1. **Phage-axis discrimination parity**: Guelin AUC 0.8863 vs BASEL AUC 0.8818, |ΔAUC| 0.0045 — a
+1. **Phage-axis discrimination parity**: Guelin AUC 0.8861 vs BASEL AUC 0.8829, |ΔAUC| 0.0032 — a
    weak non-rejection on 52 BASEL phages (CI 3× wider than Guelin's), not positive evidence of
    equivalence.
 2. **Phage-axis calibration divergence**: Guelin Brier 0.1329 vs BASEL Brier 0.1884 — 42% relative
@@ -438,19 +440,19 @@ this caveat).
 **Run.** `PYTHONPATH=. python -m lyzortx.pipeline.autoresearch.ch05_eval --device-type cpu` —
 10,774 s (3 hr): 2 axes × 10 folds × 3 seeds on ~270–290K rows per fit.
 
-**Results (BASEL encoded at log_dilution=0).**
+**Results (BASEL encoded at absolute log₁₀ pfu/ml = 9.0, Guelin neat = 8.7).**
 
 | Quantity | Value | 95% CI |
 |---|---|---|
-| Bacteria-axis AUC | 0.8061 | [0.7917, 0.8199] |
+| Bacteria-axis AUC | 0.8063 | [0.7919, 0.8202] |
 | Bacteria-axis Brier | 0.1778 | [0.1702, 0.1853] |
-| Phage-axis AUC | 0.8850 | [0.8617, 0.9062] |
-| Phage-axis Brier | 0.1348 | [0.1219, 0.1495] |
-| Phage-axis Guelin subset AUC | 0.8863 | [0.8653, 0.9078] |
-| Phage-axis BASEL subset AUC | 0.8818 | [0.8194, 0.9320] |
-| Phage-axis Guelin subset Brier | 0.1329 | [0.1191, 0.1472] |
-| Phage-axis BASEL subset Brier | **0.1884** | [0.1581, 0.2206] |
-| Phage-axis generalization gap (bacteria − phage AUC) | −0.0789 | CIs disjoint |
+| Phage-axis AUC | 0.8849 | [0.8616, 0.9059] |
+| Phage-axis Brier | 0.1349 | [0.1221, 0.1497] |
+| Phage-axis Guelin subset AUC | 0.8861 | [0.8652, 0.9077] |
+| Phage-axis BASEL subset AUC | 0.8829 | [0.8207, 0.9324] |
+| Phage-axis Guelin subset Brier | 0.1330 | [0.1191, 0.1472] |
+| Phage-axis BASEL subset Brier | **0.1881** | [0.1580, 0.2208] |
+| Phage-axis generalization gap (bacteria − phage AUC) | −0.0785 | CIs disjoint |
 
 Per-fold AUC bacteria-axis: 0.822, 0.783, 0.781, 0.835, 0.806, 0.816, 0.798, 0.840, 0.794, 0.781
 (std 0.023). Per-fold phage-axis: 0.884, 0.938, 0.890, 0.900, 0.865, 0.914, 0.896, 0.895, 0.841, 0.875
@@ -566,7 +568,7 @@ overclaims — AUC and nDCG responding differently does not *prove* one was an a
 two metrics are sensitive to different aspects of the prediction distribution. CH05 data actually
 supports three separate findings, not a single parity statement:
 
-- **Phage-axis discrimination parity**: |AUC gap| 0.0045 << 1 pp. BASEL CI is 3× wider than Guelin's
+- **Phage-axis discrimination parity**: |AUC gap| 0.0032 << 1 pp. BASEL CI is 3× wider than Guelin's
   on 52 phages vs 96 — "indistinguishable" is a weak non-rejection on small N, not positive evidence
   of transfer.
 - **Phage-axis calibration divergence**: Guelin Brier 0.1329 vs BASEL 0.1884, disjoint CIs, 42%

--- a/lyzortx/tests/test_ch04_chisel_baseline.py
+++ b/lyzortx/tests/test_ch04_chisel_baseline.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from lyzortx.pipeline.autoresearch.ch03_row_expansion import GUELIN_NEAT_LOG10_PFU_ML
 from lyzortx.pipeline.autoresearch.ch04_eval import (
     CONCENTRATION_FEATURE_COLUMN,
     build_clean_row_training_frame,
@@ -21,6 +22,7 @@ def _raw_row(pair_id: str, score: str, log_dilution: int, replicate: int = 1) ->
         "phage": phage,
         "pair_id": pair_id,
         "log_dilution": log_dilution,
+        "log10_pfu_ml": GUELIN_NEAT_LOG10_PFU_ML + float(log_dilution),
         "replicate": replicate,
         "score": score,
         "split_holdout": "train_non_holdout",
@@ -42,7 +44,10 @@ def test_build_clean_row_training_frame_drops_n_rows() -> None:
     assert set(clean["score"]) == {"0", "1"}
     assert set(clean["label_row_binary"]) == {0, 1}
     assert CONCENTRATION_FEATURE_COLUMN in clean.columns
-    assert (clean[CONCENTRATION_FEATURE_COLUMN] == clean["log_dilution"].astype(float)).all()
+    assert (clean[CONCENTRATION_FEATURE_COLUMN] == clean["log10_pfu_ml"].astype(float)).all()
+    # Guelin encoding: neat (log_dilution=0) → 8.7; -1 → 7.7 under GUELIN_NEAT_LOG10_PFU_ML + log_dilution.
+    assert (clean[CONCENTRATION_FEATURE_COLUMN] >= 4.0).all()
+    assert (clean[CONCENTRATION_FEATURE_COLUMN] <= 9.0).all()
 
 
 def test_build_clean_row_training_frame_preserves_all_clean_rows() -> None:
@@ -51,85 +56,48 @@ def test_build_clean_row_training_frame_preserves_all_clean_rows() -> None:
     assert len(clean) == len(rows)
 
 
+def _pred_row(pair_id: str, log_dilution: int, replicate: int, label: int, proba: float) -> dict:
+    bacteria, phage = pair_id.split("__")
+    return {
+        "pair_id": pair_id,
+        "bacteria": bacteria,
+        "phage": phage,
+        "log_dilution": log_dilution,
+        "log10_pfu_ml": GUELIN_NEAT_LOG10_PFU_ML + float(log_dilution),
+        "replicate": replicate,
+        "label_row_binary": label,
+        "predicted_probability": proba,
+    }
+
+
 def test_select_pair_max_concentration_keeps_highest_log_dilution_per_pair() -> None:
-    # For a pair with observations at log_dilution ∈ {0, -1, -2}, log_dilution=0 is the
-    # highest actual concentration (5×10⁸ pfu/ml) — the evaluator should pick that row.
+    # For a pair with observations at log_dilution ∈ {0, -1, -2}, log_dilution=0 (log10_pfu_ml=8.7)
+    # is the highest actual concentration — the evaluator should pick that row.
     predictions = pd.DataFrame(
         [
-            {
-                "pair_id": "bac_A__phage_X",
-                "bacteria": "bac_A",
-                "phage": "phage_X",
-                "log_dilution": 0,
-                "replicate": 1,
-                "label_row_binary": 1,
-                "predicted_probability": 0.9,
-            },
-            {
-                "pair_id": "bac_A__phage_X",
-                "bacteria": "bac_A",
-                "phage": "phage_X",
-                "log_dilution": -1,
-                "replicate": 1,
-                "label_row_binary": 0,
-                "predicted_probability": 0.4,
-            },
-            {
-                "pair_id": "bac_A__phage_X",
-                "bacteria": "bac_A",
-                "phage": "phage_X",
-                "log_dilution": -2,
-                "replicate": 1,
-                "label_row_binary": 0,
-                "predicted_probability": 0.1,
-            },
-            {
-                "pair_id": "bac_B__phage_X",
-                "bacteria": "bac_B",
-                "phage": "phage_X",
-                "log_dilution": -2,
-                "replicate": 1,
-                "label_row_binary": 0,
-                "predicted_probability": 0.2,
-            },
-            {
-                "pair_id": "bac_B__phage_X",
-                "bacteria": "bac_B",
-                "phage": "phage_X",
-                "log_dilution": -4,
-                "replicate": 1,
-                "label_row_binary": 0,
-                "predicted_probability": 0.05,
-            },
+            _pred_row("bac_A__phage_X", 0, 1, 1, 0.9),
+            _pred_row("bac_A__phage_X", -1, 1, 0, 0.4),
+            _pred_row("bac_A__phage_X", -2, 1, 0, 0.1),
+            _pred_row("bac_B__phage_X", -2, 1, 0, 0.2),
+            _pred_row("bac_B__phage_X", -4, 1, 0, 0.05),
         ]
     )
     pair_rows = select_pair_max_concentration_rows(predictions)
     assert len(pair_rows) == 2
     pair_a = pair_rows[pair_rows["pair_id"] == "bac_A__phage_X"].iloc[0]
     pair_b = pair_rows[pair_rows["pair_id"] == "bac_B__phage_X"].iloc[0]
-    assert pair_a["log_dilution"] == 0
+    assert pair_a["log10_pfu_ml"] == pytest.approx(GUELIN_NEAT_LOG10_PFU_ML)
     assert pair_a["predicted_probability"] == pytest.approx(0.9)
     assert pair_a["label_row_binary"] == 1
     # bac_B's highest observed concentration is log_dilution=-2 (not every pair is tested at 0).
-    assert pair_b["log_dilution"] == -2
+    assert pair_b["log10_pfu_ml"] == pytest.approx(GUELIN_NEAT_LOG10_PFU_ML - 2.0)
     assert pair_b["predicted_probability"] == pytest.approx(0.2)
 
 
 def test_select_pair_max_concentration_averages_replicates_at_top() -> None:
     # Three replicates at log_dilution=0 — averaged; any replicate with label=1 wins the label.
     predictions = pd.DataFrame(
-        [
-            {
-                "pair_id": "bac_A__phage_X",
-                "bacteria": "bac_A",
-                "phage": "phage_X",
-                "log_dilution": 0,
-                "replicate": r,
-                "label_row_binary": label,
-                "predicted_probability": p,
-            }
-            for r, label, p in [(1, 0, 0.6), (2, 1, 0.8), (3, 0, 0.7)]
-        ]
+        [_pred_row("bac_A__phage_X", 0, r, label, p) for r, label, p in [(1, 0, 0.6), (2, 1, 0.8), (3, 0, 0.7)]]
     )
     pair_rows = select_pair_max_concentration_rows(predictions)
     assert len(pair_rows) == 1

--- a/lyzortx/tests/test_ch05_unified_kfold.py
+++ b/lyzortx/tests/test_ch05_unified_kfold.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pandas as pd
+import pytest
 
+from lyzortx.pipeline.autoresearch.candidate_replay import BootstrapMetricCI
 from lyzortx.pipeline.autoresearch.ch05_eval import (
-    BASEL_LOG_DILUTION,
+    BASEL_LOG10_PFU_ML,
+    BASEL_LOG_DILUTION_SENTINEL,
     BASEL_REPLICATE_ID,
     SOURCE_BASEL,
-    SOURCE_GUELIN,
+    _bootstrap_by_unit,
     assign_phage_folds,
     load_basel_as_row_frame,
 )
@@ -70,21 +73,15 @@ def test_load_basel_as_row_frame_inherits_cv_group_from_guelin() -> None:
                 "interaction": 0,
                 "source": "basel",
             },
-            {
-                "pair_id": "UNKNOWN__phage_Z",
-                "bacteria": "UNKNOWN",
-                "phage": "phage_Z",
-                "interaction": 1,
-                "source": "basel",
-            },
         ]
     )
-    guelin_map = {"ECOR-12": "cv42", "ECOR-13": "cv42"}  # UNKNOWN absent → row dropped
+    guelin_map = {"ECOR-12": "cv42", "ECOR-13": "cv43"}
     with patch("lyzortx.pipeline.autoresearch.ch05_eval.load_basel_interactions", return_value=basel_fake):
         result = load_basel_as_row_frame(guelin_map)
-    assert len(result) == 2  # UNKNOWN dropped
-    assert set(result["cv_group"]) == {"cv42"}
-    assert set(result["log_dilution"]) == {BASEL_LOG_DILUTION}
+    assert len(result) == 2
+    assert set(result["cv_group"]) == {"cv42", "cv43"}
+    assert set(result["log_dilution"]) == {BASEL_LOG_DILUTION_SENTINEL}
+    assert set(result["log10_pfu_ml"]) == {BASEL_LOG10_PFU_ML}
     assert set(result["replicate"]) == {BASEL_REPLICATE_ID}
     assert set(result["source"]) == {SOURCE_BASEL}
     assert set(result["split_holdout"]) == {"train_non_holdout"}
@@ -95,7 +92,84 @@ def test_load_basel_as_row_frame_inherits_cv_group_from_guelin() -> None:
     assert negative["score"] == "0"
 
 
-def test_source_constants_are_distinct() -> None:
-    assert SOURCE_GUELIN != SOURCE_BASEL
-    assert SOURCE_GUELIN.lower() == "guelin"
-    assert SOURCE_BASEL.lower() == "basel"
+def test_load_basel_as_row_frame_fails_fast_on_missing_cv_group() -> None:
+    """AGENTS.md fail-fast: unexpected empty join must raise, not warn+drop."""
+    basel_fake = pd.DataFrame(
+        [
+            {
+                "pair_id": "ECOR-12__phage_X",
+                "bacteria": "ECOR-12",
+                "phage": "phage_X",
+                "interaction": 1,
+                "source": "basel",
+            },
+            {
+                "pair_id": "UNKNOWN_BACTERIUM__phage_Y",
+                "bacteria": "UNKNOWN_BACTERIUM",
+                "phage": "phage_Y",
+                "interaction": 0,
+                "source": "basel",
+            },
+        ]
+    )
+    guelin_map = {"ECOR-12": "cv42"}
+    with patch("lyzortx.pipeline.autoresearch.ch05_eval.load_basel_interactions", return_value=basel_fake):
+        with pytest.raises(ValueError, match="no Guelin cv_group mapping"):
+            load_basel_as_row_frame(guelin_map)
+
+
+def test_bootstrap_by_unit_resamples_at_specified_unit_level() -> None:
+    """Cluster-bootstrap: resample bacteria (not pair rows) → CI width reflects
+    the independent sample size at bacterium level, not pair level."""
+    # Two bacteria, each with 50 perfectly separable pair predictions. Pair-level bootstrap
+    # would compute AUC on n=100, but the effective independent sample size is 2 bacteria.
+    rows = []
+    for bac in ["bac_A", "bac_B"]:
+        for i in range(50):
+            rows.append(
+                {
+                    "bacteria": bac,
+                    "phage": f"p{i}",
+                    "pair_id": f"{bac}__p{i}",
+                    "label_row_binary": 1 if i < 25 else 0,
+                    "predicted_probability": 0.9 if i < 25 else 0.1,
+                }
+            )
+    cis = _bootstrap_by_unit(rows, unit_key="bacteria", bootstrap_samples=100, bootstrap_random_state=1)
+    assert "holdout_roc_auc" in cis
+    assert "holdout_brier_score" in cis
+    assert cis["holdout_roc_auc"].point_estimate == pytest.approx(1.0)
+    # 100 resamples requested, though some may be skipped if they resample one bacterium twice
+    # (degenerate single-class). bootstrap_samples_used ≤ requested.
+    assert cis["holdout_roc_auc"].bootstrap_samples_requested == 100
+    assert cis["holdout_roc_auc"].bootstrap_samples_used <= 100
+
+
+def test_bootstrap_by_unit_skips_degenerate_single_class_resamples() -> None:
+    """If a resample draws only one bacterium and all its labels are identical, AUC is
+    undefined. The bootstrap should skip that resample, not crash or fabricate an AUC."""
+    rows = [
+        {
+            "bacteria": "all_positive",
+            "phage": f"p{i}",
+            "pair_id": f"ap__p{i}",
+            "label_row_binary": 1,
+            "predicted_probability": 0.9,
+        }
+        for i in range(5)
+    ] + [
+        {
+            "bacteria": "all_negative",
+            "phage": f"p{i}",
+            "pair_id": f"an__p{i}",
+            "label_row_binary": 0,
+            "predicted_probability": 0.1,
+        }
+        for i in range(5)
+    ]
+    # Bootstrap samples n_bacteria=2 with replacement. ~half of resamples pick the same
+    # bacterium twice → all one class → AUC skipped. The function should complete.
+    cis = _bootstrap_by_unit(rows, unit_key="bacteria", bootstrap_samples=200, bootstrap_random_state=42)
+    assert isinstance(cis["holdout_roc_auc"], BootstrapMetricCI)
+    # Some resamples should have been skipped.
+    assert cis["holdout_roc_auc"].bootstrap_samples_used < 200

--- a/lyzortx/tests/test_ch05_unified_kfold.py
+++ b/lyzortx/tests/test_ch05_unified_kfold.py
@@ -1,0 +1,101 @@
+"""Tests for CH05 unified Guelin+BASEL frame and phage-axis fold assignment."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pandas as pd
+
+from lyzortx.pipeline.autoresearch.ch05_eval import (
+    BASEL_LOG_DILUTION,
+    BASEL_REPLICATE_ID,
+    SOURCE_BASEL,
+    SOURCE_GUELIN,
+    assign_phage_folds,
+    load_basel_as_row_frame,
+)
+
+
+def test_assign_phage_folds_is_deterministic_and_stratifies() -> None:
+    phages = [f"p{i:02d}" for i in range(20)]
+    family = {p: ("famA" if int(p[1:]) < 10 else "famB") for p in phages}
+    folds_a = assign_phage_folds(phages, family, n_splits=5)
+    folds_b = assign_phage_folds(phages, family, n_splits=5)
+    assert folds_a == folds_b
+    # Each fold should carry both families roughly evenly.
+    per_fold_family: dict[int, dict[str, int]] = {}
+    for phage, fold in folds_a.items():
+        per_fold_family.setdefault(fold, {"famA": 0, "famB": 0})[family[phage]] += 1
+    for fold, counts in per_fold_family.items():
+        assert counts["famA"] == 2, f"Fold {fold} famA count {counts['famA']}"
+        assert counts["famB"] == 2, f"Fold {fold} famB count {counts['famB']}"
+
+
+def test_assign_phage_folds_collapses_rare_families() -> None:
+    # 10 phages in famA, 1 in famB, 1 in famC (both rare) — rares collapse to "other".
+    phages = [f"p{i:02d}" for i in range(12)]
+    family = {phages[i]: "famA" for i in range(10)}
+    family[phages[10]] = "famB"
+    family[phages[11]] = "famC"
+    folds = assign_phage_folds(phages, family, n_splits=5)
+    # Every phage receives a fold, assignment covers all 12.
+    assert set(folds.keys()) == set(phages)
+    assert set(folds.values()) == set(range(5))
+
+
+def test_assign_phage_folds_handles_missing_family() -> None:
+    phages = [f"p{i:02d}" for i in range(10)]
+    # Only half the phages have a family entry.
+    family = {phages[i]: "famA" for i in range(5)}
+    folds = assign_phage_folds(phages, family, n_splits=5)
+    assert set(folds.keys()) == set(phages)
+    # All folds populated.
+    assert set(folds.values()) == set(range(5))
+
+
+def test_load_basel_as_row_frame_inherits_cv_group_from_guelin() -> None:
+    basel_fake = pd.DataFrame(
+        [
+            {
+                "pair_id": "ECOR-12__phage_X",
+                "bacteria": "ECOR-12",
+                "phage": "phage_X",
+                "interaction": 1,
+                "source": "basel",
+            },
+            {
+                "pair_id": "ECOR-13__phage_Y",
+                "bacteria": "ECOR-13",
+                "phage": "phage_Y",
+                "interaction": 0,
+                "source": "basel",
+            },
+            {
+                "pair_id": "UNKNOWN__phage_Z",
+                "bacteria": "UNKNOWN",
+                "phage": "phage_Z",
+                "interaction": 1,
+                "source": "basel",
+            },
+        ]
+    )
+    guelin_map = {"ECOR-12": "cv42", "ECOR-13": "cv42"}  # UNKNOWN absent → row dropped
+    with patch("lyzortx.pipeline.autoresearch.ch05_eval.load_basel_interactions", return_value=basel_fake):
+        result = load_basel_as_row_frame(guelin_map)
+    assert len(result) == 2  # UNKNOWN dropped
+    assert set(result["cv_group"]) == {"cv42"}
+    assert set(result["log_dilution"]) == {BASEL_LOG_DILUTION}
+    assert set(result["replicate"]) == {BASEL_REPLICATE_ID}
+    assert set(result["source"]) == {SOURCE_BASEL}
+    assert set(result["split_holdout"]) == {"train_non_holdout"}
+    assert set(result["is_hard_trainable"]) == {"1"}
+    positive = result[result["pair_id"] == "ECOR-12__phage_X"].iloc[0]
+    assert positive["score"] == "1"
+    negative = result[result["pair_id"] == "ECOR-13__phage_Y"].iloc[0]
+    assert negative["score"] == "0"
+
+
+def test_source_constants_are_distinct() -> None:
+    assert SOURCE_GUELIN != SOURCE_BASEL
+    assert SOURCE_GUELIN.lower() == "guelin"
+    assert SOURCE_BASEL.lower() == "basel"


### PR DESCRIPTION
## Summary

Successor to SX15 under the CHISEL frame. Per-row all-pairs training on the unified 148-phage × 369-bacterium panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL) with bacterium-level / phage-level bootstrap CIs.

**Three separate findings, not a single parity headline** (the earlier draft's "BASEL phages generalize essentially identically" framing is retired as an over-reduction — see the CH05 entry in track_CHISEL.md):

1. **Phage-axis discrimination parity**: Guelin AUC 0.8863 vs BASEL AUC 0.8818, |ΔAUC| 0.0045 — weak non-rejection on 52 BASEL phages with CI 3× wider than Guelin's, not positive evidence of transfer.
2. **Phage-axis calibration divergence**: Guelin Brier 0.1329 vs BASEL 0.1884, disjoint CIs. BASEL mid-P (0.5–0.9 predicted-probability bins) reliability gap 21–27 pp wider than Guelin's.
3. **BASEL bacteria-axis deficit**: BASEL-only bacteria-axis AUC 0.7152 on the 1,240 BASEL pairs vs Guelin-only 0.8098 on the same axis — 9.5 pp BASEL-specific deficit invisible in the 96.6% Guelin-weighted aggregate.

| Axis | AUC | Brier |
|---|---|---|
| Bacteria-axis (CH02 cv_group folds, all 148 phages in training) | **0.8061** [0.7917, 0.8199] | 0.1778 [0.1702, 0.1853] |
| Phage-axis (ICTV family + Other + UNKNOWN catch-all stratification) | **0.8850** [0.8617, 0.9062] | 0.1348 [0.1219, 0.1495] |
| Phage-axis Guelin (96 phages, 35,403 pairs) | 0.8863 [0.8653, 0.9078] | 0.1329 |
| Phage-axis BASEL (52 phages, 1,240 pairs) | 0.8818 [0.8194, 0.9320] | **0.1884** |
| Bacteria-axis Guelin subset | 0.8098 | 0.1748 |
| Bacteria-axis BASEL subset | **0.7152** | 0.2632 |

Phage-axis beats bacteria-axis by 7.9 pp with disjoint CIs. This is a structural training-coverage effect, not a model-quality improvement: holding out phages keeps all 369 bacteria in training. Do NOT interpret phage-axis AUC 0.885 as "better" than bacteria-axis AUC 0.806 — they measure different generalization questions.

## Remediation after review

A second reviewer surfaced that the original PR's "cross-source parity" framing conflated discrimination, calibration, and cross-axis questions and hid the 9.5 pp BASEL bacteria-axis deficit inside a Guelin-weighted aggregate. Five post-hoc diagnostics now run against the existing CH05 artifacts:

- `ch05_per_family_phage_axis.py` — per-family AUC + Brier. Straboviridae within-family AUC 0.7338 vs Drexlerviridae 0.9251 — aggregate 0.8850 mixes very different signals.
- `ch05_straboviridae_exclusion.py` — excluding Straboviridae closes only 1.5 pp of the 9.5 pp bacteria-axis BASEL gap. **Family-bias-straboviridae ruled out as primary driver.**
- `ch05_reliability_diagrams.py` — per-decile reliability tables for all four (source × axis) combinations confirming the 21-27 pp BASEL mid-P calibration gap.
- `ch05_basel_feature_variance.py` — 36.4% of `phage_projection` features are constant across all 52 BASEL phages (vs 0% across Guelin); 25% of BASEL phages carry all-zero projection vectors.
- `ch05_basel_zero_vector_split.py` — the mid-P miscalibration localises to the **39/52 non-zero-projection BASEL phages** (Brier 0.31 bacteria-axis, mean_pred_neg 0.55); the 13/52 zero-vector BASEL phages calibrate correctly (Brier 0.12) because the model has no phage signal to misuse. **Root cause: phage features from a Guelin-only reference bank are actively harmful on out-of-distribution phages, not merely neutral.** Connects to `plm-rbp-redundant` (same mechanism cross-family) and supports `panel-size-ceiling`.
- `ch05_isotonic_calibration_test.py` — **two mechanisms are empirically separable.** Leave-one-fold-out isotonic on Guelin closes 78–89% of Guelin decile gaps (ECE 0.12→0.008, AUC preserved within 0.5 pp under isotonic boundary-clipping ties). Applying the Guelin-fitted calibrator to BASEL closes only 34–37% of BASEL's gaps (residual ECE 0.11–0.12). **Outcome B confirmed**: Guelin mid-P = training-label-vs-deployment-question mismatch (Gaborieau 2024 admits clearing can be non-productive) — fixable post-hoc without features. BASEL's additional gap = TL17-bias feature-transfer problem — requires CH06 panel-independent features, not calibration. ECE added to the scorecard going forward.

Additional remediation commits:
- **Absolute log₁₀ pfu/ml concentration encoding** replaces the relative `log_dilution` feature. Guelin {4.7, 6.7, 7.7, 8.7}; BASEL 9.0 per Maffei 2021 Fig. 12 + Maffei 2025 Fig. 13 (">10⁹ pfu/ml if possible"). Semantic correctness fix — not the dominant driver of the BASEL calibration divergence (the reliability diagnostic shows BASEL over-predicted in mid-P, the opposite direction an encoding mismatch would produce). CH04 sanity rerun under the new encoding confirms bit-identical results at fold level through the first 3 folds (LightGBM bin-then-split makes a monotonic affine shift of one feature a no-op). CH05 rerun under the new encoding deferred to a follow-up amendment on this PR.
- **Notebook + knowledge unit rewrite** with the narrower claims (track_CHISEL.md, `chisel-unified-kfold-baseline` unit, GLOSSARY "Phage projection (TL17 BLAST features, zero-vector projection)" entry).
- **Fail-fast on missing BASEL cv_group** (was warn + drop). Pair-drop log in `build_clean_row_training_frame` so the 21 IAI64 all-`n` drops are traceable across future dataset revisions.
- **`ci_samples_used`** now exposed in the bootstrap JSON so degenerate-resample skips are visible.

## Ticket deviations

- **Per-phage blending retired on bacteria-axis** (ticket says "retain AX02"). Inherits CH04's `per-phage-retired-under-chisel` knowledge unit with "do not re-enable in CHISEL or successor tracks" directive. Per AGENTS.md "Question the requirement" — the retirement rationale is track-wide, not axis-specific.
- **"Blending tax" metric retired.** Under all-pairs-only there is no blending to tax. Reported as "phage-axis generalization gap" instead.

## Follow-ups

- **CH05 rerun under new encoding** (~3 hr) slots into this PR as a follow-up amendment.
- **New CH06 panel-independent phage-feature sweep** (four arms: OOD-aware inference, pairwise proteome similarity, Moriniere receptor-class probabilities, tail-protein-restricted TL17) is the root-cause attack on the TL17-bias finding. Plan entry already landed on main via separate direct-to-main commit.

Closes #429

## Test plan

- [ ] CH04 sanity rerun confirms |ΔAUC| ≤ 1e-4 and |ΔBrier| ≤ 1e-4 vs the prior-encoding baseline at aggregate level
- [ ] CH05 rerun under new encoding produces final headline numbers before merge
- [ ] 511/511 unit tests pass