### PR TITLE
[CH06-Arm3] Moriniere receptor-class fractions — validates panel-independent phage features

### DIFF
--- a/lyzortx/pipeline/autoresearch/ch06_arm3_moriniere_receptor.py
+++ b/lyzortx/pipeline/autoresearch/ch06_arm3_moriniere_receptor.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""CH06 Arm 3: Moriniere receptor-class probabilities as phage-side feature slot.
+
+Replaces the TL17 categorical projection with a per-receptor k-mer-presence
+fraction vector. For each phage P and each receptor class R, the feature value
+is `|kmers(R) ∩ kmers(P)| / |kmers(R)|` — the fraction of receptor R's
+characteristic k-mers that appear anywhere in phage P's proteome. Moriniere 2026
+Dataset S6 provides 13 receptor classes (plan.yml says "19-dim", but the actual
+Moriniere supplementary dataset has 13 — tsx, ompA/C/F, fhuA, btuB, lptD, lamB,
+NGR, Kdo, HepI, HepII, GluI).
+
+The raw 815 k-mers were null in SX12 (see `kmer-receptor-expansion-neutral`).
+This arm tests whether aggregating to per-receptor normalized fractions (which
+controls for class imbalance: HepI has 168 k-mers, Kdo has 9) carries
+discrimination signal missed by the raw-k-mer representation. Plan.yml pre-
+registers this as **expected null** per:
+
+  (a) same-receptor-uncorrelated-hosts — Tsx phages have Jaccard 0.091 on host
+      ranges; receptor class is far from sufficient for predicting lysis.
+  (b) Moriniere's classifier trained on BW25113/BL21, which lack capsule /
+      O-antigen, so polysaccharide-mediated specificity (Gate 1 mechanism —
+      depo-capsule-validated) is not represented.
+
+Normalizing per-receptor (vs raw count or softmax across receptors) is a small
+refinement on SX12 at best.
+
+Two-phase:
+
+1. `build_receptor_fraction_matrix`: for each of 148 phages, compute the
+   13-dim receptor-fraction vector. Uses `load_receptor_kmers` and
+   `collect_*_phage_proteomes` already in the repo (SX12 infrastructure).
+
+2. `run_variance_preflight`: CV and Cohen's d on the three standard subsets
+   (Guelin, BASEL non-zero TL17, BASEL zero TL17). If the arm fails the gate,
+   we skip training and document the kill.
+
+3. `run_arm3_training_eval`: CH05 two-axis retraining via the same patch-in-place
+   path as Arm 2 but with `.scratch/basel/feature_slots_arm3/` as the slot root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.build_moriniere_kmer_slot import (
+    DEFAULT_BASEL_PHAROKKA_DIR,
+    DEFAULT_DATASET_PATH,
+    DEFAULT_GUELIN_PROTEIN_DIR,
+    collect_basel_phage_proteomes,
+    collect_guelin_phage_proteomes,
+)
+from lyzortx.pipeline.autoresearch.predict_receptor_from_kmers import load_receptor_kmers
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_SLOT_CSV = Path(".scratch/basel/feature_slots_arm3/phage_projection/features.csv")
+DEFAULT_ORIGINAL_SLOT_CSV = Path(".scratch/basel/feature_slots/phage_projection/features.csv")
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/ch06_arm3_moriniere_receptor")
+COLUMN_PREFIX = "phage_projection__recep_frac_"
+
+
+def build_receptor_fraction_matrix(
+    dataset_path: Path,
+    guelin_protein_dir: Path,
+    basel_pharokka_dir: Path,
+) -> tuple[list[str], list[str], np.ndarray]:
+    """Compute per-(phage, receptor) fraction of characteristic k-mers present.
+
+    Returns (phage_order, receptor_order, matrix[n_phages, n_receptors]).
+    """
+    receptor_kmers = load_receptor_kmers(dataset_path)
+    receptor_order = sorted(receptor_kmers.keys())
+    guelin = collect_guelin_phage_proteomes(guelin_protein_dir)
+    basel = collect_basel_phage_proteomes(basel_pharokka_dir)
+    proteomes = {**guelin, **basel}
+    phage_order = sorted(proteomes.keys())
+
+    matrix = np.zeros((len(phage_order), len(receptor_order)), dtype=np.float32)
+    for i, phage in enumerate(phage_order):
+        proteome = proteomes[phage]
+        for j, receptor in enumerate(receptor_order):
+            kmers = receptor_kmers[receptor]
+            hits = sum(1 for k in kmers if k in proteome)
+            matrix[i, j] = hits / len(kmers) if kmers else 0.0
+
+    LOGGER.info(
+        "Receptor-fraction matrix: %d phages × %d receptors; overall mean=%.3f",
+        matrix.shape[0],
+        matrix.shape[1],
+        float(matrix.mean()),
+    )
+    return phage_order, receptor_order, matrix
+
+
+def materialize_arm3_slot(
+    phage_order: Sequence[str],
+    receptor_order: Sequence[str],
+    matrix: np.ndarray,
+    slot_csv: Path,
+) -> pd.DataFrame:
+    slot_csv.parent.mkdir(parents=True, exist_ok=True)
+    columns = [f"{COLUMN_PREFIX}{r}" for r in receptor_order]
+    df = pd.DataFrame(matrix, columns=columns)
+    df.insert(0, "phage", list(phage_order))
+    df.to_csv(slot_csv, index=False)
+    LOGGER.info("Arm 3 receptor-fraction slot written to %s", slot_csv)
+    return df
+
+
+def run_variance_preflight(
+    slot_df: pd.DataFrame,
+    original_slot_csv: Path,
+    interactions_path: Path,
+    output_json: Path,
+) -> dict[str, object]:
+    """CV and Cohen's d on three phage subsets (Guelin / BASEL non-zero / BASEL zero).
+
+    Same structure as Arm 2's pre-flight — see `ch06_arm2_mmseqs_proteome.py` for
+    rationale. Gate passes if any subset has CV > 0.1 OR Cohen's d > 0.1.
+    """
+    original = pd.read_csv(original_slot_csv)
+    feature_cols = [c for c in original.columns if c != "phage"]
+    original_nonzero = original[feature_cols].abs().sum(axis=1) > 0
+    nonzero_phages = set(original.loc[original_nonzero, "phage"])
+
+    guelin = [p for p in slot_df["phage"] if not p.startswith("Bas")]
+    basel_all = [p for p in slot_df["phage"] if p.startswith("Bas")]
+    basel_nonzero_proj = [p for p in basel_all if p in nonzero_phages]
+    basel_zero_proj = [p for p in basel_all if p not in nonzero_phages]
+
+    feature_cols = [c for c in slot_df.columns if c.startswith(COLUMN_PREFIX)]
+
+    interactions = pd.read_csv(interactions_path, sep=";", low_memory=False)
+    interactions["score"] = interactions["score"].astype(str)
+    guelin_labels = (interactions["score"] == "1").astype(int)
+    guelin_lysis = (
+        pd.DataFrame({"phage": interactions["phage"], "label": guelin_labels}).groupby("phage")["label"].mean()
+    )
+    basel_path = Path(".scratch/genophi_data/BASEL_ECOR_interaction_matrix.csv")
+    basel_lysis = pd.Series(dtype=float)
+    if basel_path.exists():
+        basel = pd.read_csv(basel_path).dropna(subset=["interaction"])
+        basel_lysis = basel.groupby("phage")["interaction"].mean()
+    phage_lysis_rate = pd.concat([guelin_lysis, basel_lysis])
+
+    summary: dict[str, dict[str, object]] = {}
+    subsets = {
+        "guelin_n=%d" % len(guelin): guelin,
+        "basel_nonzero_proj_n=%d" % len(basel_nonzero_proj): basel_nonzero_proj,
+        "basel_zero_proj_n=%d" % len(basel_zero_proj): basel_zero_proj,
+    }
+
+    for label, phages in subsets.items():
+        sub = slot_df[slot_df["phage"].isin(phages)]
+        if sub.empty:
+            summary[label] = {"status": "empty_subset"}
+            continue
+        mat = sub[feature_cols].to_numpy(dtype=float)
+        mean = mat.mean(axis=0)
+        std = mat.std(axis=0, ddof=1)
+        cv = np.where(np.abs(mean) > 1e-10, std / np.abs(mean), np.nan)
+
+        lysis = sub["phage"].map(phage_lysis_rate).fillna(phage_lysis_rate.median()).to_numpy()
+        median_lysis = np.median(lysis)
+        hi = mat[lysis > median_lysis]
+        lo = mat[lysis <= median_lysis]
+        if hi.size and lo.size:
+            pooled = np.sqrt((hi.var(axis=0, ddof=1) + lo.var(axis=0, ddof=1)) / 2)
+            cohens_d = np.where(pooled > 1e-10, (hi.mean(axis=0) - lo.mean(axis=0)) / pooled, 0.0)
+        else:
+            cohens_d = np.zeros(len(feature_cols))
+
+        max_abs_cv = float(np.nanmax(np.abs(cv)))
+        max_abs_d = float(np.max(np.abs(cohens_d)))
+        summary[label] = {
+            "n_phages": len(sub),
+            "n_receptors": len(feature_cols),
+            "max_abs_cv": round(max_abs_cv, 4),
+            "max_abs_cohens_d": round(max_abs_d, 4),
+            "n_receptors_with_cv_gt_0.1": int(np.nansum(np.abs(cv) > 0.1)),
+            "n_receptors_with_cohens_d_gt_0.1": int(np.sum(np.abs(cohens_d) > 0.1)),
+            "gate_status": "pass" if (max_abs_cv > 0.1 or max_abs_d > 0.1) else "fail",
+        }
+
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    with output_json.open("w") as f:
+        json.dump(summary, f, indent=2)
+    LOGGER.info("Variance pre-flight: %s", json.dumps(summary, indent=2))
+    return summary
+
+
+def run_arm3_training_eval(
+    *,
+    slot_csv: Path,
+    output_dir: Path,
+    cache_dir: Path,
+    candidate_dir: Path,
+    device_type: str = "cpu",
+    max_folds: int | None = None,
+    num_workers: int = 3,
+    drop_high_titer_only_positives: bool = True,
+) -> dict[str, object]:
+    """Run CH05's two-axis evaluation with the Arm 3 phage_projection slot."""
+    from lyzortx.pipeline.autoresearch.candidate_replay import load_module_from_path
+    from lyzortx.pipeline.autoresearch.ch04_eval import (
+        BOOTSTRAP_RANDOM_STATE,
+        BOOTSTRAP_SAMPLES,
+        build_clean_row_training_frame,
+        select_pair_max_concentration_rows,
+    )
+    from lyzortx.pipeline.autoresearch.ch05_eval import (
+        BASEL_LOG10_PFU_ML,
+        SOURCE_BASEL,
+        SOURCE_GUELIN,
+        _bootstrap_by_unit,
+        _ci_to_dict,
+        load_unified_row_frame,
+        run_bacteria_axis,
+        run_phage_axis,
+    )
+    from lyzortx.pipeline.autoresearch.sx03_eval import patch_context_with_extended_slots
+    from lyzortx.pipeline.autoresearch.sx15_eval import load_unified_phage_family_map
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if not slot_csv.exists():
+        raise FileNotFoundError(f"Arm 3 slot CSV missing: {slot_csv}")
+
+    arm3_slot_dir = slot_csv.parent.parent
+    arm3_slot_dir.mkdir(parents=True, exist_ok=True)
+    for slot_name in ("phage_stats", "phage_rbp_struct"):
+        arm3_side = arm3_slot_dir / slot_name / "features.csv"
+        baseline_side = Path(".scratch/basel/feature_slots") / slot_name / "features.csv"
+        if not arm3_side.exists() and baseline_side.exists():
+            arm3_side.parent.mkdir(parents=True, exist_ok=True)
+            arm3_side.symlink_to(baseline_side.resolve())
+
+    unified = load_unified_row_frame(basel_log10_pfu_ml=BASEL_LOG10_PFU_ML)
+    clean_rows = build_clean_row_training_frame(unified, drop_high_titer_only_positives=drop_high_titer_only_positives)
+    pair_source = clean_rows[["pair_id", "source"]].drop_duplicates(subset=["pair_id"]).set_index("pair_id")["source"]
+    phage_family = load_unified_phage_family_map()
+    candidate_module = load_module_from_path("ch06_arm3_candidate", candidate_dir / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=cache_dir, include_host_defense=True)
+    patch_context_with_extended_slots(context, slots_dir=arm3_slot_dir)
+
+    bacteria_per_row = run_bacteria_axis(
+        candidate_module=candidate_module,
+        context=context,
+        candidate_dir=candidate_dir,
+        clean_rows=clean_rows,
+        device_type=device_type,
+        output_dir=output_dir,
+        max_folds=max_folds,
+        num_workers=num_workers,
+    )
+    phage_per_row = run_phage_axis(
+        candidate_module=candidate_module,
+        context=context,
+        candidate_dir=candidate_dir,
+        clean_rows=clean_rows,
+        phage_family=phage_family,
+        device_type=device_type,
+        output_dir=output_dir,
+        max_folds=max_folds,
+        num_workers=num_workers,
+    )
+
+    bacteria_pairs = select_pair_max_concentration_rows(bacteria_per_row)
+    bacteria_pairs["source"] = bacteria_pairs["pair_id"].map(pair_source)
+    bacteria_pairs.to_csv(output_dir / "ch06_arm3_bacteria_axis_predictions.csv", index=False)
+    bacteria_cis = _bootstrap_by_unit(
+        bacteria_pairs.to_dict(orient="records"),
+        unit_key="bacteria",
+        bootstrap_samples=BOOTSTRAP_SAMPLES,
+        bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+    )
+
+    phage_pairs = select_pair_max_concentration_rows(phage_per_row)
+    phage_pairs["source"] = phage_pairs["pair_id"].map(pair_source)
+    phage_pairs.to_csv(output_dir / "ch06_arm3_phage_axis_predictions.csv", index=False)
+    phage_rows = phage_pairs.to_dict(orient="records")
+    phage_cis_all = _bootstrap_by_unit(
+        phage_rows,
+        unit_key="phage",
+        bootstrap_samples=BOOTSTRAP_SAMPLES,
+        bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+    )
+
+    cross_source_rows: list[dict[str, object]] = []
+    for source_label in (SOURCE_GUELIN, SOURCE_BASEL):
+        subset = [r for r in phage_rows if r["source"] == source_label]
+        if not subset:
+            raise ValueError(f"Empty cross-source subset for {source_label!r}")
+        subset_cis = _bootstrap_by_unit(
+            subset,
+            unit_key="phage",
+            bootstrap_samples=BOOTSTRAP_SAMPLES,
+            bootstrap_random_state=BOOTSTRAP_RANDOM_STATE,
+        )
+        cross_source_rows.append(
+            {
+                "source": source_label,
+                "n_pairs": len(subset),
+                "n_phages": len({r["phage"] for r in subset}),
+                "auc": subset_cis["holdout_roc_auc"].point_estimate,
+                "auc_low": subset_cis["holdout_roc_auc"].ci_low,
+                "auc_high": subset_cis["holdout_roc_auc"].ci_high,
+                "brier": subset_cis["holdout_brier_score"].point_estimate,
+                "brier_low": subset_cis["holdout_brier_score"].ci_low,
+                "brier_high": subset_cis["holdout_brier_score"].ci_high,
+            }
+        )
+    pd.DataFrame(cross_source_rows).to_csv(output_dir / "ch06_arm3_cross_source_breakdown.csv", index=False)
+
+    summary = {
+        "arm": "CH06 Arm 3 — Moriniere receptor-class probabilities",
+        "slot_csv": str(slot_csv),
+        "bacteria_axis": {
+            "aggregate": {name: _ci_to_dict(ci) for name, ci in bacteria_cis.items()},
+            "n_pairs": len(bacteria_pairs),
+        },
+        "phage_axis": {
+            "aggregate": {name: _ci_to_dict(ci) for name, ci in phage_cis_all.items()},
+            "cross_source": cross_source_rows,
+            "n_pairs": len(phage_pairs),
+        },
+    }
+    with (output_dir / "ch06_arm3_metrics.json").open("w") as f:
+        json.dump(summary, f, indent=2, default=str)
+    LOGGER.info("CH06 Arm 3 summary written to %s", output_dir / "ch06_arm3_metrics.json")
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-path", type=Path, default=DEFAULT_DATASET_PATH)
+    parser.add_argument("--guelin-protein-dir", type=Path, default=DEFAULT_GUELIN_PROTEIN_DIR)
+    parser.add_argument("--basel-pharokka-dir", type=Path, default=DEFAULT_BASEL_PHAROKKA_DIR)
+    parser.add_argument("--slot-csv", type=Path, default=DEFAULT_SLOT_CSV)
+    parser.add_argument("--original-slot-csv", type=Path, default=DEFAULT_ORIGINAL_SLOT_CSV)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--interactions-path",
+        type=Path,
+        default=Path("data/interactions/raw/raw_interactions.csv"),
+    )
+    parser.add_argument("--skip-preflight", action="store_true")
+    parser.add_argument("--run-training", action="store_true")
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path("lyzortx/generated_outputs/autoresearch/search_cache_v1"),
+    )
+    parser.add_argument("--candidate-dir", type=Path, default=Path("lyzortx/autoresearch"))
+    parser.add_argument("--device-type", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument("--max-folds", type=int, default=None)
+    parser.add_argument("--num-workers", type=int, default=3)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    phage_order, receptor_order, matrix = build_receptor_fraction_matrix(
+        args.dataset_path, args.guelin_protein_dir, args.basel_pharokka_dir
+    )
+    slot_df = materialize_arm3_slot(phage_order, receptor_order, matrix, args.slot_csv)
+
+    if not args.skip_preflight:
+        run_variance_preflight(
+            slot_df,
+            args.original_slot_csv,
+            args.interactions_path,
+            args.output_dir / "ch06_arm3_variance_preflight.json",
+        )
+
+    if args.run_training:
+        run_arm3_training_eval(
+            slot_csv=args.slot_csv,
+            output_dir=args.output_dir,
+            cache_dir=args.cache_dir,
+            candidate_dir=args.candidate_dir,
+            device_type=args.device_type,
+            max_folds=args.max_folds,
+            num_workers=args.num_workers,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -1175,3 +1175,145 @@ Arms 2/3 and "Closes #440" for Arm 4).
   columns: phage + 32 PCA).
 - `lyzortx/generated_outputs/ch06_arm2_mmseqs_proteome/` — variance pre-flight JSON, per-
   row and pair-level prediction CSVs, cross-source breakdown, final metrics JSON.
