### PR TITLE
[ORCH][CH08] Wave-2 feature-family re-audit under CHISEL frame

### DIFF
--- a/lyzortx/pipeline/autoresearch/ch04_parallel.py
+++ b/lyzortx/pipeline/autoresearch/ch04_parallel.py
@@ -42,13 +42,24 @@ RFE_SEED = 42
 
 HOST_SLOTS = ("host_surface", "host_typing", "host_stats", "host_defense")
 PHAGE_SLOTS = ("phage_projection", "phage_stats")
+# Allowlist of design-matrix column prefixes that reach RFE + LightGBM. Any slot
+# whose columns are not covered here is silently filtered out of the feature set
+# (columns remain in the design matrix for downstream joins, but no model ever
+# sees them). CH08 caught this: earlier wave-2 ablation tickets attached
+# `host_omp_kmer` and `phage_moriniere_kmer` slots to the context but their
+# features were silently dropped because the prefixes were missing here. When
+# adding a new slot family whose columns carry a distinct prefix, register it
+# below.
 FEATURE_COLUMN_PREFIXES = (
     "host_surface__",
     "host_typing__",
     "host_stats__",
     "host_defense__",
+    "host_omp_kmer__",
+    "host_omp_cluster__",
     "phage_projection__",
     "phage_stats__",
+    "phage_moriniere_kmer__",
     "pair_depo_capsule__",
     "pair_receptor_omp__",
     "pair_concentration__",

--- a/lyzortx/pipeline/autoresearch/ch08_wave2_reaudit.py
+++ b/lyzortx/pipeline/autoresearch/ch08_wave2_reaudit.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+"""CH08: SX12 + SX13 wave-2 feature-family re-audit under the CHISEL frame.
+
+Verifies that the SPANDEX wave-2 nulls (SX12 Moriniere 815-kmer phage-side
+features; SX13 host OMP 5-mer features) still hold under the CHISEL training
+frame (per-row binary labels, `pair_concentration__log10_pfu_ml` feature,
+all-pairs only, neat-only filter).
+
+SX11 (loss-function ablation) is explicitly out of scope per plan.yml — it
+chased MLC-graded potency which no longer exists in the CHISEL label frame.
+
+Arms evaluated (each is a full CH04 10-fold bacteria-axis CV on the
+369-bacterium Guelin panel):
+  1. baseline   — CH04 canonical (reused from lyzortx/generated_outputs/ch04_chisel_baseline/)
+  2. sx12       — baseline + `phage_moriniere_kmer` slot (815 k-mers)
+  3. sx13       — baseline + `host_omp_kmer` slot (marginal arm only)
+
+Deltas are computed by paired bacterium-level bootstrap: the same 1000 resamples
+(same random state, same unit IDs) are applied to both baseline and +slot
+predictions so the AUC/Brier deltas are within-resample, preserving the pairing.
+
+Artifacts under `lyzortx/generated_outputs/ch08_wave2_reaudit/`:
+  - ch08_sx12_delta.json — SX12 arm: AUC/Brier with CIs, paired delta CI
+  - ch08_sx13_delta.json — SX13 arm: same, marginal arm only
+  - ch08_summary.csv     — baseline vs +sx12 vs +sx13 one-row-per-arm table
+  - ch08_<arm>_predictions.csv — per-arm pair-level predictions (for audit)
+
+Expected outcome: null (within ~0.5 pp of CH04 baseline) per the SX12/SX13
+knowledge units `kmer-receptor-expansion-neutral` and
+`host-omp-variation-unpredictive`. If CI on the delta is disjoint from zero,
+the wave-2 null is reopened and the corresponding knowledge unit must be
+reverted.
+
+Usage:
+    python -m lyzortx.pipeline.autoresearch.ch08_wave2_reaudit --device-type cpu
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import brier_score_loss, roc_auc_score
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.candidate_replay import (
+    load_module_from_path,
+    safe_round,
+)
+from lyzortx.pipeline.autoresearch.ch03_row_expansion import load_row_expanded_frame
+from lyzortx.pipeline.autoresearch.ch04_eval import (
+    BOOTSTRAP_RANDOM_STATE,
+    BOOTSTRAP_SAMPLES,
+    build_clean_row_training_frame,
+    compute_aggregate_auc_brier,
+    select_pair_max_concentration_rows,
+)
+from lyzortx.pipeline.autoresearch.ch04_parallel import (
+    HOST_SLOTS as BASE_HOST_SLOTS,
+    PHAGE_SLOTS as BASE_PHAGE_SLOTS,
+    fit_seeds,
+    prepare_fold_design_matrices,
+    select_rfe_features,
+)
+from lyzortx.pipeline.autoresearch.sx01_eval import (
+    N_FOLDS,
+    SEEDS,
+    assign_bacteria_folds,
+    bacteria_to_cv_group_map,
+)
+from lyzortx.pipeline.autoresearch.sx12_eval import (
+    DEFAULT_KMER_SLOT_PATH as DEFAULT_PHAGE_KMER_SLOT_PATH,
+    MORINIERE_SLOT_NAME,
+    attach_moriniere_slot,
+)
+from lyzortx.pipeline.autoresearch.sx13_eval import (
+    HOST_OMP_KMER_SLOT,
+    attach_csv_slot,
+)
+from lyzortx.pipeline.autoresearch.build_host_omp_kmer_slot import (
+    DEFAULT_SLOT_OUTPUT_PATH as DEFAULT_HOST_OMP_KMER_SLOT_PATH,
+    FEATURE_PREFIX as HOST_OMP_KMER_PREFIX,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CACHE_DIR = Path("lyzortx/generated_outputs/autoresearch/search_cache_v1")
+DEFAULT_CANDIDATE_DIR = Path("lyzortx/autoresearch")
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/ch08_wave2_reaudit")
+CH04_CANONICAL_DIR = Path("lyzortx/generated_outputs/ch04_chisel_baseline")
+CH04_CANONICAL_PREDICTIONS = CH04_CANONICAL_DIR / "ch04_predictions.csv"
+CH04_CANONICAL_METRICS = CH04_CANONICAL_DIR / "ch04_aggregate_metrics.json"
+
+ARM_BASELINE = "baseline"
+ARM_SX12 = "sx12"
+ARM_SX13 = "sx13"
+
+# Kmer slots have 815 (phage Moriniere) and 5546 (host OMP) binary features. With
+# RFECV step=0.1, cv=5, and 281K-row training frames the full-feature RFE runs
+# at >60min/fold (20 folds = 20h+) — infeasible per plan.yml's "estimate before
+# running and confirm wallclock is feasible" criterion. We cap each kmer slot
+# at the top-K features by binary variance (maximally discriminative across
+# entities). K=100 chosen empirically to land RFE fold time in the CH04
+# baseline range (~2-3 min/fold). Top-K by variance preserves:
+#  * sparse receptor-class-specific signals (e.g. kmers in ~10% of phages —
+#    high variance, kept)
+#  * balanced OMP 5mers (support near 50% — maximum variance, kept)
+# Features with near-constant presence (variance → 0) are dropped.
+#
+# Rank is computed entity-level once per slot before any fold split — leakage-
+# free. Threshold K is recorded in each arm's delta JSON alongside the delta
+# estimates.
+KMER_TOPK_PER_SLOT = 100
+
+
+def _aggregate_fold_rows_to_pairs(fold_rows: list[dict[str, object]]) -> pd.DataFrame:
+    df = pd.DataFrame(fold_rows)
+    aggregated = (
+        df.groupby(
+            [
+                "fold_id",
+                "pair_id",
+                "bacteria",
+                "phage",
+                "log_dilution",
+                "log10_pfu_ml",
+                "replicate",
+                "label_row_binary",
+            ],
+            as_index=False,
+        )["predicted_probability"]
+        .mean()
+        .sort_values(["bacteria", "phage", "log10_pfu_ml", "replicate"])
+    )
+    return aggregated
+
+
+def run_ch04_variant(
+    *,
+    arm_id: str,
+    phage_slots: tuple[str, ...],
+    host_slots: tuple[str, ...],
+    slot_attach_fns: list,
+    device_type: str,
+    cache_dir: Path,
+    candidate_dir: Path,
+    output_dir: Path,
+    num_workers: int,
+    drop_high_titer_only_positives: bool,
+) -> pd.DataFrame:
+    """Run one CH04 bacteria-axis 10-fold variant with an extended slot bundle.
+
+    `slot_attach_fns` are callables taking the loaded context and mutating it in place
+    (e.g., `attach_moriniere_slot`, `attach_csv_slot`). `phage_slots` / `host_slots`
+    are the slot name tuples passed to `prepare_fold_design_matrices` so the new slot
+    participates in feature table construction.
+    """
+    LOGGER.info(
+        "=== CH08 variant '%s' starting: phage_slots=%s, host_slots=%s ===",
+        arm_id,
+        list(phage_slots),
+        list(host_slots),
+    )
+    row_frame = load_row_expanded_frame()
+    clean_rows = build_clean_row_training_frame(
+        row_frame, drop_high_titer_only_positives=drop_high_titer_only_positives
+    )
+    training = clean_rows[
+        (clean_rows["split_holdout"] == "train_non_holdout") & (clean_rows["is_hard_trainable"] == "1")
+    ].copy()
+    holdout = clean_rows[
+        (clean_rows["split_holdout"] == "holdout_test") & (clean_rows["is_hard_trainable"] == "1")
+    ].copy()
+    full_frame = pd.concat([training, holdout], ignore_index=True)
+    mapping = bacteria_to_cv_group_map(full_frame)
+    fold_assignments = assign_bacteria_folds(mapping)
+
+    candidate_module = load_module_from_path(f"ch08_{arm_id}_candidate", candidate_dir / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=cache_dir, include_host_defense=True)
+    for fn in slot_attach_fns:
+        fn(context)
+
+    all_per_row: list[dict[str, object]] = []
+    for fold_id in range(N_FOLDS):
+        holdout_b = {b for b, f in fold_assignments.items() if f == fold_id}
+        train_b = {b for b, f in fold_assignments.items() if f != fold_id}
+        fold_train = full_frame[full_frame["bacteria"].isin(train_b)].copy()
+        fold_holdout = full_frame[full_frame["bacteria"].isin(holdout_b)].copy()
+        LOGGER.info(
+            "=== CH08/%s Fold %d: %d train bacteria (%d rows), %d holdout bacteria (%d rows) ===",
+            arm_id,
+            fold_id,
+            len(train_b),
+            len(fold_train),
+            len(holdout_b),
+            len(fold_holdout),
+        )
+        train_design, holdout_design, feature_columns, categorical_columns = prepare_fold_design_matrices(
+            candidate_module=candidate_module,
+            context=context,
+            training_frame=fold_train,
+            holdout_frame=fold_holdout,
+            host_slots=host_slots,
+            phage_slots=phage_slots,
+        )
+        rfe_features, rfe_categorical = select_rfe_features(
+            train_design=train_design,
+            feature_columns=feature_columns,
+            categorical_columns=categorical_columns,
+        )
+        seed_results = fit_seeds(
+            seeds=SEEDS,
+            candidate_module=candidate_module,
+            candidate_dir=candidate_dir,
+            train_design=train_design,
+            holdout_design=holdout_design,
+            rfe_features=rfe_features,
+            rfe_categorical=rfe_categorical,
+            device_type=device_type,
+            num_workers=num_workers,
+        )
+        fold_seed_rows: list[dict[str, object]] = []
+        for _seed, rows, _fi in seed_results:
+            for r in rows:
+                r["fold_id"] = fold_id
+            fold_seed_rows.extend(rows)
+        aggregated = _aggregate_fold_rows_to_pairs(fold_seed_rows)
+        all_per_row.extend(aggregated.to_dict(orient="records"))
+    per_row_df = pd.DataFrame(all_per_row)
+    pair_pred = select_pair_max_concentration_rows(per_row_df)
+    pair_pred.to_csv(output_dir / f"ch08_{arm_id}_predictions.csv", index=False)
+    LOGGER.info("CH08 variant '%s' done: %d pair-level predictions", arm_id, len(pair_pred))
+    return pair_pred
+
+
+def _bootstrap_paired_by_bacterium(
+    baseline_rows: Sequence[dict[str, object]],
+    variant_rows: Sequence[dict[str, object]],
+    *,
+    bootstrap_samples: int = BOOTSTRAP_SAMPLES,
+    bootstrap_random_state: int = BOOTSTRAP_RANDOM_STATE,
+) -> dict[str, object]:
+    """Paired bacterium-level bootstrap: baseline and variant use same resample indices.
+
+    Returns point AUC/Brier for baseline and variant plus the delta distribution with CIs.
+    Requires pair_id sets to match — we align on pair_id before resampling.
+    """
+    base_by_pair = {str(r["pair_id"]): r for r in baseline_rows}
+    var_by_pair = {str(r["pair_id"]): r for r in variant_rows}
+    common_pairs = sorted(set(base_by_pair.keys()) & set(var_by_pair.keys()))
+    if len(common_pairs) < max(len(base_by_pair), len(var_by_pair)) * 0.95:
+        LOGGER.warning(
+            "Baseline and variant share only %d pairs (base=%d, variant=%d) — delta may be biased",
+            len(common_pairs),
+            len(base_by_pair),
+            len(var_by_pair),
+        )
+    base_rows = [base_by_pair[p] for p in common_pairs]
+    var_rows = [var_by_pair[p] for p in common_pairs]
+
+    grouped_base: dict[str, list[int]] = defaultdict(list)
+    for i, r in enumerate(base_rows):
+        grouped_base[str(r["bacteria"])].append(i)
+    unit_ids = tuple(sorted(grouped_base.keys()))
+    rng = np.random.default_rng(bootstrap_random_state)
+
+    base_aucs: list[float] = []
+    base_briers: list[float] = []
+    var_aucs: list[float] = []
+    var_briers: list[float] = []
+    delta_aucs: list[float] = []
+    delta_briers: list[float] = []
+
+    progress_interval = max(1, bootstrap_samples // 5)
+    for i in range(bootstrap_samples):
+        if i == 0 or (i + 1) % progress_interval == 0 or i + 1 == bootstrap_samples:
+            LOGGER.info("Paired bootstrap progress: %d/%d", i + 1, bootstrap_samples)
+        idx = rng.integers(0, len(unit_ids), size=len(unit_ids))
+        row_indices: list[int] = []
+        for j in idx.tolist():
+            row_indices.extend(grouped_base[unit_ids[j]])
+        if not row_indices:
+            continue
+        y_base = np.array([int(base_rows[k]["label_row_binary"]) for k in row_indices])
+        y_var = np.array([int(var_rows[k]["label_row_binary"]) for k in row_indices])
+        assert np.array_equal(y_base, y_var), "Baseline and variant label vectors diverged on pair-id alignment"
+        p_base = np.array([float(base_rows[k]["predicted_probability"]) for k in row_indices])
+        p_var = np.array([float(var_rows[k]["predicted_probability"]) for k in row_indices])
+        if len(np.unique(y_base)) < 2:
+            continue
+        auc_b = float(roc_auc_score(y_base, p_base))
+        auc_v = float(roc_auc_score(y_var, p_var))
+        brier_b = float(brier_score_loss(y_base, p_base))
+        brier_v = float(brier_score_loss(y_var, p_var))
+        base_aucs.append(auc_b)
+        var_aucs.append(auc_v)
+        base_briers.append(brier_b)
+        var_briers.append(brier_v)
+        delta_aucs.append(auc_v - auc_b)
+        delta_briers.append(brier_v - brier_b)
+
+    point_base = compute_aggregate_auc_brier(base_rows)
+    point_var = compute_aggregate_auc_brier(var_rows)
+
+    def _ci(values: Sequence[float]) -> dict[str, Optional[float]]:
+        if not values:
+            return {"low": None, "high": None, "mean": None, "n_resamples": 0}
+        arr = np.asarray(values, dtype=float)
+        low, high = np.quantile(arr, [0.025, 0.975])
+        return {
+            "low": safe_round(float(low)),
+            "high": safe_round(float(high)),
+            "mean": safe_round(float(arr.mean())),
+            "n_resamples": len(values),
+        }
+
+    return {
+        "n_common_pairs": len(common_pairs),
+        "baseline": {
+            "auc_point": safe_round(point_base["auc"]),
+            "brier_point": safe_round(point_base["brier"]),
+            "auc_ci": _ci(base_aucs),
+            "brier_ci": _ci(base_briers),
+        },
+        "variant": {
+            "auc_point": safe_round(point_var["auc"]),
+            "brier_point": safe_round(point_var["brier"]),
+            "auc_ci": _ci(var_aucs),
+            "brier_ci": _ci(var_briers),
+        },
+        "delta": {
+            "auc_point": safe_round(point_var["auc"] - point_base["auc"]),
+            "brier_point": safe_round(point_var["brier"] - point_base["brier"]),
+            "auc_ci": _ci(delta_aucs),
+            "brier_ci": _ci(delta_briers),
+        },
+    }
+
+
+def prefilter_slot_topk_by_variance(
+    context: Any,
+    *,
+    slot_name: str,
+    feature_prefix: str,
+    top_k: int,
+) -> dict[str, int]:
+    """Keep the top-K features ranked by entity-level variance; drop the rest.
+
+    Rank-by-variance preserves both max-balanced features (support near 50% →
+    Var=0.25) and narrow-support features concentrated in small cliques
+    (support 10/148 → Var=0.063 — still informative). Drops near-constant
+    features (support 1 of 369 → Var=0.003) which carry no discriminative
+    signal for the task and just slow down RFE.
+
+    Deterministic (sort is stable on feature name for ties), leakage-free
+    (variance is over entities, not over training/test pairs), ablation-
+    consistent (top_k is recorded alongside delta estimates). Returns
+    `{"before": N, "after": K, "top_k": K}` for logging.
+    """
+    from lyzortx.autoresearch.train import SlotArtifact
+
+    if slot_name not in context.slot_artifacts:
+        raise KeyError(f"Slot {slot_name!r} not attached to context — call attach first")
+    art = context.slot_artifacts[slot_name]
+    frame = art.frame
+    n_entities = len(frame)
+    feature_cols = [c for c in frame.columns if c.startswith(feature_prefix)]
+    before = len(feature_cols)
+    if before <= top_k:
+        LOGGER.info("Slot %s has %d features ≤ top_k=%d; keeping all", slot_name, before, top_k)
+        return {"before": before, "after": before, "top_k": top_k, "n_entities": n_entities}
+    variances = frame[feature_cols].var(axis=0).sort_values(ascending=False, kind="stable")
+    kept = variances.head(top_k).index.tolist()
+    after = len(kept)
+    non_feature_cols = [c for c in frame.columns if c not in feature_cols]
+    new_frame = frame[non_feature_cols + kept].copy()
+    new_artifact = SlotArtifact(
+        slot_name=slot_name,
+        entity_key=art.entity_key,
+        feature_columns=tuple(kept),
+        frame=new_frame,
+    )
+    context.slot_artifacts[slot_name] = new_artifact
+    LOGGER.info(
+        "Pre-filtered slot %s by top-%d variance (n_entities=%d): %d → %d features",
+        slot_name,
+        top_k,
+        n_entities,
+        before,
+        after,
+    )
+    return {"before": before, "after": after, "top_k": top_k, "n_entities": n_entities}
+
+
+def load_canonical_baseline_predictions() -> pd.DataFrame:
+    if not CH04_CANONICAL_PREDICTIONS.exists():
+        raise FileNotFoundError(
+            f"CH04 canonical predictions not found at {CH04_CANONICAL_PREDICTIONS}; "
+            f"CH08 reuses these as the baseline arm. Run CH04 first."
+        )
+    df = pd.read_csv(CH04_CANONICAL_PREDICTIONS)
+    LOGGER.info("Loaded CH04 canonical baseline predictions: %d rows", len(df))
+    return df
+
+
+def run_ch08_eval(
+    *,
+    device_type: str,
+    output_dir: Path,
+    cache_dir: Path,
+    candidate_dir: Path,
+    phage_kmer_slot_path: Path = DEFAULT_PHAGE_KMER_SLOT_PATH,
+    host_omp_kmer_slot_path: Path = DEFAULT_HOST_OMP_KMER_SLOT_PATH,
+    num_workers: int = 3,
+    drop_high_titer_only_positives: bool = True,
+    max_folds: Optional[int] = None,
+) -> dict[str, object]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    start_time = datetime.now(timezone.utc)
+    LOGGER.info(
+        "CH08 wave-2 re-audit starting at %s (num_workers=%d, drop_high_titer_only=%s)",
+        start_time.isoformat(),
+        num_workers,
+        drop_high_titer_only_positives,
+    )
+
+    # Baseline reused from CH04 canonical.
+    baseline_df = load_canonical_baseline_predictions()
+    baseline_rows = baseline_df.to_dict(orient="records")
+
+    # Arm SX12 — extend phage_slots with MORINIERE_SLOT_NAME.
+    sx12_phage_slots = tuple(BASE_PHAGE_SLOTS) + (MORINIERE_SLOT_NAME,)
+
+    def _attach_sx12_slot(ctx: Any) -> None:
+        attach_moriniere_slot(ctx, phage_kmer_slot_path)
+        prefilter_slot_topk_by_variance(
+            ctx,
+            slot_name=MORINIERE_SLOT_NAME,
+            feature_prefix="phage_moriniere_kmer__",
+            top_k=KMER_TOPK_PER_SLOT,
+        )
+
+    sx12_pair_preds = run_ch04_variant(
+        arm_id=ARM_SX12,
+        phage_slots=sx12_phage_slots,
+        host_slots=tuple(BASE_HOST_SLOTS),
+        slot_attach_fns=[_attach_sx12_slot],
+        device_type=device_type,
+        cache_dir=cache_dir,
+        candidate_dir=candidate_dir,
+        output_dir=output_dir,
+        num_workers=num_workers,
+        drop_high_titer_only_positives=drop_high_titer_only_positives,
+    )
+    if max_folds is not None:
+        LOGGER.warning("max_folds not passed through — CH08 always runs all 10 folds per arm")
+
+    sx12_report = _bootstrap_paired_by_bacterium(baseline_rows, sx12_pair_preds.to_dict(orient="records"))
+    with open(output_dir / "ch08_sx12_delta.json", "w", encoding="utf-8") as f:
+        json.dump({"arm": ARM_SX12, "extra_slot": MORINIERE_SLOT_NAME, **sx12_report}, f, indent=2)
+    LOGGER.info(
+        "SX12 delta: AUC %s (CI %s, %s), Brier %s (CI %s, %s), n_common=%d",
+        sx12_report["delta"]["auc_point"],
+        sx12_report["delta"]["auc_ci"]["low"],
+        sx12_report["delta"]["auc_ci"]["high"],
+        sx12_report["delta"]["brier_point"],
+        sx12_report["delta"]["brier_ci"]["low"],
+        sx12_report["delta"]["brier_ci"]["high"],
+        sx12_report["n_common_pairs"],
+    )
+
+    # Arm SX13 marginal — extend host_slots with host_omp_kmer. Per plan.yml: "the
+    # marginal arm only (cross_term, path1_cluster added no additional lift in SX13 and
+    # can be skipped)".
+    sx13_host_slots = tuple(BASE_HOST_SLOTS) + (HOST_OMP_KMER_SLOT,)
+
+    def _attach_sx13_slot(ctx: Any) -> None:
+        attach_csv_slot(
+            context=ctx,
+            features_path=host_omp_kmer_slot_path,
+            slot_name=HOST_OMP_KMER_SLOT,
+            feature_prefix=HOST_OMP_KMER_PREFIX,
+            entity_key="bacteria",
+        )
+        prefilter_slot_topk_by_variance(
+            ctx,
+            slot_name=HOST_OMP_KMER_SLOT,
+            feature_prefix=HOST_OMP_KMER_PREFIX,
+            top_k=KMER_TOPK_PER_SLOT,
+        )
+
+    sx13_pair_preds = run_ch04_variant(
+        arm_id=ARM_SX13,
+        phage_slots=tuple(BASE_PHAGE_SLOTS),
+        host_slots=sx13_host_slots,
+        slot_attach_fns=[_attach_sx13_slot],
+        device_type=device_type,
+        cache_dir=cache_dir,
+        candidate_dir=candidate_dir,
+        output_dir=output_dir,
+        num_workers=num_workers,
+        drop_high_titer_only_positives=drop_high_titer_only_positives,
+    )
+    sx13_report = _bootstrap_paired_by_bacterium(baseline_rows, sx13_pair_preds.to_dict(orient="records"))
+    with open(output_dir / "ch08_sx13_delta.json", "w", encoding="utf-8") as f:
+        json.dump({"arm": ARM_SX13, "extra_slot": HOST_OMP_KMER_SLOT, **sx13_report}, f, indent=2)
+    LOGGER.info(
+        "SX13 delta: AUC %s (CI %s, %s), Brier %s (CI %s, %s), n_common=%d",
+        sx13_report["delta"]["auc_point"],
+        sx13_report["delta"]["auc_ci"]["low"],
+        sx13_report["delta"]["auc_ci"]["high"],
+        sx13_report["delta"]["brier_point"],
+        sx13_report["delta"]["brier_ci"]["low"],
+        sx13_report["delta"]["brier_ci"]["high"],
+        sx13_report["n_common_pairs"],
+    )
+
+    summary = pd.DataFrame(
+        [
+            {
+                "arm": ARM_BASELINE,
+                "extra_slot": None,
+                "auc_point": sx12_report["baseline"]["auc_point"],
+                "brier_point": sx12_report["baseline"]["brier_point"],
+                "auc_low": sx12_report["baseline"]["auc_ci"]["low"],
+                "auc_high": sx12_report["baseline"]["auc_ci"]["high"],
+                "brier_low": sx12_report["baseline"]["brier_ci"]["low"],
+                "brier_high": sx12_report["baseline"]["brier_ci"]["high"],
+                "delta_auc": None,
+                "delta_auc_low": None,
+                "delta_auc_high": None,
+                "delta_brier": None,
+                "delta_brier_low": None,
+                "delta_brier_high": None,
+            },
+            {
+                "arm": ARM_SX12,
+                "extra_slot": MORINIERE_SLOT_NAME,
+                "auc_point": sx12_report["variant"]["auc_point"],
+                "brier_point": sx12_report["variant"]["brier_point"],
+                "auc_low": sx12_report["variant"]["auc_ci"]["low"],
+                "auc_high": sx12_report["variant"]["auc_ci"]["high"],
+                "brier_low": sx12_report["variant"]["brier_ci"]["low"],
+                "brier_high": sx12_report["variant"]["brier_ci"]["high"],
+                "delta_auc": sx12_report["delta"]["auc_point"],
+                "delta_auc_low": sx12_report["delta"]["auc_ci"]["low"],
+                "delta_auc_high": sx12_report["delta"]["auc_ci"]["high"],
+                "delta_brier": sx12_report["delta"]["brier_point"],
+                "delta_brier_low": sx12_report["delta"]["brier_ci"]["low"],
+                "delta_brier_high": sx12_report["delta"]["brier_ci"]["high"],
+            },
+            {
+                "arm": ARM_SX13,
+                "extra_slot": HOST_OMP_KMER_SLOT,
+                "auc_point": sx13_report["variant"]["auc_point"],
+                "brier_point": sx13_report["variant"]["brier_point"],
+                "auc_low": sx13_report["variant"]["auc_ci"]["low"],
+                "auc_high": sx13_report["variant"]["auc_ci"]["high"],
+                "brier_low": sx13_report["variant"]["brier_ci"]["low"],
+                "brier_high": sx13_report["variant"]["brier_ci"]["high"],
+                "delta_auc": sx13_report["delta"]["auc_point"],
+                "delta_auc_low": sx13_report["delta"]["auc_ci"]["low"],
+                "delta_auc_high": sx13_report["delta"]["auc_ci"]["high"],
+                "delta_brier": sx13_report["delta"]["brier_point"],
+                "delta_brier_low": sx13_report["delta"]["brier_ci"]["low"],
+                "delta_brier_high": sx13_report["delta"]["brier_ci"]["high"],
+            },
+        ]
+    )
+    summary.to_csv(output_dir / "ch08_summary.csv", index=False)
+    LOGGER.info("CH08 summary:\n%s", summary.to_string(index=False))
+
+    combined = {
+        "task_id": "CH08",
+        "scorecard": "AUC + Brier (paired bacterium-level bootstrap)",
+        "drop_high_titer_only_positives": drop_high_titer_only_positives,
+        "sx12": sx12_report,
+        "sx13": sx13_report,
+        "elapsed_seconds": round((datetime.now(timezone.utc) - start_time).total_seconds(), 1),
+    }
+    with open(output_dir / "ch08_combined_summary.json", "w", encoding="utf-8") as f:
+        json.dump(combined, f, indent=2)
+    return combined
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device-type", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--candidate-dir", type=Path, default=DEFAULT_CANDIDATE_DIR)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--phage-kmer-slot-path", type=Path, default=DEFAULT_PHAGE_KMER_SLOT_PATH)
+    parser.add_argument("--host-omp-kmer-slot-path", type=Path, default=DEFAULT_HOST_OMP_KMER_SLOT_PATH)
+    parser.add_argument("--num-workers", type=int, default=3)
+    parser.add_argument(
+        "--drop-high-titer-only-positives",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+    run_ch08_eval(
+        device_type=args.device_type,
+        output_dir=args.output_dir,
+        cache_dir=args.cache_dir,
+        candidate_dir=args.candidate_dir,
+        phage_kmer_slot_path=args.phage_kmer_slot_path,
+        host_omp_kmer_slot_path=args.host_omp_kmer_slot_path,
+        num_workers=args.num_workers,
+        drop_high_titer_only_positives=args.drop_high_titer_only_positives,
+    )
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = [
+    "run_ch08_eval",
+]

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -1590,3 +1590,182 @@ well without any specific training pair.
   Brier and CIs.
 - `.../ch07_cell_distribution.png` — histogram of per-cell AUC with mean and median
   markers.
+
+### 2026-04-21 05:37 CEST: CH08 — Wave-2 feature-family re-audit under CHISEL frame
+
+#### Executive summary
+
+Re-audited SPANDEX wave-2 nulls (SX12 Moriniere 815 phage 5-mers;
+SX13 host OMP 5546 5-mers) under the CHISEL training frame: per-row binary labels,
+`pair_concentration__log10_pfu_ml` feature, all-pairs only (no per-phage blending),
+neat-only positive filter, 10-fold bacteria-axis CV over the 369×96 Guelin panel. Each
+kmer slot was pre-filtered to the **top-100 features by binary variance** before RFE
+to keep per-fold wallclock tractable on a 281K-row training frame (unfiltered RFE on
+1281 total features had run at ~60 min/fold — 20 folds = 20 h+). Paired bacterium-level
+bootstrap (1000 resamples) on the CH04-canonical baseline predictions vs each arm's
+variant predictions:
+
+| Arm | Extra slot | Arm AUC | Arm Brier | Δ AUC (CI) | Δ Brier (CI) | Knowledge-unit verdict |
+|---|---|---|---|---|---|---|
+| baseline | — | 0.8217 | 0.1435 | — | — | — |
+| sx12 | phage_moriniere_kmer (top-100 var) | **0.8333** | 0.1415 | **+1.16 pp [+0.82, +1.51]** | **−0.20 pp [−0.41, ≈0]** | **`kmer-receptor-expansion-neutral` reopens** |
+| sx13 | host_omp_kmer (top-100 var) | 0.8234 | 0.1423 | +0.17 pp [+0.03, +0.31] | −0.12 pp [−0.20, −0.06] | **`host-omp-variation-unpredictive` reopens** |
+
+Both arms land with delta CIs disjoint from zero, so per plan.yml's "CRITIC RESPONSE: if
+either re-audit shows non-null lift (CI disjoint from zero), this reopens the wave-2
+feature-family conclusions … Do not suppress unexpected positives", **both wave-2
+null knowledge units must be reverted from validated-null to open**. SX12's effect
+size (+1.16 pp) is ~7× SX13's (+0.17 pp) — the Moriniere phage k-mers contribute a
+meaningful signal under CHISEL that they did not contribute under SPANDEX; the host
+OMP k-mers still barely move the needle but the CI is technically disjoint.
+
+#### Bug caught during CH08 development
+
+The initial CH08 run silently dropped BOTH extra slots because
+`ch04_parallel.FEATURE_COLUMN_PREFIXES` was a hardcoded allowlist of slot column
+prefixes that did not include `phage_moriniere_kmer__` or `host_omp_kmer__`. The
+slots were attached to the `context.slot_artifacts` dict, the columns showed up in
+the design matrix, but `prepare_fold_design_matrices` filtered `feature_columns` by
+the hardcoded prefix tuple, so the kmer columns never reached RFE or LightGBM. The
+symptom was SX13 predictions bit-identical to the CH04 baseline (max pred diff 0.0)
+and SX12 predictions differing only via deterministic dataframe-ordering artifacts
+that happened to bias probabilities downstream (spurious +1.0 pp point estimate
+driven entirely by column-order side effects). Fix: added `host_omp_kmer__`,
+`host_omp_cluster__`, and `phage_moriniere_kmer__` to `FEATURE_COLUMN_PREFIXES` with
+a docstring calling out the allowlist contract. Re-running under the fix produced
+the real numbers above.
+
+This is a canonical silent-fail shape — slot attached, columns present in DataFrame,
+model never sees them. If a future ticket adds a new slot family with its own
+prefix, the onus is on the implementer to register the prefix in
+`FEATURE_COLUMN_PREFIXES`. Consider hoisting that allowlist into the slot registry
+so attaching a slot automatically declares its prefix.
+
+#### Why pre-filtering to top-100 by variance
+
+The SX12 slot has 815 5-mers; the SX13 slot has 5546 5-mers. RFECV (step=0.1, cv=5
+internal folds, on 281K-row training frames) does ~41 iterations for 788 input
+features, each fitting LightGBM 5 times → ~60 minutes per CV fold. 10 folds per arm
+× 2 arms × 60 min = 20 h wallclock, violating plan.yml's "estimate before running
+and confirm wallclock is feasible". Top-K-by-variance pre-filtering (K=100) rank-
+orders features by entity-level binary variance and keeps the K most-variable. This
+preserves:
+
+- sparse receptor-class-specific kmers (support ≈ 10% of phages → binary variance
+  0.09, rank-competitive with medium-support kmers)
+- maximally-balanced OMP kmers (support ≈ 50% of bacteria → variance 0.25, the
+  theoretical max for binary features)
+
+It drops near-constant kmers (support 1/369 or 368/369 → variance → 0) which
+contribute no discriminative signal anyway. Pre-filter is deterministic, leakage-
+free (computed over entities, not over training/test pair splits), runs once before
+any fold split. Arm AUC deltas are measured under the pre-filter, so the arm-level
+conclusion "does any meaningful subset of the kmer slot help?" is answered without
+the 20h-wallclock cost of the unfiltered RFE. Caveat: the pre-filter is NOT identical
+to the SPANDEX SX12/SX13 runs, which saw the full 815 / 5546 kmers. So the CH08
+deltas are not direct apples-to-apples replacements for SPANDEX SX12/SX13 deltas —
+they're CHISEL-frame estimates on the top-100-variance subset.
+
+#### SX12 result interpretation
+
+SX12 reopens: **+1.16 pp [+0.82, +1.51] AUC, −0.20 pp Brier, CIs disjoint from zero**.
+Under SPANDEX (pair-level any_lysis training, per-phage blending enabled, pre-fix
+cv_group folds, full 815 kmers), SX12 was null: "+0.23 pp AUC, CIs overlap baseline"
+(`kmer-receptor-expansion-neutral`). Under CHISEL (per-row binary, concentration
+feature, per-phage retired, fixed cv_group folds, top-100 variance-filtered kmers),
+the same slot contributes a statistically significant lift. Several plausible
+mechanisms for the shift; the data does not decide among them:
+
+1. **Per-row training exposes concentration-dependent signal** the pair-level rollup
+   erased. Kmers that predict graded dilution response may correlate with receptor-
+   class strength in a way pair-level labels averaged out.
+2. **Pre-filter to top-100 variance** happens to select the receptor-class-
+   discriminative kmers and drops ~700 near-constant features that just added noise
+   to RFE under SPANDEX. Note this is consistent with Arm 3's finding: per-class
+   Moriniere features help once aggregated appropriately — here "aggregation" is the
+   variance-rank filter keeping the features that matter.
+3. **cv_group fold fix** removed ANI-duplicate leakage; both baseline and variant
+   gain under the fix, but the variant's ability to exploit receptor-class signal
+   may benefit differently than baseline's ability to memorize host-side priors.
+4. **Per-phage blending retired** shifts attribution from bacterium-level memorization
+   to all-pairs mechanism; SX12 kmers may carry phage-mechanism signal that per-phage
+   blending was otherwise double-counting.
+
+The SPANDEX `kmer-receptor-expansion-neutral` unit framed SX12 as null on mechanism-
+level grounds ("k-mers were selected to discriminate receptor class on K-12 … they
+predict what we already know, not what we need"). That framing is still directionally
+right — the +1.16 pp lift doesn't close the BASEL bacteria-axis 10-pp deficit or the
+panel-size-ceiling gap — but the unit needs updating: SX12 kmers are NOT null under
+CHISEL, they're a modest additive feature-family lift.
+
+**Does this supersede CH06 Arm 3?** No. CH06 Arm 3 (per-receptor k-mer-fraction
+vectors, 13-dim, panel-independent) beat CH06 Arm 2 and Arm 4 on the BASEL
+deployability axis (+4.36 pp zero-vec BASEL phage-axis). SX12 kmer slot here is a
+different feature shape (100 individual k-mer presence/absence features, not per-
+class aggregates) and is evaluated on the Guelin bacteria-axis, not BASEL. The two
+findings are complementary: Arm 3 says "aggregate to per-class fractions for panel
+independence"; CH08 SX12 says "even the raw kmers, if variance-filtered, give a
+~1 pp lift under CHISEL". A future experiment could test Arm 3 + SX12-kmer jointly,
+but plan.yml has no such ticket and the Arm 3 + Arm 3 → canonical migration is
+higher priority.
+
+#### SX13 result interpretation
+
+SX13 reopens: **+0.17 pp [+0.03, +0.31] AUC, −0.12 pp Brier, CIs barely disjoint
+from zero**. Under SPANDEX, SX13 was null across four arms (marginal, cross_term,
+path1_cluster, and baseline — all within ±0.4 pp). Under CHISEL, the marginal arm
+shows a tiny CI-disjoint lift, but 0.17 pp is far smaller than any ordinary signal
+and smaller than the typical run-to-run variance on other tickets (±0.5 pp).
+
+The underlying `host-omp-variation-unpredictive` knowledge unit framed SX13 as
+null because "host-range variance lives downstream of OMP recognition" and the
+loop-level kmer escalation did not rescue prediction. That framing is still
+essentially correct — +0.17 pp is not the "host OMP variation actually predicts
+lysis" story. Likely mechanism: top-100 variance-filtered OMP kmers include kmers
+that happen to correlate with phylogroup (lineage-confounding effect similar to
+`defense-lineage-confounding`), and the filter captured a noise-level amount of
+host-phylogroup marginal information. The Brier improvement of 0.12 pp is barely
+detectable.
+
+Update `host-omp-variation-unpredictive` with the CHISEL-frame note: under the
+top-100 variance-filtered subset, the host OMP kmer slot contributes a tiny but
+CI-disjoint +0.17 pp lift; this is consistent with phylogroup-correlated lineage
+signal, not with OMP-specific host-range prediction.
+
+#### Compute
+
+6938 s (~1.9 h) on laptop after orphan subprocess cleanup (earlier runs left
+residual RFECV worker pools that starved CPU and made fold wallclocks meaningless).
+SX12 arm: 10 folds × ~2.4 min = 24 min; SX13 arm: 10 folds × ~2.8 min = 28 min;
+bootstrap: ~1 min per arm. Full determinism (SEEDS, RFE seed, pre-filter rank) —
+rerunning under the same code path reproduces the numbers bit-for-bit.
+
+#### Open follow-ups
+
+1. **Hoist the slot-prefix allowlist into a slot registry** so attaching a slot
+   auto-declares its prefix. The current `FEATURE_COLUMN_PREFIXES` allowlist bug
+   pattern will recur otherwise.
+2. **Ablate pre-filter top-K** — repeat SX12 at K=50, K=200, K=400 to check whether
+   the +1.16 pp is K-stable or K-sensitive. If K-sensitive, the lift is
+   filter-artefactual and should be demoted.
+3. **SX13 phylogroup-confound check** — permute the OMP kmer values within
+   phylogroup and re-run; if the +0.17 pp lift survives, the effect is
+   OMP-specific; if it vanishes, it's phylogroup-marginal noise.
+4. **CHISEL-frame comparison vs SX12/SX13 unfiltered** — nice-to-have if compute
+   budget allows, but the wallclock (20 h+) is prohibitive without either
+   cell-level parallelism or a faster RFE variant.
+
+#### Artifacts
+
+- `lyzortx/pipeline/autoresearch/ch08_wave2_reaudit.py` — eval driver, pre-filter,
+  paired-bootstrap helpers.
+- `lyzortx/pipeline/autoresearch/ch04_parallel.py` — FEATURE_COLUMN_PREFIXES fix
+  adding `host_omp_kmer__`, `host_omp_cluster__`, `phage_moriniere_kmer__`.
+- `lyzortx/tests/test_ch08_wave2_reaudit.py` — unit tests for paired bootstrap.
+- `lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_summary.csv` — one row per arm
+  (baseline, sx12, sx13) with AUC/Brier point + CIs and delta CIs.
+- `.../ch08_combined_summary.json` — full report (task_id, scorecard, per-arm
+  paired-bootstrap output with baseline/variant/delta blocks).
+- `.../ch08_sx12_delta.json`, `.../ch08_sx13_delta.json` — per-arm delta reports.
+- `.../ch08_sx12_predictions.csv`, `.../ch08_sx13_predictions.csv` — per-arm
+  pair-level predictions (max-concentration) for audit.

--- a/lyzortx/tests/test_ch08_wave2_reaudit.py
+++ b/lyzortx/tests/test_ch08_wave2_reaudit.py
@@ -1,0 +1,60 @@
+"""Tests for CH08 paired bootstrap and slot attachment plumbing."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from lyzortx.pipeline.autoresearch.ch08_wave2_reaudit import _bootstrap_paired_by_bacterium
+
+
+def _make_pair_rows(n_pairs: int, seed: int, signal_boost: float = 0.0) -> list[dict]:
+    rng = np.random.default_rng(seed)
+    labels = rng.integers(0, 2, size=n_pairs)
+    base = rng.uniform(0.1, 0.5, size=n_pairs)
+    preds = np.clip(base + signal_boost * labels, 0.0, 1.0)
+    return [
+        {
+            "pair_id": f"b{i // 5}__p{i}",
+            "bacteria": f"b{i // 5}",
+            "phage": f"p{i}",
+            "label_row_binary": int(labels[i]),
+            "predicted_probability": float(preds[i]),
+        }
+        for i in range(n_pairs)
+    ]
+
+
+def test_paired_bootstrap_returns_baseline_variant_and_delta() -> None:
+    baseline = _make_pair_rows(200, seed=1, signal_boost=0.2)
+    variant = _make_pair_rows(200, seed=1, signal_boost=0.35)  # stronger signal
+    report = _bootstrap_paired_by_bacterium(baseline, variant, bootstrap_samples=50)
+    assert report["n_common_pairs"] == 200
+    assert report["baseline"]["auc_point"] is not None
+    assert report["variant"]["auc_point"] is not None
+    # Variant boost should give variant > baseline on point AUC.
+    assert report["variant"]["auc_point"] >= report["baseline"]["auc_point"]
+    # Delta has CI around the point estimate.
+    assert report["delta"]["auc_ci"]["low"] is not None
+    assert report["delta"]["auc_ci"]["high"] is not None
+    assert report["delta"]["auc_ci"]["low"] <= report["delta"]["auc_point"]
+    assert report["delta"]["auc_point"] <= report["delta"]["auc_ci"]["high"]
+
+
+def test_paired_bootstrap_null_case_delta_centered_near_zero() -> None:
+    baseline = _make_pair_rows(300, seed=7, signal_boost=0.25)
+    # Identical variant → delta should center at 0 exactly.
+    variant = [dict(r) for r in baseline]
+    report = _bootstrap_paired_by_bacterium(baseline, variant, bootstrap_samples=100)
+    assert abs(report["delta"]["auc_point"]) < 1e-9
+    assert abs(report["delta"]["brier_point"]) < 1e-9
+    assert abs(report["delta"]["auc_ci"]["low"] or 0.0) < 1e-6
+    assert abs(report["delta"]["auc_ci"]["high"] or 0.0) < 1e-6
+
+
+def test_paired_bootstrap_on_nonoverlapping_pairs_uses_intersection() -> None:
+    baseline = _make_pair_rows(100, seed=2, signal_boost=0.2)
+    variant = _make_pair_rows(100, seed=2, signal_boost=0.2)
+    # Drop half of variant pairs; bootstrap must restrict to common pairs.
+    variant = variant[:50]
+    report = _bootstrap_paired_by_bacterium(baseline, variant, bootstrap_samples=25)
+    assert report["n_common_pairs"] == 50

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ matplotlib==3.10.8
 mdmparis-defense-finder==2.0.1
 notebook==7.5.5
 numpy==2.4.2
+openpyxl==3.1.5
 optuna==4.8.0
 pandas==3.0.1
 pre-commit==4.5.1


### PR DESCRIPTION
## Summary

Re-audits SPANDEX wave-2 nulls under the CHISEL training frame. Paired bacterium-level bootstrap (1000 resamples) against the CH04 canonical baseline predictions:

| Arm | Extra slot | AUC | Brier | Δ AUC (CI) | Δ Brier (CI) |
|---|---|---|---|---|---|
| baseline | — | 0.8217 | 0.1435 | — | — |
| **sx12** | phage_moriniere_kmer (top-100 var) | **0.8333** | 0.1415 | **+1.16 pp [+0.82, +1.51]** | **−0.20 pp [−0.41, ≈0]** |
| sx13 | host_omp_kmer (top-100 var) | 0.8234 | 0.1423 | +0.17 pp [+0.03, +0.31] | −0.12 pp [−0.20, −0.06] |

**Both wave-2 nulls REOPEN under CHISEL** — both delta CIs disjoint from zero. Per plan.yml's "Do not suppress unexpected positives".

- `kmer-receptor-expansion-neutral`: needs revision. SX12 kmers DO contribute under CHISEL (+1.16 pp).
- `host-omp-variation-unpredictive`: needs CHISEL-frame caveat. SX13 effect is tiny and consistent with phylogroup-correlated lineage noise rather than OMP-specific host-range signal.

## Bug fix included

Initial CH08 run revealed that `ch04_parallel.FEATURE_COLUMN_PREFIXES` was a hardcoded allowlist that didn't include `host_omp_kmer__` or `phage_moriniere_kmer__`. The slots were attached to the context and columns were in the design matrix, but `prepare_fold_design_matrices` silently filtered them out of `feature_columns`. Symptom: SX13 predictions bit-identical to CH04 baseline; SX12 differed only via deterministic dataframe-ordering artefacts.

Fix: registered all three prefixes (`host_omp_kmer__`, `host_omp_cluster__`, `phage_moriniere_kmer__`) in `FEATURE_COLUMN_PREFIXES` with a docstring calling out the allowlist contract. Open follow-up (notebook): hoist the allowlist into the slot registry so attaching a slot auto-declares its prefix.

## Why top-100 variance pre-filter

RFECV (step=0.1, cv=5) on 281K rows × 1281 features = ~60 min/fold × 20 folds = 20 h wallclock, infeasible per plan.yml's "estimate before running and confirm wallclock is feasible" criterion. Top-K-by-variance keeps sparse receptor-class-specific kmers (support ≈ 10% → var 0.09) AND maximally-balanced OMP kmers (support ≈ 50% → var 0.25), dropping only near-constant features that contribute no discriminative signal. Deterministic, leakage-free (computed over entities not over train/test splits), ablation-consistent. Caveat: CH08 deltas are CHISEL-frame estimates on the top-100-variance subset — NOT apples-to-apples against SPANDEX SX12/SX13 which saw the full 815/5546 kmers. Notebook flags this as an open follow-up (ablate K).

## Compute

6938 s (~1.9 h) on laptop after cleaning up orphan RFECV subprocess pools from killed earlier runs. SX12 ~24 min; SX13 ~28 min; bootstrap ~1 min/arm. Fully deterministic.

Closes #449

## Test plan

- [x] Unit tests for paired bootstrap (3 tests pass)
- [x] Full 10-fold × 2-arm run completed, all artifacts materialized
- [x] Bug-fix verified: SX12 now sees 566 numeric features in RFE (was 466 pre-fix with kmer cols silently dropped); predictions now genuinely differ from baseline
- [x] Delta CIs computed via paired bacterium-level bootstrap (1000 resamples, 1000 used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)