### PR TITLE
Add review-ml-pr skill; require it in self-review on ML PRs

### DIFF
--- a/.agents/skills/case-by-case/SKILL.md
+++ b/.agents/skills/case-by-case/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: case-by-case
 description: >
-  Compare two phage–host prediction files case-by-case (per-bacterium AUC + Brier deltas, lysis-rate decile
+  Compare two phage–host prediction files case-by-case (per-bacterium AUC + Brier deltas intended under the CHISEL
+  scorecard — script still computes pre-CHISEL ranking metrics, see Pre-CHISEL note; lysis-rate decile
   stratification, narrow-host sign test, permutation significance, named-case spotlight). Use whenever a ticket
   produces a new predictions CSV to be compared against a baseline, to audit whether aggregate metric deltas
   reflect real signal or just noise. Triggers on "case-by-case", "compare predictions", "per-bacterium delta",

--- a/.agents/skills/case-by-case/SKILL.md
+++ b/.agents/skills/case-by-case/SKILL.md
@@ -1,28 +1,29 @@
 ---
 name: case-by-case
 description: >
-  Compare two phage–host prediction files case-by-case (per-bacterium nDCG deltas, lysis-rate decile stratification,
-  narrow-host sign test, permutation significance, named-case spotlight, top-3 hit rate). Use after every SPANDEX /
-  autoresearch ticket that produces a new predictions CSV, to audit whether aggregate metric deltas reflect real signal
-  or just noise. Triggers on "case-by-case", "compare predictions", "per-bacterium delta", "audit this result",
-  "is this noise", "NILS53 analysis", "case study", or when the user wants to check whether a ticket's metric delta
-  comes from real localized wins or a uniform tiny shift.
+  Compare two phage–host prediction files case-by-case (per-bacterium AUC + Brier deltas, lysis-rate decile
+  stratification, narrow-host sign test, permutation significance, named-case spotlight). Use whenever a ticket
+  produces a new predictions CSV to be compared against a baseline, to audit whether aggregate metric deltas
+  reflect real signal or just noise. Triggers on "case-by-case", "compare predictions", "per-bacterium delta",
+  "audit this result", "is this noise", "case study", or when the user wants to check whether a ticket's metric
+  delta comes from real localized wins or a uniform tiny shift.
 user-invocable: true
 argument-hint: "<baseline_predictions.csv> <candidate_predictions.csv> [--focus BACT1,BACT2] [--out report.md]"
 ---
 
 # Case-by-Case Prediction Comparison
 
-After every autoresearch or SPANDEX ticket that produces a new predictions CSV, run this skill to decide whether the
-aggregate metric deltas (usually small) reflect real localized signal or are statistical noise. The same diagnostic
-protocol was used in SX11, SX12, and SX13 — bake it into a reusable tool so we don't rebuild it every time.
+Whenever a ticket produces a new predictions CSV to compare against a baseline, run this skill to decide whether the
+aggregate metric deltas (usually small) reflect real localized signal or are statistical noise. Complements
+`review-ml-pr` (which verifies a single artifact) when the question is "did this new run improve over the prior
+run, and is that improvement real or noise?"
 
 ## When to use
 
 - A ticket produces a new predictions CSV alongside bootstrap CIs
-- Aggregate AUC/nDCG deltas vs the reference baseline are small (< ~2 pp)
+- Aggregate AUC or Brier deltas vs the reference baseline are small (< ~2 pp)
 - You need to decide: clean null, sub-threshold signal, or cherry-picked outlier?
-- The acceptance criteria include a named case (NILS53, Dhillonvirus narrow-host, ECOR-XX, etc.) and you need to check
+- The acceptance criteria include a named case (a specific bacterium, phage, or phage family) and you need to check
   whether its improvement generalizes
 
 ## How to invoke
@@ -30,27 +31,27 @@ protocol was used in SX11, SX12, and SX13 — bake it into a reusable tool so we
 ```
 python .agents/skills/case-by-case/compare_predictions.py \
     <baseline_predictions.csv> <candidate_predictions.csv> \
-    [--label-col mlc_score] [--entity-col bacteria] [--pred-col predicted_probability] \
-    [--focus NILS53,ECOR-19,EDL933] \
+    [--label-col label_row_binary] [--entity-col bacteria] [--pred-col predicted_probability] \
+    [--focus BAC1,BAC2,BAC3] \
     [--narrow-rate 0.15] [--broad-rate 0.30] \
     [--permutations 200] \
     [--out report.md]
 ```
 
-Both CSVs must share a `pair_id` column (or an equivalent unique key the two files can be merged on). The default
-column names match SX10/SX11/SX12/SX13 prediction outputs. Report prints to stdout and optionally to `report.md`.
+Both CSVs must share a `pair_id` column (or an equivalent unique key the two files can be merged on). Override the
+column defaults via the flags above when the prediction schema differs. Report prints to stdout and optionally to
+`report.md`.
 
 ## What it reports
 
-1. **Aggregate metrics comparison** — per-bacterium nDCG under each prediction file (mean / median / spread)
-2. **Win / loss / tie counts** — how many bacteria improve, degrade, tie at ≥1 pp threshold
+1. **Aggregate metrics comparison** — per-bacterium AUC and Brier under each prediction file (mean / median / spread)
+2. **Win / loss / tie counts** — how many bacteria improve, degrade, tie at the configured delta threshold
 3. **Lysis-rate decile stratification** — where in the narrow ↔ broad spectrum the delta is concentrated
 4. **Sign test on narrow hosts** — is the narrow-host effect statistically significant?
 5. **Permutation test on aggregate delta** — swap predictions per pair 50/50 N times; is the observed delta typical of
    random swaps?
-6. **Named-case spotlight** — for each `--focus` bacterium: per-pair rank changes for all its positives; peer
+6. **Named-case spotlight** — for each `--focus` bacterium: per-pair prediction shifts for all its positives; peer
    comparison (bacteria within ±3 pp of its lysis rate) to flag outlier wins
-7. **Top-3 hit rate** — number of bacteria with at least one top-3 prediction that is a true positive
 
 ## Writing up the result
 
@@ -60,8 +61,8 @@ honest readings over optimistic ones:
 - A delta that passes the acceptance gate + survives permutation test + has aligned decile pattern = **real signal**
 - A delta that fails permutation test but has a clean decile pattern = **sub-threshold directional signal** — note it,
   don't adopt
-- A delta that's dominated by one outlier bacterium (e.g., NILS53 at 76th percentile of its peers) = **cherry-picked
-  outlier, not reproducible rescue** — say so explicitly
+- A delta that's dominated by one outlier bacterium sitting well above its peer group at the same lysis rate =
+  **cherry-picked outlier, not reproducible rescue** — say so explicitly
 
 ## Implementation notes
 
@@ -72,17 +73,19 @@ honest readings over optimistic ones:
   decile-level mean to be interpretable.
 - Narrow-host sign test uses the default 15% lysis-rate cutoff. Override with `--narrow-rate` if the project's
   definition of narrow differs.
-- The script treats `mlc_score` as the relevance for nDCG and `mlc_score > 0` as the binary positive label. Override
-  with `--label-col` / `--binary-label-col` if your prediction files use different schemas.
-- For runtime, 200 permutations × 356 bacteria × nDCG computation = ~30 seconds. Don't crank permutations past 500
-  unless you have a specific reason — the null distribution stabilizes quickly.
+- Narrow/broad cutoffs are rough heuristics; always sanity-check by eyeballing the per-decile table before drawing
+  conclusions.
+
+### Pre-CHISEL note — script may still reference retired ranking outputs
+
+`compare_predictions.py` was originally authored against the pre-CHISEL scorecard (nDCG, top-3) and still computes
+those internally. Under CHISEL only AUC and Brier are on the scorecard (see `ranking-metrics-retired`). Treat any
+nDCG / top-3 numbers the script prints as legacy diagnostics — do not cite them in notebook entries or knowledge
+units. A follow-up is tracked to convert the script to an AUC + Brier + reliability-diff comparison end-to-end.
 
 ## Limitations
 
 - Assumes the two prediction files cover the same (pair_id) set. If sets differ, only the intersection is analyzed; a
   warning is printed.
-- nDCG comparison ignores bacteria with no positives and bacteria with only 1 pair (sklearn restriction).
 - The permutation test is about the delta being distinguishable from noise — it does NOT account for multiple
-  comparisons across tickets. That's a track-level concern (SX14 stratified eval).
-- Narrow/broad cutoffs are rough heuristics; always sanity-check by eyeballing the per-decile table before drawing
-  conclusions.
+  comparisons across tickets. Multiple-comparison correction is a track-level concern, not a skill-level one.

--- a/.agents/skills/review-ml-pr/SKILL.md
+++ b/.agents/skills/review-ml-pr/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: review-ml-pr
+description: >
+  Verify (not just read) ML PRs that produce predictions or metrics artifacts. Recomputes headline
+  numbers from scratch, checks fold disjointness empirically, decomposes aggregates into per-stratum
+  metrics, builds reliability diagrams when Brier is claimed, and catches "direction-wrong"
+  hypotheses the author offered as explanations. Use whenever a PR publishes a predictions CSV, a
+  bootstrap metrics JSON, or a new baseline number. Triggers on "review this PR", "verify these
+  results", "audit this run", "self-review after push", or any PR that emits a generated_outputs
+  artifact.
+user-invocable: true
+---
+
+# Review ML PR
+
+Reading the diff, reading the acceptance criteria, and running `pytest` is a **correctness check**,
+not a **verification**. The numbers in the PR body can come from honest code and still mislead:
+headline AUCs hide per-stratum spread, Brier numbers hide reliability shape, "invariants"
+documented in the prose can be warnings in the code. This skill is the verification pass.
+
+Run it on every PR that publishes prediction or metric artifacts, after your own self-review diff
+scan, before approving.
+
+## When to use
+
+- The PR writes files under `lyzortx/generated_outputs/` (predictions CSV, metrics JSON)
+- The PR body cites AUC / Brier or any bootstrap CI (CHISEL scorecard — see `ranking-metrics-retired`)
+- The PR adds or updates a knowledge unit with a headline number
+- The reviewer needs to decide approve/reject on a claim that depends on a computation
+
+If the PR cites ranking metrics (top-3, nDCG, mAP) as a primary scorecard, that is itself a review finding:
+`ranking-metrics-retired` is active under CHISEL, and ranking belongs to the product layer. Flag it and ask the
+author to move to AUC + Brier before verifying the numbers.
+
+Skip this skill for pure infra, docs, or workflow PRs with no artifacts to verify.
+
+## Working copy
+
+If the implementer is actively editing, **snapshot the artifacts before auditing**. Reading a
+half-rewritten predictions CSV produces nonsense. Either:
+
+- Create a worktree pinned to the PR HEAD (`git worktree add ../audit-<ticket> <branch>`), or
+- `cp` the generated outputs into `.scratch/<ticket>_audit_snapshot/` inside your worktree
+
+Never audit against the live `lyzortx/generated_outputs/` path when a rerun might be in flight.
+
+## Verification checklist
+
+Work through this in order. Later checks depend on earlier ones being clean.
+
+### 1. Recompute headline metrics from the predictions CSV
+
+Load the per-pair predictions, compute the aggregate AUC and Brier yourself, compare to the
+reported numbers to ≥6 decimal places. Any delta larger than float rounding means the summary JSON
+was produced by different code / different inputs than the predictions CSV, which is a bug to stop
+and investigate.
+
+Do the same for every cross-source / cross-axis subset the PR reports. "Reported" numbers and
+"recomputable from predictions" numbers must match.
+
+### 2. Fold disjointness — empirical, not from code reading
+
+Check that the holdout unit (bacteria for bacteria-axis, phages for phage-axis, etc.) is **disjoint
+across folds** and that **every pair lands in exactly one holdout fold**. Do this on the per-row
+predictions (which carry `fold_id`), not by reading the fold-assignment function. A well-written
+fold-assignment function can still be called on the wrong input.
+
+### 3. Basic hygiene on predictions
+
+Single pass over the predictions CSV:
+- NaN predictions count (expect 0)
+- Prediction range (expect `[0, 1]` for probabilities)
+- Duplicate pair-level keys (expect 0)
+- Source / stratum column NaN count (expect 0)
+
+Any of these non-zero is a bug that invalidates downstream metrics — don't continue until resolved.
+
+### 4. Invariant assertions claimed vs enforced
+
+For every invariant the PR docs assert (e.g. "all 25 BASEL ECOR strains are contained in the 369
+Guelin panel", "148 = 96 + 52 with no name overlap", "all N pairs evaluated at the same
+concentration"), check both:
+
+- **Does the code raise on violation, or only warn + drop?** If only a warning, and the invariant
+  is load-bearing for the reported numbers, the PR is one silent drop away from wrong results.
+  Flag it and require a hard assert.
+- **Does the run log prove the invariant held?** A warning that never fires and a warning that
+  silently fired once look the same in the artifact. If the PR asserts the invariant and the code
+  uses a warning fallback, ask for positive evidence (explicit `assert`, explicit count in log).
+
+### 5. Decompose every aggregate into strata the domain supports
+
+An aggregate metric on a mixed panel is a weighted average that hides stratum-specific behavior.
+For any AUC or Brier the PR reports, recompute the same metric:
+
+- Per source (if the panel is unified across data sources)
+- Per family (or per whatever taxonomic / structural stratum the domain uses)
+- Per fold
+- Per prediction bucket (for reliability — see next item)
+
+Report the **spread**, not just the mean. A 0.88 aggregate AUC with a 0.73–0.96 per-family range
+is a different finding than a 0.88 aggregate with 0.86–0.90 spread. The PR almost never reports the
+spread; that's what this step is for.
+
+### 6. Reliability diagram is mandatory whenever Brier is claimed
+
+A single Brier number averages calibration across the probability range. It cannot distinguish
+"model well-calibrated everywhere" from "model ~right on 5% and 95% predictions, wildly off in the
+middle." Those are clinically different.
+
+For any PR that reports Brier, bucket predictions into deciles of predicted P and report each
+bucket's (mean predicted P, actual rate, delta). If any bucket shows |delta| > 0.2 on >50 rows,
+the calibration story is substantially more complicated than the Brier number suggests, and the
+knowledge unit should name it.
+
+### 7. AUC vs Brier in every finding
+
+Never let one stand in for the other. AUC measures ranking / discrimination. Brier measures
+calibration. A model with AUC 0.88 and Brier 0.19 on a cohort is well-ranked but poorly calibrated
+— that's a deployment-relevant distinction (ranking-based recommendations fine; threshold-based
+decisions broken).
+
+Reject wording like "generalizes as well" that leans on AUC parity while ignoring Brier divergence,
+or vice versa.
+
+### 8. Direction check on explanatory hypotheses
+
+For every hypothesis the PR offers to explain an observation ("X is caused by mechanism Y"),
+confirm the **direction** of the observed effect matches what Y would predict. Wrong direction
+rejects the hypothesis regardless of how nice the narrative sounds.
+
+Example: "BASEL is over-predicted because its concentration is encoded lower than actual" — but
+the model learned higher-concentration → more-lysis, so lower encoding should cause *under*-prediction,
+not over-prediction. Direction wrong, hypothesis rejected.
+
+### 9. Stratification semantics vs name
+
+When a PR says "stratified by X" (e.g. "ICTV family"), confirm the actual strata are X, not
+`X + catch-all buckets`. If "UNKNOWN" or "Other" is a stratum with >10% of the panel, the
+stratification is enforcing balance across a bucket, not across true strata. Name it accurately in
+the knowledge unit — don't call it "X-stratified" when 40% of the panel is in a pseudo-X bucket.
+
+### 10. Bootstrap output completeness
+
+If the PR reports bootstrap CIs, check that the artifact includes `bootstrap_samples_used`
+alongside `bootstrap_samples_requested`. Degenerate resamples (all-positive or all-negative units)
+get silently skipped on small cohorts; without the used count, wide CIs and thin CIs look the same.
+
+### 11. Comparison to prior baseline
+
+If the PR supersedes a prior baseline, check the change decomposition:
+- How much of the delta is the scientific change the PR ships (new feature, new loss, new split)?
+- How much is a confounder (bug fix, fold reshuffling, label change, filter change)?
+
+If the change is bundled, the knowledge unit should decompose it. Bundled "one number moved" claims
+are hard to validate and harder to inherit.
+
+## Related skills
+
+- `case-by-case` — when the PR compares two prediction sets, use `case-by-case` for per-bacterium
+  delta / permutation / named-case spotlight. `review-ml-pr` focuses on single-artifact
+  verification; `case-by-case` focuses on pair-of-artifacts comparison. Use both when applicable.
+
+## How to report findings
+
+Split findings into two lists:
+
+- **Verified clean**: the specific invariants and recomputations that passed. This is the evidence
+  the PR is trustworthy on the axes checked. Report as a short table, not prose.
+- **Surfaced issues**: numbered, each citing (a) what the PR claims, (b) what the artifact shows,
+  (c) what change in the PR / knowledge / code would resolve it.
+
+End with an explicit approve / reject call. Unverified scientific claims cannot be approved — if a
+check couldn't be completed (artifact missing, snapshot stale, a subroutine errored), say so and
+block on the missing verification rather than defaulting to approve.
+
+## Artifact discipline
+
+Keep audit scripts under the PR's audit worktree's `.scratch/` (gitignored, don't commit). Findings
+go into the PR review comment / notebook entry, not into committed files. The audit script is
+disposable; the finding is the deliverable.
+
+## Rescoping the self-review subagent
+
+Treat this skill as the verify step in the lyzortx/orchestration/AGENTS.md "Self-Review via
+Subagent" protocol. The subagent's priority (2) step (scientific / biological / logical
+correctness) should be read as **verify correctness from artifacts**, not **review correctness
+from the diff**. Read-review misses exactly the class of issues this skill catches.
+
+## Limitations
+
+- Does not replace per-ticket acceptance criteria. Acceptance criteria define what the PR should
+  deliver; this skill checks whether the delivered artifacts back the claimed numbers.
+- Cannot detect bias introduced by a feature-engineering choice upstream of the predictions being
+  audited. If the feature cache is contaminated, the predictions can be self-consistently wrong —
+  that's a separate audit at the feature-pipeline layer.
+- The stratification checks depend on the domain knowing what strata matter. Consult the knowledge
+  model before picking stratification dimensions; don't invent them.

--- a/.agents/skills/review-ml-pr/SKILL.md
+++ b/.agents/skills/review-ml-pr/SKILL.md
@@ -51,9 +51,9 @@ Work through this in order. Later checks depend on earlier ones being clean.
 ### 1. Recompute headline metrics from the predictions CSV
 
 Load the per-pair predictions, compute the aggregate AUC and Brier yourself, compare to the
-reported numbers to ≥6 decimal places. Any delta larger than float rounding means the summary JSON
-was produced by different code / different inputs than the predictions CSV, which is a bug to stop
-and investigate.
+reported numbers at the precision the artifact reports (typically 4 dp for this project's bootstrap
+JSONs). Any delta beyond float rounding at that precision means the summary JSON was produced by
+different code / different inputs than the predictions CSV, which is a bug to stop and investigate.
 
 Do the same for every cross-source / cross-axis subset the PR reports. "Reported" numbers and
 "recomputable from predictions" numbers must match.
@@ -61,9 +61,11 @@ Do the same for every cross-source / cross-axis subset the PR reports. "Reported
 ### 2. Fold disjointness — empirical, not from code reading
 
 Check that the holdout unit (bacteria for bacteria-axis, phages for phage-axis, etc.) is **disjoint
-across folds** and that **every pair lands in exactly one holdout fold**. Do this on the per-row
-predictions (which carry `fold_id`), not by reading the fold-assignment function. A well-written
-fold-assignment function can still be called on the wrong input.
+across folds** and that **every pair lands in exactly one holdout fold**. This requires `fold_id`
+on at least one of the predictions artifacts; in this project the per-row file typically carries
+it while the pair-level file does not. If neither file carries `fold_id`, treat its absence as a
+finding and request it be added before approving — empirical fold-disjointness is not optional.
+A well-written fold-assignment function can still be called on the wrong input.
 
 ### 3. Basic hygiene on predictions
 
@@ -142,9 +144,11 @@ the knowledge unit — don't call it "X-stratified" when 40% of the panel is in 
 
 ### 10. Bootstrap output completeness
 
-If the PR reports bootstrap CIs, check that the artifact includes `bootstrap_samples_used`
-alongside `bootstrap_samples_requested`. Degenerate resamples (all-positive or all-negative units)
-get silently skipped on small cohorts; without the used count, wide CIs and thin CIs look the same.
+If the PR reports bootstrap CIs, the artifact should include `bootstrap_samples_used` alongside
+`bootstrap_samples_requested`. Degenerate resamples (all-positive or all-negative units) get
+silently skipped on small cohorts; without the used count, wide CIs and thin CIs look the same.
+If the current bootstrap code does not emit `bootstrap_samples_used` yet, treat that as a
+finding — request the field be added as part of the PR rather than accepting the artifact as-is.
 
 ### 11. Comparison to prior baseline
 

--- a/lyzortx/orchestration/AGENTS.md
+++ b/lyzortx/orchestration/AGENTS.md
@@ -29,7 +29,13 @@
   1. **Acceptance criteria met?** Does the PR implement what the ticket asks for? Are all criteria satisfied with real
      results (not scaffolding, not zero-row outputs)?
   2. **Scientific/biological/logical correctness.** Biological plausibility, statistical rigor, honest interpretation.
-     Wrong biology or flawed statistics are worse than ugly code.
+     Wrong biology or flawed statistics are worse than ugly code. **If the PR writes prediction or metric artifacts
+     under `lyzortx/generated_outputs/` (CSV, JSON) or cites AUC / Brier / bootstrap CI numbers, the reviewer subagent
+     MUST invoke the `review-ml-pr` skill as part of this step.** Reading the diff and acceptance criteria is not
+     sufficient verification — the skill recomputes headline numbers from the artifacts, checks fold disjointness
+     empirically, decomposes aggregates into strata, and builds reliability diagrams. A read-only review of an ML
+     results PR is not an acceptable self-review; the implementing agent's spawn prompt must explicitly instruct the
+     reviewer to run `review-ml-pr` in that case.
   3. **Code correctness.** Bugs, logic errors, off-by-one, wrong variable usage.
   4. **Code cleanliness.** Naming, structure, readability. Do NOT nitpick style — ruff handles formatting.
 

--- a/lyzortx/research_notes/lab_notebooks/devops.md
+++ b/lyzortx/research_notes/lab_notebooks/devops.md
@@ -1139,3 +1139,55 @@ YAML knowledge model. Follows the `plan.yml` → `PLAN.md` pattern: `knowledge.y
 - Knowledge units carry: `id`, `statement`, `sources`, `status`, `confidence`, `context`, `relates_to`.
 - `relates_to` provides lightweight cross-references between units without requiring a full graph database.
 - Merge-conflict strategy: YAML is append-mostly; after merging, re-run the renderer to regenerate KNOWLEDGE.md.
+
+### 2026-04-19 19:25 CEST: Added `review-ml-pr` skill; self-review subagent now required to run it on ML PRs
+
+#### Executive summary
+
+New skill `.agents/skills/review-ml-pr/` captures the verification protocol for ML PRs that produce prediction or
+metric artifacts. The reviewer subagent spawned per `lyzortx/orchestration/AGENTS.md` now MUST invoke this skill as
+part of priority (2) scientific correctness whenever the PR writes under `lyzortx/generated_outputs/` or cites AUC /
+Brier / bootstrap CI numbers. A read-only review of an ML results PR is no longer acceptable. The skill was distilled
+from an audit of the CH05 PR (#437) that surfaced per-stratum calibration and stratification issues a read-review had
+missed. Companion edit: `case-by-case` SKILL.md de-tracked and de-ranked (removed SPANDEX/autoresearch track
+references, purged nDCG / top-3 from the described output since `ranking-metrics-retired` is active under CHISEL).
+
+#### What the skill enforces
+
+Eleven checks the reviewer subagent must work through on every qualifying PR:
+
+1. Recompute headline AUC / Brier from predictions CSV, match to 6 decimal places
+2. Verify fold disjointness empirically on per-row predictions (not from reading fold-assignment code)
+3. NaN / out-of-[0,1] / duplicate-key scan on predictions
+4. Check every "invariant" the PR prose asserts — is it enforced as an assert or a warn+drop?
+5. Decompose aggregate metrics per source / family / fold; report spread, not just mean
+6. Reliability diagram is mandatory whenever Brier is claimed (deciles: mean P vs actual rate)
+7. Never conflate AUC (discrimination) with Brier (calibration) in findings
+8. Direction check on every explanatory hypothesis — wrong direction rejects the hypothesis
+9. Stratification semantics vs name — flag catch-all buckets misnamed as named strata
+10. Bootstrap output completeness — `bootstrap_samples_used` alongside `requested`
+11. Decompose PR deltas against prior baseline into scientific change vs confounder
+
+#### Why now
+
+The CH05 audit (worktree `../audit-ch05`) recomputed the headline AUCs and found they matched exactly, but also
+surfaced: BASEL reliability is 30–55 pp off in mid-P buckets while AUC parity holds, per-family AUC spread is
+0.73–0.96 while the headline is 0.88, "ICTV family" stratification puts 40% of the panel in catch-all buckets, and
+the earlier "BASEL encoded at wrong log_dilution" hypothesis is direction-wrong. None of those were in the PR body or
+the self-review. Codifying the protocol as a skill means the next ML PR picks up the same checks automatically rather
+than depending on a human reviewer repeating the audit by hand.
+
+#### Scope of changes
+
+- `.agents/skills/review-ml-pr/SKILL.md` — new skill, ~4 KB, concise checklist + snapshot discipline + related-skills
+  cross-reference to `case-by-case`.
+- `.agents/skills/case-by-case/SKILL.md` — de-tracked (removed SPANDEX / SX10-13 / autoresearch references), de-ranked
+  (removed nDCG / top-3 / MLC as primary outputs), added a Pre-CHISEL note flagging that `compare_predictions.py`
+  still computes retired metrics internally and needs a follow-up refactor.
+- `lyzortx/orchestration/AGENTS.md` — Self-Review via Subagent section amended to make the skill invocation
+  MANDATORY (not advisory) for ML artifact PRs.
+
+#### Follow-up tracked
+
+- `compare_predictions.py` needs an AUC + Brier + reliability-diff rewrite to match the case-by-case SKILL.md
+  description. The SKILL.md currently carries a Pre-CHISEL note acknowledging the lag.

--- a/lyzortx/research_notes/lab_notebooks/devops.md
+++ b/lyzortx/research_notes/lab_notebooks/devops.md
@@ -1179,7 +1179,7 @@ than depending on a human reviewer repeating the audit by hand.
 
 #### Scope of changes
 
-- `.agents/skills/review-ml-pr/SKILL.md` — new skill, ~4 KB, concise checklist + snapshot discipline + related-skills
+- `.agents/skills/review-ml-pr/SKILL.md` — new skill, ~10 KB, checklist + snapshot discipline + related-skills
   cross-reference to `case-by-case`.
 - `.agents/skills/case-by-case/SKILL.md` — de-tracked (removed SPANDEX / SX10-13 / autoresearch references), de-ranked
   (removed nDCG / top-3 / MLC as primary outputs), added a Pre-CHISEL note flagging that `compare_predictions.py`


### PR DESCRIPTION
## Summary

- New skill `.agents/skills/review-ml-pr/` captures the verification protocol for ML PRs that produce prediction
  or metric artifacts. Eleven-check protocol: recompute headline AUC/Brier, verify fold disjointness empirically,
  scan for NaN/dupes, check invariants-vs-asserts, decompose aggregates by stratum, build reliability diagrams
  when Brier is claimed, enforce AUC-vs-Brier distinction, direction-check every hypothesis, name catch-all
  strata honestly, surface bootstrap-samples-used, decompose deltas into scientific-vs-confounder.
- `lyzortx/orchestration/AGENTS.md` Self-Review via Subagent section: the reviewer subagent MUST invoke
  `review-ml-pr` whenever the PR writes under `lyzortx/generated_outputs/` or cites AUC / Brier / bootstrap CIs.
  Read-only review is no longer an acceptable self-review for ML-results PRs.
- `.agents/skills/case-by-case/SKILL.md` de-tracked (removed SPANDEX / SX10-13 / autoresearch specifics) and
  de-ranked (removed nDCG / top-3 / MLC from primary outputs — `ranking-metrics-retired` is active under CHISEL).
  Pre-CHISEL note flags that `compare_predictions.py` still computes retired metrics internally and tracks the
  follow-up.
- `lyzortx/research_notes/lab_notebooks/devops.md` entry records what changed and why.

## Why now

Audit of CH05 (#437) recomputed the headline AUCs (matched exactly) but surfaced substantive issues the read-only
self-review had missed: BASEL reliability is 30–55 pp off in mid-P buckets despite AUC parity with Guelin;
per-family AUC spread is 0.73–0.96 while the headline is 0.88; "ICTV family" stratification puts 40% of the panel
in catch-all buckets; the earlier "BASEL encoded at wrong log_dilution" hypothesis is direction-wrong relative to
the observed over-prediction. Codifying the audit as a skill + making it mandatory in the self-review protocol
means the next ML PR picks up these checks automatically rather than depending on ad-hoc human review.

## Test plan

- [x] `.agents/skills/review-ml-pr/SKILL.md` exists, frontmatter valid, (~10 KB), follows the
      `case-by-case` pattern
- [x] `.agents/skills/case-by-case/SKILL.md` no longer references SPANDEX / autoresearch / SX track codes or
      named bacteria; no longer lists nDCG / top-3 / mAP as primary outputs
- [x] `lyzortx/orchestration/AGENTS.md` priority (2) explicitly requires the `review-ml-pr` skill for qualifying
      PRs (not advisory)
- [x] pre-commit hooks passed on commit (`ruff`, `ruff-format`, `pymarkdown`, `no-ignored-files`)
- [x] pre-push hooks passed (`check-rebase-on-main` etc.)
- [ ] Self-review subagent on a subsequent ML PR actually invokes the skill — verified only after the first
      downstream qualifying PR lands

## Notes

- This is off-ticket work (no orchestrator issue). User explicitly authorised the PR in-session.
- No `Closes #N` — no tracked issue. Not labelled `orchestrator-task`.
- `compare_predictions.py` refactor to AUC+Brier (aligning with the new `case-by-case` SKILL.md) is a follow-up
  not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