+
+### 2026-04-20 15:08 CEST: CH06 Arm 3 — Moriniere receptor probabilities (validated — meets acceptance)
+
+#### Executive summary
+
+Plan.yml pre-registered Arm 3 as "expected null" based on `same-receptor-uncorrelated-hosts`
+and Moriniere's classifier training on K-12 derivatives. The full run contradicts that:
+Arm 3 meets the CH06 acceptance criterion with **BASEL bacteria-axis AUC 0.7374** (baseline
+0.7229, target > 0.7152, **+1.45 pp**). The decisive deployability metric — BASEL
+zero-projection phages (n=13, the literal TL17 zero-vector-failure subset) — improves
+**+4.36 pp on phage-axis** (0.6901 → 0.7337). Guelin numbers flat (±0.15 pp on both axes);
+BASEL non-zero-projection phages also gain (+2.54 pp bacteria-axis, +0.54 pp phage-axis).
+Arm 3 replaces the Guelin-only TL17 categorical projection with a 13-dim per-receptor
+k-mer-fraction vector, trained upstream on 260 non-Guelin phages so the feature basis is
+panel-independent at source — which is exactly what the plan's `deployment-goal` needs.
+
+#### Feature construction
+
+For each phage P and each of the 13 Moriniere receptor classes R, the feature value is
+`|kmers(R) ∩ kmers(P)| / |kmers(R)|` — the fraction of receptor R's 5-mer set that appears
+anywhere in P's proteome. Divided per-receptor so the class imbalance in Dataset S6 (HepI:
+168 k-mers, Kdo: 9, GluI: 28, …) is normalized out; otherwise HepI would dominate raw
+hit counts just by having more k-mers to match.
+
+Critical reuse: `lyzortx.pipeline.autoresearch.build_moriniere_kmer_slot.collect_*_phage_
+proteomes` provides the 148-phage Guelin-plus-BASEL proteome load, and
+`lyzortx.pipeline.autoresearch.predict_receptor_from_kmers.load_receptor_kmers` parses the
+GenoPHI Dataset S6 supplementary XLSX. Plan.yml listed the feature space as "19-dim softmax"
+but the actual Moriniere dataset has **13 receptor classes** (tsx, ompA, ompC, ompF, fhuA,
+btuB, lptD, lamB, NGR, Kdo, HepI, HepII, GluI) — the notebook entry reports 13-dim
+reflecting the data as-loaded rather than the plan's stale number.
+
+Slot schema: `phage_projection__recep_frac_<receptor>` × 13 columns, materialized to
+`.scratch/basel/feature_slots_arm3/phage_projection/features.csv`. Phage-stats and
+phage-rbp-struct slots symlinked from the baseline directory, so only the projection slot
+is changed.
+
+#### Variance pre-flight
+
+All three subsets pass the CV > 0.1 OR Cohen's d > 0.1 gate — and unlike Arm 2, the
+BASEL zero-projection subset shows strong signal: 11/13 receptors have Cohen's d > 0.1
+against phage-level lysis-rate median split, max abs d 1.20.
+
+| Subset | n | Max CV | Max Cohen's d | d > 0.1 | CV > 0.1 | Gate |
+|---|---|---|---|---|---|---|
+| Guelin | 96 | 6.7 | 0.60 | 12/13 | 13/13 | pass |
+| BASEL non-zero TL17 | 39 | 6.25 | 1.67 | 13/13 | 13/13 | pass |
+| BASEL zero-vector TL17 | 13 | 3.61 | 1.20 | 11/13 | 12/13 | pass |
+
+#### Full-training results
+
+10-fold bacteria-axis (CH02 cv_group hash) and 10-fold phage-axis (StratifiedKFold by ICTV
+family + "other" + "UNKNOWN"), 3 seeds each under `ch04_parallel.fit_seeds`, 1000-sample
+unit-level bootstrap.
+
+| Axis | Metric | Baseline | Arm 3 | Δ | CI overlap |
+|---|---|---|---|---|---|
+| Bacteria | AUC (agg) | 0.8218 [0.8063, 0.8368] | 0.8205 [0.8039, 0.8362] | −0.13 pp | yes |
+| Bacteria | Brier (agg) | 0.1466 | 0.1457 | −0.09 pp | yes |
+| Phage | AUC (agg) | 0.8919 [0.8650, 0.9166] | 0.8936 [0.8672, 0.9171] | +0.17 pp | yes |
+| Phage | Brier (agg) | 0.1181 | 0.1177 | −0.04 pp | yes |
+
+Aggregate numbers are flat (as expected when Guelin dominates weight). The real signal
+lives in the cross-source and BASEL-subset decomposition:
+
+| Subset | Bact-axis Baseline | Arm 3 | Δ | Phage-axis Baseline | Arm 3 | Δ |
+|---|---|---|---|---|---|---|
+| Guelin (n=96) | 0.8247 | 0.8232 | −0.15 pp | 0.8922 | 0.8934 | +0.12 pp |
+| BASEL all (n=52) | **0.7229** | **0.7374** | **+1.45 pp** | 0.8822 | 0.8902 | +0.80 pp |
+| BASEL non-zero TL17 (n=39) | 0.6968 | 0.7222 | +2.54 pp | 0.8974 | 0.9028 | +0.54 pp |
+| **BASEL zero-vec TL17 (n=13)** | 0.6325 | 0.6484 | +1.59 pp | **0.6901** | **0.7337** | **+4.36 pp** |
+
+**Acceptance criterion met.** BASEL bacteria-axis 0.7374 > 0.7152 target, with improvement
+on every cross-source subset on both axes (Guelin flat; BASEL positive across zero/non-zero
+decomposition). No cannibalization signature — unlike Arm 2, Arm 3 rescues zero-proj BASEL
+without regressing non-zero-proj BASEL.
+
+#### Arm 2 re-interpretation in light of Arm 3
+
+Arm 2's merged notebook entry framed the result as "null / BASEL regression" on the
+aggregate BASEL bacteria-axis AUC. The subset decomposition after the fact shows a more
+nuanced picture: Arm 2 **does** rescue zero-proj BASEL (+1.07 pp bacteria-axis, +1.27 pp
+phage-axis) — the deployability mechanism it was designed to address — but cannibalizes
+non-zero-proj BASEL (−2.07 pp bacteria-axis, −1.52 pp phage-axis). The 39/52 non-zero
+BASEL phages contribute 920/1240 pairs (74%), so their regression dominates the aggregate.
+Arm 2 as a **drop-in replacement** for TL17 fails; Arm 2's phage-level similarity vector
+composed **alongside** TL17 (keep RBP-focused signal where available, add proteome
+similarity where TL17 is zero) could be a valid follow-up — but not needed if Arm 3 does
+the same rescue cleanly, which it does.
+
+#### Why the plan's "expected null" prediction was wrong
+
+Plan.yml cited two reasons Arm 3 would fail:
+
+1. `same-receptor-uncorrelated-hosts` — phages sharing a predicted receptor have Jaccard
+   0.091 on host ranges (Tsx phages).
+2. Moriniere trained on K-12 derivatives lacking capsule/O-antigen, so
+   polysaccharide-mediated specificity is not in scope.
+
+Both are correct characterizations of what receptor-class probabilities *don't* encode, but
+the CH06 acceptance criterion is not "within-receptor-class host-range accuracy" or "capture
+Gate-1 polysaccharide mechanism." It is **absolute cross-panel discrimination AUC on
+BASEL bacteria-axis**. A 13-dim probability vector that is panel-independent (trained on
+260 non-Guelin phages) and distinguishes "which of the major receptor families does this
+phage use" is a real discriminative feature even if it says nothing about strain-level
+host-range rank ordering. The null prediction was reasoning about a different question.
+
+`kmer-receptor-expansion-neutral` (the SX12 / GT06 null) stands — raw 815-kmer
+presence-absence is information-redundant with `phage_projection`. Arm 3's aggregation to
+13 per-receptor fractions removes that redundancy by forcing the model to see class-level
+probabilities rather than re-deriving them from the 815 raw k-mers; the aggregation turns
+out to carry more actionable signal than the raw features.
+
+#### Verdict
+
+**Success — promote to canonical.** Arm 3 should become the default `phage_projection`
+slot for CHISEL going forward. Recommendation (handled in follow-up commits to
+`knowledge.yml`):
+
+- Update `chisel-unified-kfold-baseline` knowledge unit to note the CH06 outcome and
+  reference Arm 3 as the validated panel-independent phage-side feature slot.
+- Add a new knowledge unit `moriniere-receptor-probabilities-panel-independent`
+  summarizing the finding (BASEL bacteria-axis +1.45 pp, zero-proj BASEL phage-axis
+  +4.36 pp, Guelin flat).
+- Harden `plm-rbp-redundant` with "receptor-class probability aggregation (Arm 3) is the
+  working alternative to global protein similarity" — the PLM null stands, but the
+  replacement path is per-receptor aggregation, not global pooling.
+
+Arm 4 (tail-restricted TL17) runs next for completeness. Under the Arm 3 win, Arm 4's
+expected-null-or-wash carries less weight: even if Arm 4 works, Arm 3 is the simpler,
+source-panel-independent solution.
+
+#### Artifacts
+
+- `lyzortx/pipeline/autoresearch/ch06_arm3_moriniere_receptor.py` — precompute + eval driver.
+- `.scratch/basel/feature_slots_arm3/phage_projection/features.csv` — Arm 3 slot
+  (148 × 14 columns: phage + 13 receptor-fraction).
+- `lyzortx/generated_outputs/ch06_arm3_moriniere_receptor/ch06_arm3_metrics.json` — final
+  aggregate AUC/Brier with CIs.
+- `.../ch06_arm3_{bacteria,phage}_axis_predictions.csv` — per-pair predictions.
+- `.../ch06_arm3_cross_source_breakdown.csv` — phage-axis cross-source.
+- `.../ch06_arm3_variance_preflight.json` — pre-flight subset breakdown.


