### PR TITLE
Amend chisel-baseline: disclose label-shift mechanism in filter adoption

### DIFF
--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -210,17 +210,33 @@ Architecture choices, calibration, and performance bounds.
     removing the bacterium-level memorization head that contributed to CH02's AUC under the bacteria-axis setup. The
     CH06-followup filter adoption is the fourth adjustment: CH09 Arm 3 showed that dropping Guelin positives occurring
     only at neat (the "clearing at high titer, possibly non-productive" candidate per Gaborieau 2024) yields a cleaner
-    discrimination surface. The improvement is discrimination-only (AUC/Brier); ECE did NOT drop under the filter (+0.7
-    pp), consistent with the filter sharpening the decision surface rather than removing systematically over-inflated
-    predictions — see CH09 notebook entry for the directional-miss analysis. Diagnostic decomposition (CH02 → CH04
-    pre-filter): evaluation label distribution was nearly unchanged (27.4% positive at max-conc vs 27.6% pair-level
-    any_lysis — ~47 pair labels flip), so the drop was training-side, not evaluation-side. Concentration feature is the
-    #4 ranked feature by mean LightGBM importance (280.5 under the post-filter canonical, 328.7 pre-filter), retained by
-    RFE in all 30 fold × seed fits. Subsequent CHISEL tickets (CH05 phage-axis, CH07 both-axis, CH08 feature re-audit,
-    CH09 calibration layer) all anchor to the post-filter canonical. The filter default can be reversed via
-    `--no-drop-high-titer-only-positives` for sensitivity analysis. Canonical artifacts:
-    lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json, ch04_predictions.csv (pair-level),
-    ch04_per_row_predictions.csv (per-row), and ch04_feature_importance.csv.*
+    discrimination surface. **The headline +1.3 pp AUC / −3.2 pp Brier vs pre-filter is NOT a pure model-quality gain**
+    — a 2026-04-21 post-hoc case-by-case decomposition (`.scratch/chisel_review/caseXcase_chisel.py`) shows that the
+    filter flips 4,428 pair eval labels 1→0 (12.6% of the 35,266-pair eval set). Mechanism: evaluation takes the label
+    from the pair's max-concentration observation; the filter removes the neat-only positive replicate in Guelin
+    training data and the same removal leaves a 0 replicate standing at eval time, so the pair appears as a trivial
+    negative instead of a narrow positive. The 2×2 decomposition on matched pairs: (prior model / prior labels) = 0.8084
+    AUC / 0.1750 Brier (headline); (prior model / canonical labels) = 0.8244 / 0.1916 (label-shift alone: +1.60 pp AUC
+    trivialization); (canonical model / prior labels) = 0.7937 / 0.1652 (model alone: **−1.47 pp AUC regression, −0.98
+    pp Brier improvement**); (canonical model / canonical labels) = 0.8217 / 0.1435 (file headline). On matched labels,
+    the filter-trained model has LOWER discrimination than the pre-filter model; the headline AUC gain is entirely a
+    population-easier artifact. Brier gain partially survives the decomposition (−0.98 pp genuine) because removing
+    neat-only positives from training makes the model predict lower probability on those pairs, which is correct once
+    the eval label flips to 0. ECE did NOT drop under the filter (+0.7 pp), consistent with the filter sharpening the
+    decision surface on the remaining (non-neat-only) positives rather than removing systematically over-inflated
+    predictions — see CH09 notebook entry for the directional-miss analysis. The filter adoption is still justified
+    (Gaborieau 2024 Methods explicitly admits clearing at high titer can be non-productive — we're correcting a
+    label-policy defect, not a model defect; and the −0.98 pp Brier improvement survives decomposition) but future
+    CHISEL comparisons must disclose this label-shift explicitly and cite the on-matched-labels AUC (0.7937 vs 0.8084)
+    when making model-quality claims. The (CH02 → CH04 pre-filter) diagnostic decomposition was done on the pre-filter
+    labels where evaluation distribution was nearly unchanged (27.4% positive at max-conc vs 27.6% pair-level any_lysis
+    — ~47 pair labels flip from the per-row vs any_lysis training-unit change alone), so the CH02 → CH04 pre-filter ΔAUC
+    is still a training-side signal. Concentration feature is the #4 ranked feature by mean LightGBM importance (280.5
+    under the post-filter canonical, 328.7 pre-filter), retained by RFE in all 30 fold × seed fits. Subsequent CHISEL
+    tickets (CH05 phage-axis, CH07 both-axis, CH08 feature re-audit, CH09 calibration layer) all anchor to the
+    post-filter canonical. The filter default can be reversed via `--no-drop-high-titer-only-positives` for sensitivity
+    analysis. Canonical artifacts: lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json,
+    ch04_predictions.csv (pair-level), ch04_per_row_predictions.csv (per-row), and ch04_feature_importance.csv.*
 - **`spandex-final-baseline`**: HISTORICAL (SPANDEX-era). Superseded as the active canonical by chisel-baseline (CH04).
   SPANDEX final configuration — GT03 all_gates_rfe + AX02 per-phage blending on SX05-corrected MLC 0-3 labels, 10-fold
   CV bacteria-axis on the 369×96 panel: **AUC 0.8699 [0.8570, 0.8819], Brier 0.1248 [0.1187, 0.1309]** within-panel,

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -391,13 +391,38 @@ themes:
           filter adoption is the fourth adjustment: CH09 Arm 3 showed that dropping
           Guelin positives occurring only at neat (the "clearing at high titer, possibly
           non-productive" candidate per Gaborieau 2024) yields a cleaner discrimination
-          surface. The improvement is discrimination-only (AUC/Brier); ECE did NOT drop
-          under the filter (+0.7 pp), consistent with the filter sharpening the decision
-          surface rather than removing systematically over-inflated predictions — see
-          CH09 notebook entry for the directional-miss analysis. Diagnostic decomposition
-          (CH02 → CH04 pre-filter): evaluation label distribution was nearly unchanged
+          surface. **The headline +1.3 pp AUC / −3.2 pp Brier vs pre-filter is NOT a
+          pure model-quality gain** — a 2026-04-21 post-hoc case-by-case decomposition
+          (`.scratch/chisel_review/caseXcase_chisel.py`) shows that the filter flips
+          4,428 pair eval labels 1→0 (12.6% of the 35,266-pair eval set). Mechanism:
+          evaluation takes the label from the pair's max-concentration observation;
+          the filter removes the neat-only positive replicate in Guelin training data
+          and the same removal leaves a 0 replicate standing at eval time, so the pair
+          appears as a trivial negative instead of a narrow positive. The 2×2 decomposition
+          on matched pairs: (prior model / prior labels) = 0.8084 AUC / 0.1750 Brier
+          (headline); (prior model / canonical labels) = 0.8244 / 0.1916 (label-shift
+          alone: +1.60 pp AUC trivialization); (canonical model / prior labels) = 0.7937
+          / 0.1652 (model alone: **−1.47 pp AUC regression, −0.98 pp Brier improvement**);
+          (canonical model / canonical labels) = 0.8217 / 0.1435 (file headline).
+          On matched labels, the filter-trained model has LOWER discrimination than
+          the pre-filter model; the headline AUC gain is entirely a population-easier
+          artifact. Brier gain partially survives the decomposition (−0.98 pp genuine)
+          because removing neat-only positives from training makes the model predict
+          lower probability on those pairs, which is correct once the eval label flips
+          to 0. ECE did NOT drop under the filter (+0.7 pp), consistent with the filter
+          sharpening the decision surface on the remaining (non-neat-only) positives
+          rather than removing systematically over-inflated predictions — see CH09
+          notebook entry for the directional-miss analysis. The filter adoption is
+          still justified (Gaborieau 2024 Methods explicitly admits clearing at high
+          titer can be non-productive — we're correcting a label-policy defect, not
+          a model defect; and the −0.98 pp Brier improvement survives decomposition)
+          but future CHISEL comparisons must disclose this label-shift explicitly and
+          cite the on-matched-labels AUC (0.7937 vs 0.8084) when making model-quality
+          claims. The (CH02 → CH04 pre-filter) diagnostic decomposition was done on
+          the pre-filter labels where evaluation distribution was nearly unchanged
           (27.4% positive at max-conc vs 27.6% pair-level any_lysis — ~47 pair labels
-          flip), so the drop was training-side, not evaluation-side. Concentration
+          flip from the per-row vs any_lysis training-unit change alone), so the CH02
+          → CH04 pre-filter ΔAUC is still a training-side signal. Concentration
           feature is the #4 ranked feature by mean LightGBM importance (280.5 under the
           post-filter canonical, 328.7 pre-filter), retained by RFE in all 30 fold × seed
           fits. Subsequent CHISEL tickets (CH05 phage-axis, CH07 both-axis, CH08 feature

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -1769,3 +1769,101 @@ rerunning under the same code path reproduces the numbers bit-for-bit.
 - `.../ch08_sx12_delta.json`, `.../ch08_sx13_delta.json` — per-arm delta reports.
 - `.../ch08_sx12_predictions.csv`, `.../ch08_sx13_predictions.csv` — per-arm
   pair-level predictions (max-concentration) for audit.
+
+### 2026-04-21 06:00 CEST: Post-close review — label-shift disclosure on `chisel-baseline`
+
+#### Executive summary
+
+External reviewer ran `review-ml-pr` + `case-by-case` on the
+post-filter CH04 canonical. All structural checks clean (headline
+AUC/Brier recompute to 6 dp, fold disjointness empirically 0 overlap,
+hygiene clean, reliability max|gap| 0.42 in 0.63-0.84 bucket matching the
+knowledge unit). One load-bearing finding: the CH06-followup filter
+adoption's headline +1.3 pp AUC / −3.2 pp Brier is not a pure model-quality
+gain — the filter flips 4,428 pair eval labels 1→0 (12.6% of the eval set)
+because evaluation pulls the label from the pair's max-concentration
+observation and the filter's training-row removal leaves a 0 replicate
+standing. On matched (pre-filter) labels the filter-trained model regresses
+−1.47 pp AUC and improves −0.98 pp Brier. Knowledge unit `chisel-baseline`
+has been amended to disclose the 2×2 decomposition and retire the
+"improvement is discrimination-only" framing that the original adoption
+note used.
+
+#### 2×2 decomposition on matched pairs
+
+Merging
+`lyzortx/generated_outputs/ch04_chisel_baseline/ch04_predictions.csv`
+(canonical) with the prior-encoding canonical predictions by `pair_id`:
+
+| Model  | Eval labels | AUC    | Brier  | Interpretation |
+|--------|-------------|--------|--------|----------------|
+| prior  | prior       | 0.8084 | 0.1750 | file headline (pre-filter) |
+| prior  | canonical   | 0.8244 | 0.1916 | label-shift alone: +1.60 pp AUC trivialization |
+| canon. | prior       | 0.7937 | 0.1652 | **model alone: −1.47 pp AUC regression, −0.98 pp Brier improvement** |
+| canon. | canonical   | 0.8217 | 0.1435 | file headline (post-filter) |
+
+The headline ΔAUC = +1.33 pp is almost exactly the label-shift component
+(+1.60 pp trivialization) minus the model regression (−1.47 pp), plus an
+interaction term. AUC gain does NOT survive decomposition on matched
+labels. Brier gain DOES survive: −0.98 pp is real model improvement
+(removing neat-only positives from training teaches the model to predict
+lower probability on those pairs, which is correct once the eval label
+flips to 0).
+
+Case-by-case on the same paired CSVs using the project's
+`compare_predictions.py` gives aggregate mean Δ nDCG −1.81 pp with
+permutation p ≈ 0 (171 losses vs 63 wins across 362 bacteria,
+narrow-host sign test p = 0.000 with mean Δ = −2.19 pp). nDCG is
+retired from the CHISEL scorecard, but the regression direction on
+per-bacterium nDCG is consistent with the on-matched-labels AUC
+regression: where the label does not flip, the filter-trained model
+is worse at ranking.
+
+#### Why the filter still stays adopted
+
+Two reasons survive the disclosure:
+
+1. **Label-policy correctness.** Gaborieau 2024 Methods explicitly
+   admits that clearing at high titer can be non-productive. A
+   neat-only positive is candidate-non-productive; the filter removes
+   it from training and re-labels it 0 at eval. That is the correct
+   label under the paper's own framing. The eval population shift is
+   a consequence of fixing the label policy, not a trick.
+2. **Brier on matched labels is genuinely better.** −0.98 pp Brier
+   gain survives the decomposition. Filter-trained model predicts lower
+   probability on the candidate-non-productive positives, which is an
+   honest calibration improvement even on the original labels.
+
+What does NOT survive:
+
+- The "discrimination-only (AUC/Brier)" claim in `chisel-baseline`'s
+  adoption note. Discrimination on matched labels is WORSE, not
+  better. Future comparisons against pre-filter numbers must cite the
+  on-matched-labels AUC 0.7937, not the file-headline 0.8217, when
+  making model-quality claims.
+- The BASEL-widens-deficit explanation in
+  `chisel-unified-kfold-baseline` ("Guelin sharpens more than BASEL
+  under the Guelin-only filter") has the mechanism right but was
+  silent on the magnitude: the Guelin sharpening is mostly
+  trivialization from label flip, not discrimination gain.
+
+#### Amendments made
+
+- `lyzortx/orchestration/knowledge.yml`: `chisel-baseline` context
+  paragraph rewritten to include the 2×2 decomposition, explicit
+  label-flip mechanism, and on-matched-labels AUC/Brier.
+  `kmer-receptor-expansion-neutral` and sibling units unchanged (CH08
+  SX12 deltas are paired bootstrap against the same post-filter
+  baseline, so they're internally consistent regardless of label-shift).
+- `lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md`: CH09
+  Arm 3 dead-end bullet updated to disclose label-shift and point at
+  the decomposition.
+- `lyzortx/KNOWLEDGE.md` re-rendered.
+
+#### Artifacts
+
+- `.scratch/chisel_review/audit_ch04.py` — review-ml-pr checklist
+  (hygiene, fold disjointness, reliability).
+- `.scratch/chisel_review/caseXcase_chisel.py`,
+  `caseXcase_prior_vs_canonical.md` — case-by-case comparison across
+  pre/post-filter predictions with 2×2 decomposition.

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
@@ -85,10 +85,17 @@ re-litigate):
   BASEL closes 79.5% of bacteria-axis ECE and 53.2% of phage-axis ECE, but residual BASEL
   ECE 0.044/0.111 is 6-17× Guelin's calibrated ECE — TL17-bias is a feature-level
   problem, not a threshold-level one.
-- **CH09 Arm 3 (label-threshold sensitivity)**: directional miss. Dropping Guelin
-  neat-only positives gives +1.3 pp AUC, −3.2 pp Brier, but +0.7 pp ECE (not a
-  calibration fix). Adopted as canonical anyway on discrimination wins (see
-  `chisel-baseline` post-filter).
+- **CH09 Arm 3 (label-threshold sensitivity)**: directional miss + label-shift artifact.
+  Dropping Guelin neat-only positives gives headline +1.3 pp AUC, −3.2 pp Brier, +0.7 pp
+  ECE — but a 2026-04-21 post-hoc decomposition found the filter also flips 4,428 pair
+  eval labels 1→0 (12.6% of eval set), because evaluation pulls the label from the
+  pair's max-concentration observation and the removed neat-only positive leaves a 0
+  replicate standing. On matched (pre-filter) labels the filter-trained model has
+  −1.47 pp AUC (regression) but −0.98 pp Brier (genuine improvement survives).
+  Adopted as canonical on Gaborieau-2024 label-policy grounds (neat-only positives
+  are candidate-non-productive) plus the Brier-on-matched-labels gain, NOT on
+  discrimination. See `chisel-baseline` knowledge unit for the 2×2 decomposition and
+  the corrected framing.
 
 And what surprised us on re-audit:
 


### PR DESCRIPTION
## Summary

Post-close review of the CH04 post-filter canonical via `review-ml-pr` + `case-by-case` surfaced a load-bearing disclosure gap in the `chisel-baseline` knowledge unit.

All review checks clean (headline AUC/Brier recompute to 6 dp, fold disjointness empirical 0 overlap, hygiene clean, reliability matches knowledge unit). One finding: the CH06-followup filter adoption's headline +1.3 pp AUC / −3.2 pp Brier vs pre-filter is **not a pure model-quality gain**. The filter flips 4,428 pair eval labels 1→0 (12.6% of eval set) because evaluation pulls the label from the pair's max-concentration observation, and the filter's training-row removal leaves a 0 replicate standing.

## 2×2 decomposition on matched pairs

| Model   | Eval labels | AUC    | Brier  | Interpretation |
|---------|-------------|--------|--------|----------------|
| prior   | prior       | 0.8084 | 0.1750 | file headline pre-filter |
| prior   | canonical   | 0.8244 | 0.1916 | label-shift alone: +1.60 pp AUC trivialization |
| canon.  | prior       | **0.7937** | **0.1652** | **model alone: −1.47 pp AUC regression, −0.98 pp Brier improvement** |
| canon.  | canonical   | 0.8217 | 0.1435 | file headline post-filter |

**On matched labels the filter-trained model regresses −1.47 pp AUC.** Brier gain (−0.98 pp) survives.

## Why filter stays adopted

- **Gaborieau 2024 label-policy correctness.** Paper methods explicitly admit clearing at high titer can be non-productive. Neat-only positives are candidate-non-productive; removing them from training and re-labeling 0 at eval fixes a label-policy defect, not a model one.
- **Brier on matched labels genuinely improves** (−0.98 pp) — the filter-trained model predicts lower probability on removed-positive pairs, which is honest calibration even under pre-filter labels.

## What's retired

The "improvement is discrimination-only (AUC/Brier)" claim in the original `chisel-baseline` adoption note. Discrimination on matched labels is worse, not better. Future comparisons must cite on-matched-labels AUC 0.7937 (not file-headline 0.8217) when making model-quality claims about the filter.

## Changes

- `knowledge.yml` `chisel-baseline` context: rewritten to include 2×2 decomposition, explicit label-flip mechanism, on-matched-labels AUC/Brier.
- `KNOWLEDGE.md` re-rendered.
- `track_CHISEL.md`: new 2026-04-21 06:00 post-close review entry with full finding.
- `track_CHISEL_recap.md`: CH09 Arm 3 dead-end bullet updated.

## Test plan

- [x] `knowledge_parser.validate_knowledge()` passes
- [x] `render_knowledge.py` re-rendered KNOWLEDGE.md
- [x] pymarkdown clean
- [x] No code changes; documentation-only amendment

🤖 Generated with [Claude Code](https://claude.com/claude-code)