### PR TITLE
[CH06-Arm2] MMseqs2 pairwise proteome similarity — null / BASEL regression

### DIFF
--- a/lyzortx/pipeline/autoresearch/ch06_arm2_mmseqs_proteome.py
+++ b/lyzortx/pipeline/autoresearch/ch06_arm2_mmseqs_proteome.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""CH06 Arm 2: MMseqs2 pairwise proteome similarity as phage-side feature slot.
+
+Replaces the Guelin-only TL17 categorical projection (33-col phage_projection slot)
+with a continuous 148-dim pairwise proteome similarity vector reduced to 32 PCA
+components. Each phage's feature row is its MMseqs2 all-vs-all bit-score profile
+against every other phage in the unified 148-phage panel (96 Guelin + 52 BASEL),
+then projected onto PCA axes fit on the same matrix.
+
+A BASEL phage that has no close Guelin neighbour still produces a real (mostly
+low) similarity profile rather than TL17's zero-vector failure mode — that is the
+plan.yml hypothesis Arm 2 tests.
+
+Two-phase computation:
+
+1. Precompute (`build_similarity_matrix`): extract proteins from all 148 phages
+   into a single FASTA with `<phage_id>|<protein_id>` headers, run MMseqs2
+   easy-search all-vs-all (e-value 1e-5), aggregate hits to a 148×148 phage-level
+   sum-bit-score matrix. Self-similarity (diagonal) is zeroed so `sim_to_<self>`
+   is not a trivial constant feature that could encode phage identity.
+   Cached to `.scratch/ch06_arm2/pairwise_bitscore.npz`.
+
+2. Slot materializer (`materialize_arm2_slot`): PCA(n_components=32) fit on the
+   148 phage rows, write a feature CSV with 32 `phage_projection__arm2_pc_<k>`
+   columns (reusing the `phage_projection` slot name so the existing CH05
+   patch-in-place path picks it up without any feature-bundle refactor).
+
+3. Variance pre-flight (`run_variance_preflight`): for each PCA component, compute
+   CV across (a) Guelin phages, (b) non-zero-projection BASEL phages, (c) other
+   BASEL phages, plus Cohen's d for discriminating lysed vs non-lysed pairs at
+   the phage level. Fails loudly if every component has CV < 0.1 AND Cohen's
+   d < 0.1 on all three subsets per plan.yml variance-preflight gate.
+
+4. Eval driver (`run_arm2_eval`): patches the `phage_projection` slot with the
+   Arm 2 CSV and runs CH05's `run_bacteria_axis` + `run_phage_axis` under the
+   same parallel loop as the baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.decomposition import PCA
+
+from lyzortx.log_config import setup_logging
+
+LOGGER = logging.getLogger(__name__)
+
+GUELIN_COMBINED_FAA = Path(
+    "lyzortx/generated_outputs/autoresearch/phage_projection_cache_build/_batched/combined_queries.faa"
+)
+BASEL_PHAROKKA_DIR = Path(".scratch/basel/pharokka_output")
+DEFAULT_SCRATCH_DIR = Path(".scratch/ch06_arm2")
+DEFAULT_SLOT_CSV = Path(".scratch/basel/feature_slots_arm2/phage_projection/features.csv")
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/ch06_arm2_mmseqs_proteome")
+DEFAULT_ORIGINAL_SLOT_CSV = Path(".scratch/basel/feature_slots/phage_projection/features.csv")
+
+MMSEQS_E_VALUE = 1e-5
+MMSEQS_SENSITIVITY = 7.5
+PCA_COMPONENTS = 32
+COLUMN_PREFIX = "phage_projection__arm2_pc_"
+
+
+def build_combined_proteome(output_faa: Path) -> dict[str, int]:
+    """Concatenate Guelin + BASEL proteins into a single FASTA with `<phage>|<prot>` headers.
+
+    Guelin source (`combined_queries.faa`) already has that header shape (`409_P1|query_prot_0001`).
+    BASEL sources (`.scratch/basel/pharokka_output/<Bas##>/phanotate.faa`) use pharokka's
+    `<contig_id>_CDS_<idx>` headers, which we rewrite to `<Bas##>|<contig_id>_CDS_<idx>`.
+    """
+    output_faa.parent.mkdir(parents=True, exist_ok=True)
+    per_phage_counts: dict[str, int] = {}
+    with output_faa.open("w") as out:
+        for line in GUELIN_COMBINED_FAA.read_text().splitlines():
+            out.write(line + "\n")
+            if line.startswith(">"):
+                phage_id = line[1:].split("|", 1)[0]
+                per_phage_counts[phage_id] = per_phage_counts.get(phage_id, 0) + 1
+
+        for basel_dir in sorted(BASEL_PHAROKKA_DIR.iterdir()):
+            if not basel_dir.is_dir() or not basel_dir.name.startswith("Bas"):
+                continue
+            phage_id = basel_dir.name
+            faa = basel_dir / "phanotate.faa"
+            if not faa.exists():
+                raise FileNotFoundError(f"BASEL pharokka faa missing: {faa}")
+            n = 0
+            for line in faa.read_text().splitlines():
+                if line.startswith(">"):
+                    protein_id = line[1:].split()[0]
+                    out.write(f">{phage_id}|{protein_id}\n")
+                    n += 1
+                else:
+                    out.write(line + "\n")
+            per_phage_counts[phage_id] = n
+
+    LOGGER.info(
+        "Combined proteome: %d phages, %d proteins total, written to %s",
+        len(per_phage_counts),
+        sum(per_phage_counts.values()),
+        output_faa,
+    )
+    return per_phage_counts
+
+
+def run_mmseqs_all_vs_all(
+    combined_faa: Path,
+    output_tsv: Path,
+    scratch_dir: Path,
+    *,
+    e_value: float = MMSEQS_E_VALUE,
+    sensitivity: float = MMSEQS_SENSITIVITY,
+) -> None:
+    """Run MMseqs2 `easy-search` self-vs-self on `combined_faa` → protein-pair TSV."""
+    output_tsv.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = scratch_dir / "mmseqs_tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    # Output columns: query, target, bits (we don't need the full BLAST 12).
+    cmd = [
+        "mmseqs",
+        "easy-search",
+        str(combined_faa),
+        str(combined_faa),
+        str(output_tsv),
+        str(tmp_dir),
+        "--format-output",
+        "query,target,bits",
+        "-e",
+        str(e_value),
+        "-s",
+        str(sensitivity),
+        "--threads",
+        str(max(1, (_cpu_count()))),
+    ]
+    LOGGER.info("Running MMseqs2 easy-search: %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+    LOGGER.info("MMseqs2 hits written to %s", output_tsv)
+
+
+def _cpu_count() -> int:
+    import os
+
+    return os.cpu_count() or 4
+
+
+def aggregate_protein_hits_to_phage_matrix(
+    hits_tsv: Path,
+    phage_order: Sequence[str],
+) -> np.ndarray:
+    """Sum bit-scores of all protein-level hits per (query_phage, target_phage) pair.
+
+    MMseqs2 `easy-search` returns top-N hits per query (default 300). Summing all
+    reported hits is a proxy for "how much protein-space does phage A share with
+    phage B"; any single mutually-conserved core gene contributes once to each of
+    its per-query rows. Diagonal (self-similarity) is zeroed below to avoid
+    encoding phage identity.
+    """
+    LOGGER.info("Reading MMseqs2 hits from %s", hits_tsv)
+    hits = pd.read_csv(
+        hits_tsv,
+        sep="\t",
+        header=None,
+        names=["query", "target", "bits"],
+        dtype={"query": str, "target": str, "bits": float},
+    )
+    LOGGER.info("Parsed %d hits", len(hits))
+
+    hits["query_phage"] = hits["query"].str.split("|", n=1).str[0]
+    hits["target_phage"] = hits["target"].str.split("|", n=1).str[0]
+
+    pairwise = hits.groupby(["query_phage", "target_phage"])["bits"].sum().reset_index(name="bits_sum")
+
+    phage_to_idx = {p: i for i, p in enumerate(phage_order)}
+    n = len(phage_order)
+    matrix = np.zeros((n, n), dtype=np.float32)
+
+    known_mask = pairwise["query_phage"].isin(phage_to_idx) & pairwise["target_phage"].isin(phage_to_idx)
+    dropped = (~known_mask).sum()
+    if dropped:
+        LOGGER.warning("Dropped %d hits with unknown phage ids", dropped)
+    pairwise = pairwise[known_mask]
+
+    q_idx = pairwise["query_phage"].map(phage_to_idx).to_numpy()
+    t_idx = pairwise["target_phage"].map(phage_to_idx).to_numpy()
+    matrix[q_idx, t_idx] = pairwise["bits_sum"].to_numpy(dtype=np.float32)
+
+    np.fill_diagonal(matrix, 0.0)
+
+    nonzero_fraction = (matrix > 0).mean()
+    LOGGER.info(
+        "Pairwise bit-score matrix: %d x %d, %.1f%% nonzero (excluding diagonal), max=%.0f",
+        n,
+        n,
+        nonzero_fraction * 100,
+        matrix.max(),
+    )
+    return matrix
+
+
+def materialize_arm2_slot(
+    phage_order: Sequence[str],
+    pairwise_matrix: np.ndarray,
+    slot_csv: Path,
+    *,
+    n_components: int = PCA_COMPONENTS,
+) -> pd.DataFrame:
+    """PCA to 32 components, write a phage_projection-shaped CSV with 32 PCA columns.
+
+    The slot reuses the `phage_projection__` column prefix so CH05's existing
+    `patch_context_with_extended_slots` path picks it up without any
+    feature-bundle refactor. Column names are stable and named so LightGBM's
+    feature-importance dump distinguishes Arm 2 from Guelin TL17 slots when
+    compared across runs.
+    """
+    slot_csv.parent.mkdir(parents=True, exist_ok=True)
+
+    pca = PCA(n_components=n_components, random_state=0)
+    projected = pca.fit_transform(pairwise_matrix)
+
+    columns = [f"{COLUMN_PREFIX}{k:02d}" for k in range(n_components)]
+    df = pd.DataFrame(projected, columns=columns)
+    df.insert(0, "phage", list(phage_order))
+    df.to_csv(slot_csv, index=False)
+
+    explained = pca.explained_variance_ratio_
+    LOGGER.info(
+        "Arm 2 PCA slot written to %s; top-5 components explain %.1f%%, top-32 explain %.1f%%",
+        slot_csv,
+        explained[:5].sum() * 100,
+        explained.sum() * 100,
+    )
+    return df
+
+
+def run_variance_preflight(
+    arm2_slot_df: pd.DataFrame,
+    original_slot_csv: Path,
+    interactions_path: Path,
+    output_json: Path,
+) -> dict[str, object]:
+    """Per plan.yml VARIANCE PRE-FLIGHT — CV and Cohen's d on three phage subsets.
+
+    Three subsets (per plan.yml):
+      (1) Guelin phages (n=96)
+      (2) BASEL phages with non-zero TL17 phage_projection (n≈39, picks up Guelin-
+          neighbour-carrying BASEL phages)
+      (3) BASEL phages with zero-vector TL17 projection (n≈13)
+
+    For each subset, compute per-component CV across phages. For each phage,
+    aggregate the interaction matrix to its lysis rate across 369 clinical
+    bacteria, then compute Cohen's d on each PCA component split at median lysis
+    rate within the subset.
+
+    Gate: if ALL 32 components have CV < 0.1 AND Cohen's d < 0.1 on ALL three
+    subsets, the arm is killed before training. Because Arm 2 feature values
+    literally encode proteome similarity to specific phages, it is extremely
+    unlikely to have degenerate variance — the pre-flight exists to catch the
+    pathological case, not to screen out wash arms.
+    """
+    original = pd.read_csv(original_slot_csv)
+    feature_cols = [c for c in original.columns if c != "phage"]
+    original_nonzero = original[feature_cols].abs().sum(axis=1) > 0
+    nonzero_phages = set(original.loc[original_nonzero, "phage"])
+
+    guelin = [p for p in arm2_slot_df["phage"] if not p.startswith("Bas")]
+    basel_all = [p for p in arm2_slot_df["phage"] if p.startswith("Bas")]
+    basel_nonzero_proj = [p for p in basel_all if p in nonzero_phages]
+    basel_zero_proj = [p for p in basel_all if p not in nonzero_phages]
+
+    arm2_cols = [c for c in arm2_slot_df.columns if c.startswith(COLUMN_PREFIX)]
+    interactions = pd.read_csv(interactions_path, sep=";", low_memory=False)
+    interactions["score"] = interactions["score"].astype(str)
+    guelin_labels = (interactions["score"] == "1").astype(int)
+    guelin_lysis = (
+        pd.DataFrame({"phage": interactions["phage"], "label": guelin_labels}).groupby("phage")["label"].mean()
+    )
+    basel_path = Path(".scratch/genophi_data/BASEL_ECOR_interaction_matrix.csv")
+    basel_lysis = pd.Series(dtype=float)
+    if basel_path.exists():
+        basel = pd.read_csv(basel_path)
+        basel = basel.dropna(subset=["interaction"])
+        basel_lysis = basel.groupby("phage")["interaction"].mean()
+    phage_lysis_rate = pd.concat([guelin_lysis, basel_lysis])
+
+    summary: dict[str, dict[str, object]] = {}
+    subsets = {
+        "guelin_n=%d" % len(guelin): guelin,
+        "basel_nonzero_proj_n=%d" % len(basel_nonzero_proj): basel_nonzero_proj,
+        "basel_zero_proj_n=%d" % len(basel_zero_proj): basel_zero_proj,
+    }
+
+    for label, phages in subsets.items():
+        sub = arm2_slot_df[arm2_slot_df["phage"].isin(phages)]
+        if sub.empty:
+            summary[label] = {"status": "empty_subset"}
+            continue
+        mat = sub[arm2_cols].to_numpy(dtype=float)
+        mean = mat.mean(axis=0)
+        std = mat.std(axis=0, ddof=1)
+        cv = np.where(np.abs(mean) > 1e-10, std / np.abs(mean), np.nan)
+
+        # Cohen's d per component across lysed vs non-lysed at phage level.
+        lysis = sub["phage"].map(phage_lysis_rate).fillna(phage_lysis_rate.median()).to_numpy()
+        median_lysis = np.median(lysis)
+        hi = mat[lysis > median_lysis]
+        lo = mat[lysis <= median_lysis]
+        if hi.size and lo.size:
+            pooled = np.sqrt((hi.var(axis=0, ddof=1) + lo.var(axis=0, ddof=1)) / 2)
+            cohens_d = np.where(pooled > 1e-10, (hi.mean(axis=0) - lo.mean(axis=0)) / pooled, 0.0)
+        else:
+            cohens_d = np.zeros(len(arm2_cols))
+
+        max_abs_cv = float(np.nanmax(np.abs(cv)))
+        max_abs_d = float(np.max(np.abs(cohens_d)))
+        summary[label] = {
+            "n_phages": len(sub),
+            "n_components": len(arm2_cols),
+            "max_abs_cv_across_components": round(max_abs_cv, 4),
+            "max_abs_cohens_d_across_components": round(max_abs_d, 4),
+            "n_components_with_cv_gt_0.1": int(np.nansum(np.abs(cv) > 0.1)),
+            "n_components_with_cohens_d_gt_0.1": int(np.sum(np.abs(cohens_d) > 0.1)),
+            "gate_status": ("pass" if (max_abs_cv > 0.1 or max_abs_d > 0.1) else "fail"),
+        }
+
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    with output_json.open("w") as f:
+        json.dump(summary, f, indent=2)
+    LOGGER.info("Variance pre-flight summary: %s", json.dumps(summary, indent=2))
+
+    any_fail = any(
+        s.get("gate_status") == "fail" for s in summary.values() if isinstance(s, dict) and "gate_status" in s
+    )
+    if any_fail:
+        LOGGER.warning("At least one subset failed the CV/Cohen's d gate — see pre-flight JSON")
+    return summary
+
+
+def build_similarity_matrix(
+    scratch_dir: Path = DEFAULT_SCRATCH_DIR,
+    *,
+    force: bool = False,
+) -> tuple[list[str], np.ndarray]:
+    """End-to-end precompute: FASTA → MMseqs2 → 148×148 bit-score matrix."""
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = scratch_dir / "pairwise_bitscore.npz"
+    if cache_path.exists() and not force:
+        cached = np.load(cache_path, allow_pickle=True)
+        phage_order = list(cached["phage_order"])
+        matrix = cached["matrix"]
+        LOGGER.info("Loaded cached similarity matrix from %s (%d phages)", cache_path, len(phage_order))
+        return phage_order, matrix
+
+    combined_faa = scratch_dir / "combined_proteome.faa"
+    hits_tsv = scratch_dir / "mmseqs_hits.tsv"
+    per_phage = build_combined_proteome(combined_faa)
+    phage_order = sorted(per_phage.keys())
+    run_mmseqs_all_vs_all(combined_faa, hits_tsv, scratch_dir)
+    matrix = aggregate_protein_hits_to_phage_matrix(hits_tsv, phage_order)
+    np.savez(cache_path, phage_order=np.array(phage_order), matrix=matrix)
+    LOGGER.info("Cached similarity matrix to %s", cache_path)
+    return phage_order, matrix
+
+
+def run_arm2_training_eval(
+    *,
+    slot_csv: Path,
+    output_dir: Path,
+    cache_dir: Path,
+    candidate_dir: Path,
+    device_type: str = "cpu",
+    max_folds: int | None = None,
+    num_workers: int = 3,
+    drop_high_titer_only_positives: bool = True,
+) -> dict[str, object]:
+    """Run CH05's two-axis evaluation with the Arm 2 phage_projection slot.
+
+    Patches `phage_projection` in the loaded context with the Arm 2 CSV, then
+    invokes `run_bacteria_axis` + `run_phage_axis` directly (reusing CH05's
+    parallel loop). Results land under `output_dir` with Arm 2 naming.
+    """
+    from lyzortx.pipeline.autoresearch.candidate_replay import load_module_from_path
+    from lyzortx.pipeline.autoresearch.ch04_eval import (
+        BOOTSTRAP_RANDOM_STATE,
+        BOOTSTRAP_SAMPLES,
+        build_clean_row_training_frame,
+        select_pair_max_concentration_rows,
+    )
+    from lyzortx.pipeline.autoresearch.ch05_eval import (
+        BASEL_LOG10_PFU_ML,
+        SOURCE_BASEL,
+        SOURCE_GUELIN,
+        _bootstrap_by_unit,
+        _ci_to_dict,
+        load_unified_row_frame,
+        run_bacteria_axis,
+        run_phage_axis,
+    )
+    from lyzortx.pipeline.autoresearch.sx03_eval import patch_context_with_extended_slots
+    from lyzortx.pipeline.autoresearch.sx15_eval import load_unified_phage_family_map
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if not slot_csv.exists():
+        raise FileNotFoundError(f"Arm 2 slot CSV missing: {slot_csv}")
+
+    # The Arm 2 slot directory must hold both the new phage_projection CSV AND the
+    # original phage_stats / phage_rbp_struct CSVs (unchanged). Materialize symlinks
+    # into the Arm 2 slot dir so patch_context_with_extended_slots finds all three.
+    arm2_slot_dir = slot_csv.parent.parent
+    arm2_slot_dir.mkdir(parents=True, exist_ok=True)
+    for slot_name in ("phage_stats", "phage_rbp_struct"):
+        arm2_side = arm2_slot_dir / slot_name / "features.csv"
+        baseline_side = Path(".scratch/basel/feature_slots") / slot_name / "features.csv"
+        if not arm2_side.exists() and baseline_side.exists():
+            arm2_side.parent.mkdir(parents=True, exist_ok=True)
+            arm2_side.symlink_to(baseline_side.resolve())
+            LOGGER.info("Linked baseline slot %s → %s", baseline_side, arm2_side)
+
+    unified = load_unified_row_frame(basel_log10_pfu_ml=BASEL_LOG10_PFU_ML)
+    clean_rows = build_clean_row_training_frame(unified, drop_high_titer_only_positives=drop_high_titer_only_positives)
+    LOGGER.info(
+        "CH06 Arm 2 clean row frame: %d rows, %d pairs, %d bacteria, %d phages",
+        len(clean_rows),
+        clean_rows["pair_id"].nunique(),
+        clean_rows["bacteria"].nunique(),
+        clean_rows["phage"].nunique(),
+    )
+    pair_source = clean_rows[["pair_id", "source"]].drop_duplicates(subset=["pair_id"]).set_index("pair_id")["source"]
+
+    phage_family = load_unified_phage_family_map()
+    candidate_module = load_module_from_path("ch06_arm2_candidate", candidate_dir / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=cache_dir, include_host_defense=True)
+    patch_context_with_extended_slots(context, slots_dir=arm2_slot_dir)
+
+    bacteria_per_row = run_bacteria_axis(
+        candidate_module=candidate_module,
+        context=context,
+        candidate_dir=candidate_dir,
+        clean_rows=clean_rows,
+        device_type=device_type,
+        output_dir=output_dir,
+        max_folds=max_folds,
+        num_workers=num_workers,
+    )
+    phage_per_row = run_phage_axis(
+        candidate_module=candidate_module,
+        context=context,
+        candidate_dir=candidate_dir,
+        clean_rows=clean_rows,
+        phage_family=phage_family,
+        device_type=device_type,
+        output_dir=output_dir,
+        max_folds=max_folds,
+        num_workers=num_workers,
+    )
+
+    bacteria_pairs = select_pair_max_concentration_rows(bacteria_per_row)
+    bacteria_pairs["source"] = bacteria_pairs["pair_id"].map(pair_source)
+    bacteria_pairs.to_csv(output_dir / "ch06_arm2_bacteria_axis_predictions.csv", index=False)
+    bacteria_cis = _bootstrap_by_unit(
+        bacteria_pairs.to_dict(orient="records"),
+        unit_key="bacteria",
+        bootstrap_samples=BOOTSTRAP_SAMPLES,
+        bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+    )
+
+    phage_pairs = select_pair_max_concentration_rows(phage_per_row)
+    phage_pairs["source"] = phage_pairs["pair_id"].map(pair_source)
+    phage_pairs.to_csv(output_dir / "ch06_arm2_phage_axis_predictions.csv", index=False)
+    phage_rows = phage_pairs.to_dict(orient="records")
+    phage_cis_all = _bootstrap_by_unit(
+        phage_rows,
+        unit_key="phage",
+        bootstrap_samples=BOOTSTRAP_SAMPLES,
+        bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+    )
+
+    cross_source_rows: list[dict[str, object]] = []
+    for source_label in (SOURCE_GUELIN, SOURCE_BASEL):
+        subset = [r for r in phage_rows if r["source"] == source_label]
+        if not subset:
+            raise ValueError(f"Empty cross-source subset for {source_label!r}")
+        subset_cis = _bootstrap_by_unit(
+            subset,
+            unit_key="phage",
+            bootstrap_samples=BOOTSTRAP_SAMPLES,
+            bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+        )
+        cross_source_rows.append(
+            {
+                "source": source_label,
+                "n_pairs": len(subset),
+                "n_phages": len({r["phage"] for r in subset}),
+                "auc": subset_cis["holdout_roc_auc"].point_estimate,
+                "auc_low": subset_cis["holdout_roc_auc"].ci_low,
+                "auc_high": subset_cis["holdout_roc_auc"].ci_high,
+                "brier": subset_cis["holdout_brier_score"].point_estimate,
+                "brier_low": subset_cis["holdout_brier_score"].ci_low,
+                "brier_high": subset_cis["holdout_brier_score"].ci_high,
+            }
+        )
+    pd.DataFrame(cross_source_rows).to_csv(output_dir / "ch06_arm2_cross_source_breakdown.csv", index=False)
+
+    summary = {
+        "arm": "CH06 Arm 2 — MMseqs2 pairwise proteome similarity",
+        "slot_csv": str(slot_csv),
+        "bacteria_axis": {
+            "aggregate": {name: _ci_to_dict(ci) for name, ci in bacteria_cis.items()},
+            "n_pairs": len(bacteria_pairs),
+        },
+        "phage_axis": {
+            "aggregate": {name: _ci_to_dict(ci) for name, ci in phage_cis_all.items()},
+            "cross_source": cross_source_rows,
+            "n_pairs": len(phage_pairs),
+        },
+    }
+    with (output_dir / "ch06_arm2_metrics.json").open("w") as f:
+        json.dump(summary, f, indent=2, default=str)
+    LOGGER.info("CH06 Arm 2 summary written to %s", output_dir / "ch06_arm2_metrics.json")
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scratch-dir", type=Path, default=DEFAULT_SCRATCH_DIR)
+    parser.add_argument("--slot-csv", type=Path, default=DEFAULT_SLOT_CSV)
+    parser.add_argument("--original-slot-csv", type=Path, default=DEFAULT_ORIGINAL_SLOT_CSV)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--interactions-path",
+        type=Path,
+        default=Path("data/interactions/raw/raw_interactions.csv"),
+    )
+    parser.add_argument("--force", action="store_true", help="Recompute MMseqs2 even if cached")
+    parser.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help="Skip the variance pre-flight (useful for re-running slot materialization only)",
+    )
+    parser.add_argument(
+        "--run-training",
+        action="store_true",
+        help="After precompute+preflight, run the full CH05 two-axis evaluation with the Arm 2 slot.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/autoresearch/search_cache_v1"),
+    )
+    parser.add_argument("--candidate-dir", type=Path, default=Path("lyzortx/autoresearch"))
+    parser.add_argument("--device-type", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument("--max-folds", type=int, default=None)
+    parser.add_argument("--num-workers", type=int, default=3)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    phage_order, matrix = build_similarity_matrix(args.scratch_dir, force=args.force)
+    slot_df = materialize_arm2_slot(phage_order, matrix, args.slot_csv)
+
+    if not args.skip_preflight:
+        run_variance_preflight(
+            slot_df,
+            args.original_slot_csv,
+            args.interactions_path,
+            args.output_dir / "ch06_arm2_variance_preflight.json",
+        )
+
+    if args.run_training:
+        run_arm2_training_eval(
+            slot_csv=args.slot_csv,
+            output_dir=args.output_dir,
+            cache_dir=args.cache_dir,
+            candidate_dir=args.candidate_dir,
+            device_type=args.device_type,
+            max_folds=args.max_folds,
+            num_workers=args.num_workers,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/pipeline/autoresearch/sx03_eval.py
+++ b/lyzortx/pipeline/autoresearch/sx03_eval.py
@@ -58,10 +58,16 @@ EXTENDED_SLOTS_DIR = Path(".scratch/basel/feature_slots")
 N_FOLDS = 10
 
 
-def patch_context_with_extended_slots(context: Any) -> None:
-    """Replace phage slot artifacts with extended versions (Guelin + BASEL)."""
+def patch_context_with_extended_slots(context: Any, slots_dir: Path = EXTENDED_SLOTS_DIR) -> None:
+    """Replace phage slot artifacts with extended versions (Guelin + BASEL).
+
+    `slots_dir` defaults to the canonical CH05 extended slots at
+    `.scratch/basel/feature_slots/`. CH06 Arm 2 passes a different directory
+    (`.scratch/basel/feature_slots_arm2/`) to swap the `phage_projection` slot
+    with the MMseqs2 pairwise proteome similarity features.
+    """
     for slot_name in ("phage_projection", "phage_stats", "phage_rbp_struct"):
-        extended_csv = EXTENDED_SLOTS_DIR / slot_name / "features.csv"
+        extended_csv = slots_dir / slot_name / "features.csv"
         if not extended_csv.exists():
             LOGGER.warning("Extended slot %s not found at %s — using original", slot_name, extended_csv)
             continue

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -1044,3 +1044,134 @@ Two threads converged to this adoption:
   in `context`. `chisel-unified-kfold-baseline` similarly.
 - Canonical artifacts regenerated at `lyzortx/generated_outputs/ch04_chisel_baseline/` and
   `lyzortx/generated_outputs/ch05_unified_kfold/`.
+
+### 2026-04-20 13:54 CEST: CH06 Arm 2 — MMseqs2 pairwise proteome similarity (null / regression)
+
+#### Executive summary
+
+Replaced the Guelin-only TL17 categorical projection with a 32-dim PCA over the 148×148
+all-vs-all MMseqs2 proteome bit-score matrix — the plan's strongest structural candidate for
+closing the BASEL discrimination gap. **Arm 2 fails the acceptance criterion**: BASEL
+bacteria-axis AUC drops to **0.7045** (baseline 0.7229; target > 0.7152), a 1.84 pp
+regression with no compensating gain elsewhere. Aggregate numbers wobble within sampling
+noise: bacteria-axis AUC 0.8240 vs 0.8218 (+0.22 pp, CIs overlap), phage-axis AUC 0.8878 vs
+0.8919 (−0.41 pp, CIs overlap). Confirms the plan's "may cannibalize TL17" pre-registered
+risk — continuous proteome similarity replaces TL17 without adding BASEL-discriminative
+signal, and for BASEL phages the Guelin-dominated PCA axes are actively worse than the
+TL17 categorical encoding.
+
+#### Feature construction
+
+MMseqs2 `easy-search` self-vs-self on the 148-phage combined proteome (10,129 Guelin
+pyrodigal proteins from the existing TL17 panel FASTA + 8,701 BASEL phanotate proteins from
+the per-phage pharokka output, combined into 18,830 protein FASTA with
+`<phage>|<protein_id>` headers). e-value 1e-5, sensitivity 7.5, default top-300 targets per
+query. 294,085 hits aggregated to a 148×148 summed-bit-score phage-level matrix (68.1% off-
+diagonal nonzero; diagonal zeroed so `sim_to_self` is not a constant phage-identity feature).
+
+PCA(n_components=32) on the 148×148 matrix: top-5 components explain 84.0%, top-32 explain
+95.6% of variance. The PCA transform is unsupervised and symmetric across all 148 phages —
+no label information and no Guelin vs BASEL split at fit time, so the encoding is
+panel-independent in the sense Arm 2 was supposed to test. Materialized as a
+`phage_projection__arm2_pc_{00..31}` slot under `.scratch/basel/feature_slots_arm2/` so CH05's
+existing `patch_context_with_extended_slots` picks it up via a new `slots_dir=` parameter
+(backwards-compatible default). 33 TL17 columns replaced with 32 PCA columns; other phage
+slots (`phage_stats`, `phage_rbp_struct`) symlinked unchanged.
+
+#### Variance pre-flight
+
+Per plan.yml `VARIANCE PRE-FLIGHT`, all three subsets pass the CV > 0.1 OR Cohen's d > 0.1
+gate (against phage-level lysis rate median split):
+
+| Subset | n | Max abs CV | Max abs Cohen's d | CV > 0.1 | d > 0.1 | Gate |
+|---|---|---|---|---|---|---|
+| Guelin | 96 | 6.4e6 | 0.96 | 32/32 | 19/32 | pass |
+| BASEL non-zero TL17 | 39 | 188.3 | 3.12 | 32/32 | 21/32 | pass |
+| BASEL zero-vector TL17 | 13 | 19.8 | 2.29 | 30/32 | 31/32 | pass |
+
+The BASEL subsets' high Cohen's d on many components initially looked promising — but that's
+a phage-level marginal (phage lysis rate correlates with PCA components), not pair-level
+discrimination. The full-training result shows the pair-level signal is essentially flat
+or worse than baseline; variance pre-flight is a necessary but insufficient gate for arm
+survival.
+
+#### Full-training results
+
+10-fold bacteria-axis (CH02 cv_group hash) and 10-fold phage-axis (StratifiedKFold by ICTV
+family / other / UNKNOWN), 3 seeds each under `ch04_parallel.fit_seeds`, same CH05 feature
+bundle with `phage_projection` swapped:
+
+| Axis | Metric | Baseline | Arm 2 | Δ | Notes |
+|---|---|---|---|---|---|
+| Bacteria | AUC | 0.8218 [0.8063, 0.8368] | **0.8240** [0.8066, 0.8397] | +0.22 pp | CIs overlap |
+| Bacteria | Brier | 0.1466 [0.1393, 0.1538] | 0.1500 [0.1427, 0.1572] | +0.34 pp | marginally worse |
+| Phage | AUC | 0.8919 [0.8650, 0.9166] | 0.8878 [0.8625, 0.9114] | −0.41 pp | CIs overlap |
+| Phage | Brier | 0.1181 [0.1012, 0.1359] | 0.1175 [0.1010, 0.1344] | −0.06 pp | flat |
+
+Cross-source breakdown — the decisive numbers (CI widths from the CH05 baseline report,
+point estimates recomputed from Arm 2's per-pair predictions):
+
+| Subset | Baseline AUC | Arm 2 AUC | ΔAUC | Baseline Brier | Arm 2 Brier |
+|---|---|---|---|---|---|
+| Bact-axis Guelin (96 phages, 35403 pairs) | 0.8247 | 0.8278 | +0.31 pp | 0.1434 | 0.1476 |
+| **Bact-axis BASEL (52 phages, 1240 pairs)** | **0.7229** | **0.7045** | **−1.84 pp** | 0.2380 | 0.2185 |
+| Phage-axis Guelin | 0.8922 | 0.8879 | −0.43 pp | 0.1156 | 0.1159 |
+| Phage-axis BASEL | 0.8822 | 0.8734 | −0.88 pp | 0.1890 | 0.1628 |
+
+**BASEL bacteria-axis AUC 0.7045 is below the target 0.7152** — Arm 2 does not meet the
+plan's discrimination success criterion. Brier improves for BASEL on both axes (bacteria-
+axis 0.2380 → 0.2185; phage-axis 0.1890 → 0.1628), but that is a calibration-side effect
+driven by the wider shrunken-toward-base-rate distribution of Arm 2 predictions, not
+discrimination — AUC moves the opposite direction.
+
+#### Interpretation
+
+Arm 2 confirms the plan's pre-registered "may cannibalize TL17 — RFE keeps the better one,
+net ≈ wash" hypothesis, but resolves it in the wrong direction for BASEL. Two mechanisms:
+
+1. **Guelin-weighted PCA axes.** The 148×148 similarity matrix is dominated by the 96
+   Guelin phages (65% of rows), so PCA axes capture mostly Guelin proteome variance. BASEL
+   phages' unique proteome signals are compressed into low-variance tail components that PCA
+   drops. The top-32 components explain 95.6% of total variance, but the Guelin-specific vs
+   BASEL-specific signal ratio is heavily skewed — BASEL phages do get non-zero projections
+   (no zero-vector failure mode, which is a win over TL17), but the projections don't encode
+   BASEL-discriminative structure.
+
+2. **Proteome similarity is not RBP similarity.** The TL17 reference bank is pharokka-
+   filtered to RBP proteins (`classify_rbp_genes`) — only ~200 proteins, receptor-binding-
+   specific. MMseqs2 all-vs-all on the full 18,830-protein panel includes every core gene:
+   terminase, polymerase, capsid, lysis machinery. Conserved housekeeping proteins contribute
+   identically across all phage pairs, so the resulting similarity matrix overweights
+   core-genome shared ancestry and underweights RBP-specific variation. Per
+   `receptor-specificity-solved`: "the signal is in short motifs at specific loci, not
+   global protein similarity."
+
+Both mechanisms were anticipated by the plan's "net ≈ wash" caveat; the result sharpens
+that prediction into "BASEL regression, Guelin wash" — an active reason to stop at TL17
+rather than replace it with Arm 2.
+
+#### Verdict
+
+**Null (regression on BASEL discrimination).** Arm 2 does not replace TL17 as the canonical
+phage-side feature slot. The plan's acceptance criterion is not met on any of its three
+exit conditions (AUC lift, top-3 lift — retired under CHISEL anyway, NILS53 rescue — not
+measurable on the BASEL side). Adds to `panel-size-ceiling` evidence: continuous proteome
+similarity at phage-level aggregation does not crack the BASEL discrimination gap.
+
+#### Scope
+
+Single-arm PR. Arms 3 and 4 run on separate branches and will be reported in follow-up
+entries. CH06 closes when Arm 4 merges (per-arm PRs chain under "Relates to #440" for
+Arms 2/3 and "Closes #440" for Arm 4).
+
+#### Artifacts
+
+- `lyzortx/pipeline/autoresearch/ch06_arm2_mmseqs_proteome.py` — precompute + eval driver.
+- `lyzortx/pipeline/autoresearch/sx03_eval.py:patch_context_with_extended_slots` — new
+  backwards-compatible `slots_dir=` parameter (default unchanged).
+- `.scratch/ch06_arm2/{combined_proteome.faa, mmseqs_hits.tsv, pairwise_bitscore.npz}` —
+  precompute cache (MMseqs2 hits, 148×148 bit-score matrix).
+- `.scratch/basel/feature_slots_arm2/phage_projection/features.csv` — Arm 2 slot (148 × 33
+  columns: phage + 32 PCA).
+- `lyzortx/generated_outputs/ch06_arm2_mmseqs_proteome/` — variance pre-flight JSON, per-
+  row and pair-level prediction CSVs, cross-source breakdown, final metrics JSON.

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -1121,8 +1121,8 @@ point estimates recomputed from Arm 2's per-pair predictions):
 **BASEL bacteria-axis AUC 0.7045 is below the target 0.7152** — Arm 2 does not meet the
 plan's discrimination success criterion. Brier improves for BASEL on both axes (bacteria-
 axis 0.2380 → 0.2185; phage-axis 0.1890 → 0.1628), but that is a calibration-side effect
-driven by the wider shrunken-toward-base-rate distribution of Arm 2 predictions, not
-discrimination — AUC moves the opposite direction.
+driven by the narrower, shrunken-toward-base-rate distribution of Arm 2 predictions (BASEL
+std 0.336 → 0.303), not discrimination — AUC moves the opposite direction.
 
 #### Interpretation
 


### PR DESCRIPTION
## Summary

CH06 Arm 2: replace the Guelin-only TL17 categorical `phage_projection` slot with a 32-dim
PCA over the 148×148 all-vs-all MMseqs2 proteome bit-score matrix — the plan's strongest
structural candidate for closing the BASEL discrimination gap.

**Result:** null / regression on the decisive metric. BASEL bacteria-axis AUC drops to
**0.7045** (baseline 0.7229; plan target > 0.7152), a 1.84 pp regression. Aggregate and
Guelin numbers wobble within sampling noise; BASEL phage-axis also slips 0.88 pp. Arm 2
does not replace TL17 as the canonical phage-side slot.

## Headline numbers

| Metric | Baseline | Arm 2 | Δ |
|---|---|---|---|
| Bacteria-axis AUC (agg) | 0.8218 [0.8063, 0.8368] | 0.8240 [0.8066, 0.8397] | +0.22 pp (CIs overlap) |
| Phage-axis AUC (agg) | 0.8919 [0.8650, 0.9166] | 0.8878 [0.8625, 0.9114] | −0.41 pp |
| **Bact-axis BASEL AUC** | **0.7229** | **0.7045** | **−1.84 pp — below target** |
| Bact-axis Guelin AUC | 0.8247 | 0.8278 | +0.31 pp |
| Phage-axis Guelin AUC | 0.8922 | 0.8879 | −0.43 pp |
| Phage-axis BASEL AUC | 0.8822 | 0.8734 | −0.88 pp |

## Why Arm 2 fails

Two mechanisms, both pre-registered in plan.yml's "may cannibalize TL17 — net ≈ wash":

1. **Guelin-weighted PCA axes.** 96/148 rows are Guelin, so PCA captures mostly Guelin
   variance; BASEL-discriminative signal lives in low-variance tails that PCA drops.
2. **Proteome similarity is not RBP similarity.** TL17's reference bank is RBP-filtered
   (~200 proteins). MMseqs2 all-vs-all includes terminase, polymerase, capsid — conserved
   core-genome ancestry dominates. Per `receptor-specificity-solved`: the signal is in
   short motifs at specific loci, not global protein similarity.

BASEL Brier improves on both axes (bacteria 0.238 → 0.219; phage 0.189 → 0.163) but that
is a calibration-side effect from wider shrunken-toward-base-rate predictions, not
discrimination — AUC moves the opposite direction.

## Implementation notes

- `lyzortx/pipeline/autoresearch/ch06_arm2_mmseqs_proteome.py`: end-to-end driver
  (combined FASTA → MMseqs2 → 148×148 matrix → PCA-32 → slot CSV → CH05 two-axis eval).
  Precompute cached to `.scratch/ch06_arm2/` so slot regeneration is fast.
- `sx03_eval.patch_context_with_extended_slots` gains a backwards-compatible
  `slots_dir=` parameter so arms can patch the `phage_projection` slot with their own
  per-arm CSVs.
- Variance pre-flight passes all three subsets (Guelin/BASEL-nonzero/BASEL-zero) on the
  CV > 0.1 OR Cohen's d > 0.1 gate — but pre-flight passing is a necessary, not
  sufficient condition for arm survival (evident from the null training result).

## Artifacts

- `lyzortx/generated_outputs/ch06_arm2_mmseqs_proteome/ch06_arm2_metrics.json` — final
  numbers.
- `.../ch06_arm2_{bacteria,phage}_axis_predictions.csv` — per-pair predictions.
- `.../ch06_arm2_cross_source_breakdown.csv` — phage-axis cross-source.
- `.../ch06_arm2_variance_preflight.json` — pre-flight detail.
- Notebook entry at `lyzortx/research_notes/lab_notebooks/track_CHISEL.md` (2026-04-20
  13:54 CEST).

## Scope

Single-arm PR per ticket policy. Arms 3 and 4 follow on separate branches. CH06 closes
when Arm 4 merges.

Relates to #440

## Test plan

- [x] MMseqs2 easy-search completes (~22s on 18,830 proteins)
- [x] PCA top-32 explains 95.6% of variance (healthy structure)
- [x] Variance pre-flight passes all three subsets
- [x] Smoke test on 1 fold per axis before full run
- [x] Full 10-fold × 2-axis eval under `ch04_parallel.fit_seeds` (~80 min)
- [x] Cross-source breakdown computed from per-pair CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)