### PR DESCRIPTION
## Summary

CH06 Arm 3: replace the Guelin-only TL17 categorical `phage_projection` slot with a 13-dim
per-receptor k-mer-fraction vector derived from Moriniere 2026 Dataset S6. Moriniere's
classifier was trained on 260 non-Guelin reference phages, so the feature basis is
**panel-independent at source** — exactly what the CHISEL `deployment-goal` needs.

**Plan.yml pre-registered this as "expected null". It isn't.** Arm 3 meets the CH06
acceptance criterion with BASEL bacteria-axis AUC 0.7229 → **0.7374 (+1.45 pp)**, above
the 0.7152 target, and rescues the exact deployability failure mode: BASEL zero-vector
TL17 phages (n=13) phage-axis AUC 0.6901 → **0.7337 (+4.36 pp)**.

## Headline numbers

| Subset | Bact-axis Baseline | Arm 3 | Δ | Phage-axis Baseline | Arm 3 | Δ |
|---|---|---|---|---|---|---|
| Guelin (n=96) | 0.8247 | 0.8232 | −0.15 pp (flat) | 0.8922 | 0.8934 | +0.12 pp (flat) |
| **BASEL all** (n=52) | **0.7229** | **0.7374** | **+1.45 pp** | 0.8822 | 0.8902 | +0.80 pp |
| BASEL non-zero TL17 (n=39) | 0.6968 | 0.7222 | +2.54 pp | 0.8974 | 0.9028 | +0.54 pp |
| **BASEL zero-vec TL17 (n=13)** | 0.6325 | 0.6484 | +1.59 pp | **0.6901** | **0.7337** | **+4.36 pp** |

Guelin flat (±0.15 pp). BASEL improves on every cross-source subset on both axes. No
cannibalization signature — unlike Arm 2, Arm 3 rescues zero-proj BASEL without
regressing non-zero-proj BASEL.

## Why plan's "expected null" was wrong

The plan cited `same-receptor-uncorrelated-hosts` (Tsx phages Jaccard 0.091 on host
ranges) and Moriniere trained on K-12 (no capsule/O-antigen). Both are correct
characterizations of what receptor-class probabilities *don't* encode, but CH06's
acceptance criterion is **absolute cross-panel discrimination AUC**, not within-class
host-range accuracy. A 13-dim probability vector that is panel-independent and
distinguishes "which of the major receptor families does this phage use" carries real
cross-panel discrimination signal.

`kmer-receptor-expansion-neutral` stands — raw 815 k-mers are info-redundant with
`phage_projection`. Arm 3's aggregation to 13 per-receptor fractions removes that
redundancy, forcing the model to see class-level probabilities rather than re-deriving
them from the 815 raw features. The aggregation is the mechanism.

## Arm 2 re-interpretation

My merged Arm 2 PR #445 framed that arm as "null / BASEL regression". The subset
decomposition shows a more nuanced picture: Arm 2 **does** rescue zero-proj BASEL
(+1.07 pp bacteria-axis, +1.27 pp phage-axis), but cannibalizes non-zero-proj BASEL
(−2.07 pp / −1.52 pp). Arm 2 as a drop-in TL17 replacement fails. Composition with
TL17 could work but is unnecessary given Arm 3's clean win. This notebook entry carries
the corrected reading forward.

## Implementation

- `lyzortx/pipeline/autoresearch/ch06_arm3_moriniere_receptor.py` — end-to-end driver.
  Reuses `build_moriniere_kmer_slot.collect_*_phage_proteomes` and
  `predict_receptor_from_kmers.load_receptor_kmers` (SX12 infrastructure).
- 13 receptor classes (not 19 as plan.yml claimed — Dataset S6 has 13: tsx, ompA, ompC,
  ompF, fhuA, btuB, lptD, lamB, NGR, Kdo, HepI, HepII, GluI).
- Per-receptor fraction normalization: `|kmers(R) ∩ kmers(P)| / |kmers(R)|` — otherwise
  HepI (168 k-mers) would dominate raw hit counts just by having more k-mers to match.
- Variance pre-flight passes all three subsets (Guelin/BASEL-nonzero/BASEL-zero); 11/13
  receptors in the zero-proj BASEL subset have Cohen's d > 0.1 against phage-level lysis-
  rate median split — strong signal where Arm 2 had only PCA-compressed residuals.

## Artifacts

- `lyzortx/generated_outputs/ch06_arm3_moriniere_receptor/ch06_arm3_metrics.json`
- `.../ch06_arm3_{bacteria,phage}_axis_predictions.csv`
- `.../ch06_arm3_cross_source_breakdown.csv`
- `.../ch06_arm3_variance_preflight.json`
- `.scratch/basel/feature_slots_arm3/phage_projection/features.csv` — Arm 3 slot.
- Notebook entry at 2026-04-20 15:08 CEST.

## Scope

Relates to #440. Arm 4 follows on a separate branch; CH06 closes when Arm 4 merges.

## Test plan

- [x] Pre-flight on 148 phages across 3 subsets — passes gate
- [x] Full 10-fold × 2-axis CH05 evaluation under `ch04_parallel.fit_seeds`
- [x] Cross-source breakdown computed from per-pair CSV
- [x] BASEL zero-vector vs non-zero decomposition against baseline predictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)