### PR TITLE
[ORCH][CH10-CH13] Plan filter revert + rerun + Arm 3 migration

### DIFF
--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -168,10 +168,11 @@ What works, what doesn't, leakage risks, and encoding decisions.
     (n=39) also improve (+2.54 pp bact-axis, +0.54 pp phage-axis), so there is no zero-vs-non-zero trade-off — Arm 3
     strictly dominates baseline TL17 on the BASEL side. **Canonical migration is deferred**: Arm 3 is currently a
     side-materialized slot at `.scratch/basel/feature_slots_arm3/phage_projection/features.csv`; CH05 / CH07 / CH08 /
-    CH09 pipelines still read baseline TL17. A follow-up ticket (CH10) should make Arm 3 the default slot and re-run
-    those pipelines. Supersedes the "panel-independent phage features are the remaining lever" open question in
-    `chisel-unified-kfold-baseline` (the lever exists; now the question is migration cost + downstream calibration
-    effects). Canonical artifacts: lyzortx/generated_outputs/ch06_arm3_moriniere_receptor/ch06_arm3_metrics.json,
+    CH09 pipelines still read baseline TL17. A follow-up ticket (CH13 in plan.yml post the CH10-12 filter-revert
+    insertion) should make Arm 3 the default slot and re-run those pipelines. Supersedes the "panel-independent phage
+    features are the remaining lever" open question in `chisel-unified-kfold-baseline` (the lever exists; now the
+    question is migration cost + downstream calibration effects). Canonical artifacts:
+    lyzortx/generated_outputs/ch06_arm3_moriniere_receptor/ch06_arm3_metrics.json,
     ch06_arm3_{bacteria,phage}_axis_predictions.csv, ch06_arm3_cross_source_breakdown.csv,
     ch06_arm3_variance_preflight.json, and the slot file
     .scratch/basel/feature_slots_arm3/phage_projection/features.csv.*

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -321,8 +321,9 @@ themes:
           — Arm 3 strictly dominates baseline TL17 on the BASEL side. **Canonical migration is
           deferred**: Arm 3 is currently a side-materialized slot at
           `.scratch/basel/feature_slots_arm3/phage_projection/features.csv`; CH05 / CH07 / CH08 /
-          CH09 pipelines still read baseline TL17. A follow-up ticket (CH10) should make Arm 3
-          the default slot and re-run those pipelines. Supersedes the "panel-independent phage
+          CH09 pipelines still read baseline TL17. A follow-up ticket (CH13 in plan.yml post
+          the CH10-12 filter-revert insertion) should make Arm 3 the default slot and re-run
+          those pipelines. Supersedes the "panel-independent phage
           features are the remaining lever" open question in
           `chisel-unified-kfold-baseline` (the lever exists; now the question is migration
           cost + downstream calibration effects). Canonical artifacts:

--- a/lyzortx/orchestration/plan.yml
+++ b/lyzortx/orchestration/plan.yml
@@ -2577,3 +2577,204 @@ tracks:
         hypothesis spanning GT09 + CH09.'
       - Record the production calibration layer, its transfer limit, and the label-
         threshold sensitivity verdict in track_CHISEL.md.
+    - id: CH10
+      title: Revert neat-only positive filter to sensitivity analysis + rerun CH04/CH07
+      model: claude-opus-4-6
+      ci_image_profile: base
+      status: pending
+      depends_on_tasks:
+      - CH09
+      acceptance_criteria:
+      - 'GOAL: demote the CH06-followup neat-only positive filter from canonical
+        to an opt-in sensitivity analysis. Four reviewer objections that must be
+        documented in the chisel-baseline context paragraph so future tickets
+        cannot re-propose the filter without having seen them: (i) WRONG PROXY
+        — Gaborieau 2024 Methods flag plaques-vs-clearing as the phenotype
+        concern ("Clearing of the bacterial lawn at high phage concentration
+        COULD result from productive lysis … or from another mechanism such as
+        lysis from without, or abortive infection"); our binary {0, 1, n} score
+        cannot distinguish plaques from clearing, and "positive observed only
+        at neat" is not the same as "ambiguous clearing". A narrow-host pair
+        that barely lyses at max titer is dropped identically to an abortive-
+        infection artifact. (ii) TESTING-COMPLETENESS BIAS — "positive only at
+        neat" is also "positive at neat and either untested or negative at
+        lower dilutions". A pair with sparser dilution sampling is more likely
+        to be filtered than one with richer sampling; that is a data-collection
+        selection, not biology. (iii) BASEL INCONSISTENCY — BASEL single-titer
+        at >10⁹ pfu/ml is HIGHER than Guelin''s neat 5×10⁸ pfu/ml, but the
+        filter exempts BASEL wholesale. If "high titer is suspect" is the
+        biological rationale, BASEL positives would be MORE suspect, not
+        exempt. The real reason BASEL is exempt is structural (single-titer
+        design), which confirms the filter is about Guelin-specific dilution
+        sampling density, not biology. (iv) PAPER DOES NOT DROP — Gaborieau''s
+        MLC score has MLC=1 as a valid "lytic at highest titer only" rung
+        included in the published interaction matrix and in the "average MLC
+        upon infection" and "productive lysis %" downstream analyses. We
+        unilaterally reclassified ~20% of Guelin positives (7,574 rows across
+        4,428 pairs) as non-lytic, contrary to the paper''s convention. On
+        top of that: on matched (pre-filter) eval labels, the filter-trained
+        model REGRESSES −1.47 pp AUC (0.8084 → 0.7937). The headline +1.33 pp
+        AUC is entirely a label-population-easier artifact (4,428 pairs flip
+        1→0 at eval because evaluation pulls the label from the pair''s
+        max-concentration observation and the filter removed the neat-positive
+        replicate). Brier on matched labels is a genuine −0.98 pp improvement
+        but isotonic calibration (CH09) is the cleaner remedy without the
+        label-policy cost.'
+      - 'SUPERSEDES: the merged PR #453 (commit c22faf7, "label-shift disclosure
+        under filter-stays-canonical framing"). This ticket replaces #453 —
+        #453 amended the knowledge unit to disclose the artifact but kept the
+        filter as canonical. CH10 demotes the filter entirely. The PR
+        description must explicitly name "Supersedes PR #453" and explain why.'
+      - 'CODE: flip `drop_high_titer_only_positives` default to False in
+        ch04_eval.py, ch05_eval.py, ch07_both_axis_holdout.py,
+        ch08_wave2_reaudit.py, and any CH06 arm scripts that inherit it. Keep
+        the CLI flag so users can opt in as `--drop-high-titer-only-positives`
+        for sensitivity analysis. Keep `build_clean_row_training_frame` filter
+        logic intact (still invokable; just not the default).'
+      - 'CH04 RERUN: rerun CH04 canonical under pre-filter + current absolute
+        log₁₀ pfu/ml encoding. Replace the canonical artifacts at
+        lyzortx/generated_outputs/ch04_chisel_baseline/ with fresh numbers.
+        Expected: AUC ≈ 0.8084 (matched to the prior-encoding pre-filter
+        canonical within sampling noise; minor shift from the absolute-log
+        encoding), Brier ≈ 0.175. ~25 min wallclock, 3 seed workers,
+        bacterium-level bootstrap.'
+      - 'CH07 RERUN: rerun CH07 both-axis 10×10 under pre-filter + CH06 Arm 3
+        phage_projection slot. CH07''s 0.7749 AUC is the load-bearing cold-
+        start deployability number the recap headline rests on; cannot leave
+        it citing a number computed under the deprecated label frame.
+        Bundled in this ticket (not a later one) per reviewer direction.
+        ~4 h wallclock, can run in background while doc work proceeds.
+        Reproduce the full 100-cell grid: cell_metrics.csv + aggregate.json +
+        cross_source_breakdown.csv + cell_distribution.png.'
+      - 'KNOWLEDGE AMENDMENT: rewrite chisel-baseline statement + context.
+        Remove the "filter is canonical" framing; canonical is pre-filter.
+        Include the four reviewer objections (i)-(iv) verbatim. Update
+        chisel-unified-kfold-baseline and (when it exists) chisel-both-axis-
+        holdout with a "under deprecated post-filter frame; pending pre-filter
+        rerun" caveat — those reruns are CH11 (CH05) and CH12 (CH08), with
+        CH09 calibrator refit folded into CH11 per reviewer bundling note.'
+      - 'DOCS: update track_CHISEL_recap.md with the reverted canonical and
+        the SUPERSEDED pointer. Add a dated post-close notebook entry to
+        track_CHISEL.md documenting the revert decision, the four objections,
+        and a cross-reference to the reviewer artifacts at
+        .scratch/chisel_review/. Update the recap''s "open follow-ups" —
+        the tentative "CH10" Arm 3 migration reference now points to CH13.'
+      - 'ACCEPTANCE: `python -m lyzortx.pipeline.autoresearch.ch04_eval`
+        produces AUC within [0.794, 0.822] matching the prior-encoding
+        pre-filter canonical; CH07 aggregate.json AUC recomputes from its
+        pair_predictions.csv to 6 dp; knowledge_parser.validate_knowledge()
+        passes; pymarkdown clean; unit tests green (CH04/CH05/CH07/CH08 tests
+        must still pass under the flipped default).'
+    - id: CH11
+      title: CH05 rerun + CH09 isotonic refit under reverted pre-filter canonical
+      model: claude-opus-4-6
+      ci_image_profile: base
+      status: pending
+      depends_on_tasks:
+      - CH10
+      acceptance_criteria:
+      - 'GOAL: restore chisel-unified-kfold-baseline AND chisel-post-hoc-
+        calibration-layer to numbers computed under the pre-filter canonical
+        established by CH10. Bundled per reviewer note: the CH09 isotonic
+        refit is 5 min of compute on CH05 predictions, and keeping it in a
+        separate PR would leave the CH11 merge citing a stale calibrator in
+        chisel-unified-kfold-baseline. Merging them gives one atomic "CH05
+        under reverted canonical, with calibrator refit" deliverable.'
+      - 'CH05 RERUN: run `python -m lyzortx.pipeline.autoresearch.ch05_eval`
+        with the flipped default. Two axes: bacteria-axis 10-fold + phage-axis
+        StratifiedKFold. Use CH06 Arm 3 phage_projection slot override,
+        absolute log₁₀ pfu/ml encoding. Cross-source decomposition on phage-
+        axis. ~50 min wallclock.'
+      - 'CH09 ISOTONIC REFIT: refit
+        lyzortx/generated_outputs/ch09_calibration_layer/ch09_calibrator.pkl
+        on pre-filter Guelin training-fold predictions from the CH05 rerun.
+        LOOF evaluation, Guelin LOOF ECE target < 0.02 on both axes. Report
+        BASEL cross-panel ECE closure under the refit; replicate or
+        invalidate the 79.5% / 53.2% numbers currently in chisel-unified-
+        kfold-baseline. ~5 min wallclock after CH05 artifacts land.'
+      - 'METRICS: report new headline bacteria-axis AUC, phage-axis AUC,
+        cross-source AUC (Guelin vs BASEL), BASEL bacteria-axis deficit,
+        reliability tables. Compare to the post-filter CH05 numbers as a
+        sensitivity column. Report isotonic LOOF ECE on both axes.'
+      - 'ARTIFACTS: replace ch05_unified_kfold/ and ch09_calibration_layer/
+        artifacts with pre-filter reruns. Preserve the post-filter artifacts
+        at ch05_unified_kfold_post_filter/ and
+        ch09_calibration_layer_post_filter/ for side-by-side sensitivity
+        reference (both gitignored via generated_outputs/).'
+      - 'KNOWLEDGE: rewrite chisel-unified-kfold-baseline with new canonical
+        numbers. The "filter lift" paragraph is retired in favor of a brief
+        sensitivity note ("neat-only filter applied as training-data ablation
+        gives Δ AUC Y / Δ Brier Z, but CH10 demoted the filter to sensitivity-
+        analysis-only per reviewer findings — see chisel-baseline"). Update
+        or create chisel-post-hoc-calibration-layer with refit numbers.'
+      - Record the rerun results, the pre-filter/post-filter sensitivity
+        comparison, and the refit calibrator transfer numbers in
+        track_CHISEL.md.
+    - id: CH12
+      title: Rerun CH08 SX12/SX13 wave-2 re-audit under reverted pre-filter canonical
+      model: claude-opus-4-6
+      ci_image_profile: base
+      status: pending
+      depends_on_tasks:
+      - CH10
+      acceptance_criteria:
+      - 'GOAL: restore CH08''s SX12/SX13 delta headlines to the pre-filter
+        baseline. The merged CH08 reported SX12 +1.16 pp AUC / SX13 +0.17 pp
+        AUC against the CH04 POST-filter canonical predictions. The paired
+        bacterium-level bootstrap is internally consistent (same pairs, same
+        labels on both sides), so the deltas are valid AS MEASURED. But the
+        BASELINE reference is now the pre-filter canonical (CH10), so the arm
+        vs baseline comparison table needs to be recomputed with the pre-
+        filter CH04 predictions as the baseline reference.'
+      - 'DESIGN: rerun
+        `python -m lyzortx.pipeline.autoresearch.ch08_wave2_reaudit` with the
+        flipped default and the pre-filter CH04 canonical predictions as the
+        baseline reference. Keep the top-100 variance pre-filter on kmer
+        slots — that choice was validated under the merged CH08 and is
+        independent of the neat-only filter. ~1 h wallclock.'
+      - 'METRICS: report new SX12 and SX13 deltas with paired bacterium-level
+        bootstrap CIs. Knowledge-unit update logic from the merged CH08 still
+        applies: if either CI disjoint from zero, reopen the wave-2 null
+        (kmer-receptor-expansion-neutral / host-omp-variation-unpredictive);
+        if null, close it under CHISEL pre-filter frame.'
+      - 'ARTIFACTS: replace ch08_wave2_reaudit/ artifacts with the rerun. Keep
+        the post-filter run at ch08_wave2_reaudit_post_filter/ for
+        sensitivity.'
+      - Record the rerun deltas and the reopen/close decision in
+        track_CHISEL.md.
+    - id: CH13
+      title: Arm 3 canonical phage_projection slot migration
+      model: claude-opus-4-6
+      ci_image_profile: base
+      status: pending
+      depends_on_tasks:
+      - CH10
+      - CH11
+      - CH12
+      acceptance_criteria:
+      - 'GOAL: wire CH06 Arm 3 (Moriniere per-receptor k-mer fractions) into
+        the canonical `phage_projection` slot. Currently Arm 3 lives at
+        .scratch/basel/feature_slots_arm3/phage_projection/features.csv and
+        is consumed only via `--phage-slots-dir` overrides. Canonical
+        migration makes it the default, retires the Guelin-derived TL17
+        BLAST projection artifact (or demotes it to a sensitivity-analysis
+        fallback), and re-runs downstream tickets under the new slot. Note:
+        this ticket was originally referenced as the tentative "CH10" in
+        merged docs (knowledge.yml moriniere-receptor-fractions-validated,
+        track_CHISEL_recap.md, KNOWLEDGE.md) before the CH10-CH12 insertion
+        for the filter revert. CH10 (revert) updates those references to
+        point at this ticket as CH13.'
+      - 'DESIGN: replace the canonical `phage_projection` slot artifacts in
+        the autoresearch feature cache with the Arm 3 Moriniere per-receptor
+        fraction matrix. Retire the TL17 BLAST pipeline or demote it to a
+        sensitivity-analysis fallback. Update the feature cache manifest.'
+      - 'RERUN: under the new canonical slot, rerun CH04, CH05, CH07, CH08,
+        CH09 (calibrator refit). Total ~6 h wallclock. Reuse the same code
+        paths under the flipped slot default.'
+      - 'KNOWLEDGE: rewrite moriniere-receptor-fractions-validated to reflect
+        canonical status. Update chisel-baseline, chisel-unified-kfold-
+        baseline, chisel-both-axis-holdout (if that unit exists by now) with
+        the new numbers. Retire the "canonical migration is deferred" note.'
+      - Record the migration, the before/after numbers on all downstream
+        tickets, and the TL17 retirement in track_CHISEL.md. Add a dedicated
+        section to track_CHISEL_recap.md or extend the open-follow-ups list.

--- a/lyzortx/orchestration/plan.yml
+++ b/lyzortx/orchestration/plan.yml
@@ -2591,7 +2591,7 @@ tracks:
         cannot re-propose the filter without having seen them: (i) WRONG PROXY
         — Gaborieau 2024 Methods flag plaques-vs-clearing as the phenotype
         concern ("Clearing of the bacterial lawn at high phage concentration
-        COULD result from productive lysis … or from another mechanism such as
+        *could* result from productive lysis … or from another mechanism such as
         lysis from without, or abortive infection"); our binary {0, 1, n} score
         cannot distinguish plaques from clearing, and "positive observed only
         at neat" is not the same as "ambiguous clearing". A narrow-host pair
@@ -2660,8 +2660,8 @@ tracks:
         .scratch/chisel_review/. Update the recap''s "open follow-ups" —
         the tentative "CH10" Arm 3 migration reference now points to CH13.'
       - 'ACCEPTANCE: `python -m lyzortx.pipeline.autoresearch.ch04_eval`
-        produces AUC within [0.794, 0.822] matching the prior-encoding
-        pre-filter canonical; CH07 aggregate.json AUC recomputes from its
+        produces AUC within [0.806, 0.811] (±0.25 pp around the 0.8084
+        pre-filter canonical point estimate); CH07 aggregate.json AUC recomputes from its
         pair_predictions.csv to 6 dp; knowledge_parser.validate_knowledge()
         passes; pymarkdown clean; unit tests green (CH04/CH05/CH07/CH08 tests
         must still pass under the flipped default).'

--- a/lyzortx/research_notes/PLAN.md
+++ b/lyzortx/research_notes/PLAN.md
@@ -1631,3 +1631,117 @@ graph LR
     GT09 + CH09.
   - Record the production calibration layer, its transfer limit, and the label- threshold sensitivity verdict in
     track_CHISEL.md.
+- [ ] **CH10** Revert neat-only positive filter to sensitivity analysis + rerun CH04/CH07. Model: `claude-opus-4-6`. CI
+      image profile: `base`. Depends on tasks: `CH09`.
+  - GOAL: demote the CH06-followup neat-only positive filter from canonical to an opt-in sensitivity analysis. Four
+    reviewer objections that must be documented in the chisel-baseline context paragraph so future tickets cannot
+    re-propose the filter without having seen them: (i) WRONG PROXY — Gaborieau 2024 Methods flag plaques-vs-clearing as
+    the phenotype concern ("Clearing of the bacterial lawn at high phage concentration COULD result from productive
+    lysis … or from another mechanism such as lysis from without, or abortive infection"); our binary {0, 1, n} score
+    cannot distinguish plaques from clearing, and "positive observed only at neat" is not the same as "ambiguous
+    clearing". A narrow-host pair that barely lyses at max titer is dropped identically to an abortive- infection
+    artifact. (ii) TESTING-COMPLETENESS BIAS — "positive only at neat" is also "positive at neat and either untested or
+    negative at lower dilutions". A pair with sparser dilution sampling is more likely to be filtered than one with
+    richer sampling; that is a data-collection selection, not biology. (iii) BASEL INCONSISTENCY — BASEL single-titer at
+    >10⁹ pfu/ml is HIGHER than Guelin's neat 5×10⁸ pfu/ml, but the filter exempts BASEL wholesale. If "high titer is
+    suspect" is the biological rationale, BASEL positives would be MORE suspect, not exempt. The real reason BASEL is
+    exempt is structural (single-titer design), which confirms the filter is about Guelin-specific dilution sampling
+    density, not biology. (iv) PAPER DOES NOT DROP — Gaborieau's MLC score has MLC=1 as a valid "lytic at highest titer
+    only" rung included in the published interaction matrix and in the "average MLC upon infection" and "productive
+    lysis %" downstream analyses. We unilaterally reclassified ~20% of Guelin positives (7,574 rows across 4,428 pairs)
+    as non-lytic, contrary to the paper's convention. On top of that: on matched (pre-filter) eval labels, the
+    filter-trained model REGRESSES −1.47 pp AUC (0.8084 → 0.7937). The headline +1.33 pp AUC is entirely a
+    label-population-easier artifact (4,428 pairs flip 1→0 at eval because evaluation pulls the label from the pair's
+    max-concentration observation and the filter removed the neat-positive replicate). Brier on matched labels is a
+    genuine −0.98 pp improvement but isotonic calibration (CH09) is the cleaner remedy without the label-policy cost.
+  - SUPERSEDES: the merged PR #453 (commit c22faf7, "label-shift disclosure under filter-stays-canonical framing"). This
+    ticket replaces #453 — #453 amended the knowledge unit to disclose the artifact but kept the filter as canonical.
+    CH10 demotes the filter entirely. The PR description must explicitly name "Supersedes PR #453" and explain why.
+  - CODE: flip `drop_high_titer_only_positives` default to False in ch04_eval.py, ch05_eval.py,
+    ch07_both_axis_holdout.py, ch08_wave2_reaudit.py, and any CH06 arm scripts that inherit it. Keep the CLI flag so
+    users can opt in as `--drop-high-titer-only-positives` for sensitivity analysis. Keep
+    `build_clean_row_training_frame` filter logic intact (still invokable; just not the default).
+  - CH04 RERUN: rerun CH04 canonical under pre-filter + current absolute log₁₀ pfu/ml encoding. Replace the canonical
+    artifacts at lyzortx/generated_outputs/ch04_chisel_baseline/ with fresh numbers. Expected: AUC ≈ 0.8084 (matched to
+    the prior-encoding pre-filter canonical within sampling noise; minor shift from the absolute-log encoding), Brier ≈
+    0.175. ~25 min wallclock, 3 seed workers, bacterium-level bootstrap.
+  - CH07 RERUN: rerun CH07 both-axis 10×10 under pre-filter + CH06 Arm 3 phage_projection slot. CH07's 0.7749 AUC is the
+    load-bearing cold- start deployability number the recap headline rests on; cannot leave it citing a number computed
+    under the deprecated label frame. Bundled in this ticket (not a later one) per reviewer direction. ~4 h wallclock,
+    can run in background while doc work proceeds. Reproduce the full 100-cell grid: cell_metrics.csv + aggregate.json +
+    cross_source_breakdown.csv + cell_distribution.png.
+  - KNOWLEDGE AMENDMENT: rewrite chisel-baseline statement + context. Remove the "filter is canonical" framing;
+    canonical is pre-filter. Include the four reviewer objections (i)-(iv) verbatim. Update
+    chisel-unified-kfold-baseline and (when it exists) chisel-both-axis- holdout with a "under deprecated post-filter
+    frame; pending pre-filter rerun" caveat — those reruns are CH11 (CH05) and CH12 (CH08), with CH09 calibrator refit
+    folded into CH11 per reviewer bundling note.
+  - DOCS: update track_CHISEL_recap.md with the reverted canonical and the SUPERSEDED pointer. Add a dated post-close
+    notebook entry to track_CHISEL.md documenting the revert decision, the four objections, and a cross-reference to the
+    reviewer artifacts at .scratch/chisel_review/. Update the recap's "open follow-ups" — the tentative "CH10" Arm 3
+    migration reference now points to CH13.
+  - ACCEPTANCE: `python -m lyzortx.pipeline.autoresearch.ch04_eval` produces AUC within [0.794, 0.822] matching the
+    prior-encoding pre-filter canonical; CH07 aggregate.json AUC recomputes from its pair_predictions.csv to 6 dp;
+    knowledge_parser.validate_knowledge() passes; pymarkdown clean; unit tests green (CH04/CH05/CH07/CH08 tests must
+    still pass under the flipped default).
+- [ ] **CH11** CH05 rerun + CH09 isotonic refit under reverted pre-filter canonical. Model: `claude-opus-4-6`. CI image
+      profile: `base`. Depends on tasks: `CH10`.
+  - GOAL: restore chisel-unified-kfold-baseline AND chisel-post-hoc- calibration-layer to numbers computed under the
+    pre-filter canonical established by CH10. Bundled per reviewer note: the CH09 isotonic refit is 5 min of compute on
+    CH05 predictions, and keeping it in a separate PR would leave the CH11 merge citing a stale calibrator in
+    chisel-unified-kfold-baseline. Merging them gives one atomic "CH05 under reverted canonical, with calibrator refit"
+    deliverable.
+  - CH05 RERUN: run `python -m lyzortx.pipeline.autoresearch.ch05_eval` with the flipped default. Two axes:
+    bacteria-axis 10-fold + phage-axis StratifiedKFold. Use CH06 Arm 3 phage_projection slot override, absolute log₁₀
+    pfu/ml encoding. Cross-source decomposition on phage- axis. ~50 min wallclock.
+  - CH09 ISOTONIC REFIT: refit lyzortx/generated_outputs/ch09_calibration_layer/ch09_calibrator.pkl on pre-filter Guelin
+    training-fold predictions from the CH05 rerun. LOOF evaluation, Guelin LOOF ECE target < 0.02 on both axes. Report
+    BASEL cross-panel ECE closure under the refit; replicate or invalidate the 79.5% / 53.2% numbers currently in
+    chisel-unified- kfold-baseline. ~5 min wallclock after CH05 artifacts land.
+  - METRICS: report new headline bacteria-axis AUC, phage-axis AUC, cross-source AUC (Guelin vs BASEL), BASEL
+    bacteria-axis deficit, reliability tables. Compare to the post-filter CH05 numbers as a sensitivity column. Report
+    isotonic LOOF ECE on both axes.
+  - ARTIFACTS: replace ch05_unified_kfold/ and ch09_calibration_layer/ artifacts with pre-filter reruns. Preserve the
+    post-filter artifacts at ch05_unified_kfold_post_filter/ and ch09_calibration_layer_post_filter/ for side-by-side
+    sensitivity reference (both gitignored via generated_outputs/).
+  - KNOWLEDGE: rewrite chisel-unified-kfold-baseline with new canonical numbers. The "filter lift" paragraph is retired
+    in favor of a brief sensitivity note ("neat-only filter applied as training-data ablation gives Δ AUC Y / Δ Brier Z,
+    but CH10 demoted the filter to sensitivity- analysis-only per reviewer findings — see chisel-baseline"). Update or
+    create chisel-post-hoc-calibration-layer with refit numbers.
+  - Record the rerun results, the pre-filter/post-filter sensitivity comparison, and the refit calibrator transfer
+    numbers in track_CHISEL.md.
+- [ ] **CH12** Rerun CH08 SX12/SX13 wave-2 re-audit under reverted pre-filter canonical. Model: `claude-opus-4-6`. CI
+      image profile: `base`. Depends on tasks: `CH10`.
+  - GOAL: restore CH08's SX12/SX13 delta headlines to the pre-filter baseline. The merged CH08 reported SX12 +1.16 pp
+    AUC / SX13 +0.17 pp AUC against the CH04 POST-filter canonical predictions. The paired bacterium-level bootstrap is
+    internally consistent (same pairs, same labels on both sides), so the deltas are valid AS MEASURED. But the BASELINE
+    reference is now the pre-filter canonical (CH10), so the arm vs baseline comparison table needs to be recomputed
+    with the pre- filter CH04 predictions as the baseline reference.
+  - DESIGN: rerun `python -m lyzortx.pipeline.autoresearch.ch08_wave2_reaudit` with the flipped default and the
+    pre-filter CH04 canonical predictions as the baseline reference. Keep the top-100 variance pre-filter on kmer slots
+    — that choice was validated under the merged CH08 and is independent of the neat-only filter. ~1 h wallclock.
+  - METRICS: report new SX12 and SX13 deltas with paired bacterium-level bootstrap CIs. Knowledge-unit update logic from
+    the merged CH08 still applies: if either CI disjoint from zero, reopen the wave-2 null
+    (kmer-receptor-expansion-neutral / host-omp-variation-unpredictive); if null, close it under CHISEL pre-filter
+    frame.
+  - ARTIFACTS: replace ch08_wave2_reaudit/ artifacts with the rerun. Keep the post-filter run at
+    ch08_wave2_reaudit_post_filter/ for sensitivity.
+  - Record the rerun deltas and the reopen/close decision in track_CHISEL.md.
+- [ ] **CH13** Arm 3 canonical phage_projection slot migration. Model: `claude-opus-4-6`. CI image profile: `base`.
+      Depends on tasks: `CH10`, `CH11`, `CH12`.
+  - GOAL: wire CH06 Arm 3 (Moriniere per-receptor k-mer fractions) into the canonical `phage_projection` slot. Currently
+    Arm 3 lives at .scratch/basel/feature_slots_arm3/phage_projection/features.csv and is consumed only via
+    `--phage-slots-dir` overrides. Canonical migration makes it the default, retires the Guelin-derived TL17 BLAST
+    projection artifact (or demotes it to a sensitivity-analysis fallback), and re-runs downstream tickets under the new
+    slot. Note: this ticket was originally referenced as the tentative "CH10" in merged docs (knowledge.yml
+    moriniere-receptor-fractions-validated, track_CHISEL_recap.md, KNOWLEDGE.md) before the CH10-CH12 insertion for the
+    filter revert. CH10 (revert) updates those references to point at this ticket as CH13.
+  - DESIGN: replace the canonical `phage_projection` slot artifacts in the autoresearch feature cache with the Arm 3
+    Moriniere per-receptor fraction matrix. Retire the TL17 BLAST pipeline or demote it to a sensitivity-analysis
+    fallback. Update the feature cache manifest.
+  - RERUN: under the new canonical slot, rerun CH04, CH05, CH07, CH08, CH09 (calibrator refit). Total ~6 h wallclock.
+    Reuse the same code paths under the flipped slot default.
+  - KNOWLEDGE: rewrite moriniere-receptor-fractions-validated to reflect canonical status. Update chisel-baseline,
+    chisel-unified-kfold- baseline, chisel-both-axis-holdout (if that unit exists by now) with the new numbers. Retire
+    the "canonical migration is deferred" note.
+  - Record the migration, the before/after numbers on all downstream tickets, and the TL17 retirement in
+    track_CHISEL.md. Add a dedicated section to track_CHISEL_recap.md or extend the open-follow-ups list.

--- a/lyzortx/research_notes/PLAN.md
+++ b/lyzortx/research_notes/PLAN.md
@@ -1636,7 +1636,7 @@ graph LR
   - GOAL: demote the CH06-followup neat-only positive filter from canonical to an opt-in sensitivity analysis. Four
     reviewer objections that must be documented in the chisel-baseline context paragraph so future tickets cannot
     re-propose the filter without having seen them: (i) WRONG PROXY — Gaborieau 2024 Methods flag plaques-vs-clearing as
-    the phenotype concern ("Clearing of the bacterial lawn at high phage concentration COULD result from productive
+    the phenotype concern ("Clearing of the bacterial lawn at high phage concentration *could* result from productive
     lysis … or from another mechanism such as lysis from without, or abortive infection"); our binary {0, 1, n} score
     cannot distinguish plaques from clearing, and "positive observed only at neat" is not the same as "ambiguous
     clearing". A narrow-host pair that barely lyses at max titer is dropped identically to an abortive- infection
@@ -1679,10 +1679,10 @@ graph LR
     notebook entry to track_CHISEL.md documenting the revert decision, the four objections, and a cross-reference to the
     reviewer artifacts at .scratch/chisel_review/. Update the recap's "open follow-ups" — the tentative "CH10" Arm 3
     migration reference now points to CH13.
-  - ACCEPTANCE: `python -m lyzortx.pipeline.autoresearch.ch04_eval` produces AUC within [0.794, 0.822] matching the
-    prior-encoding pre-filter canonical; CH07 aggregate.json AUC recomputes from its pair_predictions.csv to 6 dp;
-    knowledge_parser.validate_knowledge() passes; pymarkdown clean; unit tests green (CH04/CH05/CH07/CH08 tests must
-    still pass under the flipped default).
+  - ACCEPTANCE: `python -m lyzortx.pipeline.autoresearch.ch04_eval` produces AUC within [0.806, 0.811] (±0.25 pp around
+    the 0.8084 pre-filter canonical point estimate); CH07 aggregate.json AUC recomputes from its pair_predictions.csv to
+    6 dp; knowledge_parser.validate_knowledge() passes; pymarkdown clean; unit tests green (CH04/CH05/CH07/CH08 tests
+    must still pass under the flipped default).
 - [ ] **CH11** CH05 rerun + CH09 isotonic refit under reverted pre-filter canonical. Model: `claude-opus-4-6`. CI image
       profile: `base`. Depends on tasks: `CH10`.
   - GOAL: restore chisel-unified-kfold-baseline AND chisel-post-hoc- calibration-layer to numbers computed under the

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -1411,8 +1411,8 @@ similarity (AX08 null). The aggregation level is the mechanism.
 1. **Wire Arm 3 into the canonical `phage_projection` slot** — currently Arm 3 is a
    side-materialized artifact at `.scratch/basel/feature_slots_arm3/`; canonical CH05 /
    CH07 / CH08 / CH09 pipelines still read baseline TL17. A separate migration ticket
-   (CH10?) should make Arm 3 the default, re-run CH05 / CH07 / CH08 / CH09 under the
-   new slot, and update their baseline numbers.
+   (planned as CH13 in plan.yml) should make Arm 3 the default, re-run CH05 / CH07 /
+   CH08 / CH09 under the new slot, and update their baseline numbers.
 2. **Arm 2 composition with TL17** — identified as valid follow-up during Arm 3 review
    (keep TL17 where available, add Arm 2 PCA for zero-vec phages). Under Arm 3's clean
    win this is unnecessary but could be revisited if Arm 3's canonical migration

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
@@ -61,7 +61,7 @@ Against the SPANDEX starting point:
   13/52 BASEL phages) → Moriniere per-receptor k-mer fractions (CH06 Arm 3,
   panel-independent 13-dim, BASEL zero-vec phage-axis +4.36 pp; see
   `moriniere-receptor-fractions-validated`). Canonical migration deferred to the
-  follow-up CH10 slot (currently a side-materialized artifact at
+  follow-up CH13 ticket (currently a side-materialized artifact at
   `.scratch/basel/feature_slots_arm3/`).
 - **Both-axis cold-start**: never previously measured → CH07 reports 0.7749 on 100 cells
   with pair-level bootstrap.
@@ -113,7 +113,7 @@ And what surprised us on re-audit:
 
 Each is a concrete, schedulable item — not a vague aspiration.
 
-1. **CH10 (pending) — Arm 3 canonical migration.** Wire
+1. **CH13 (pending) — Arm 3 canonical migration.** Wire
    `.scratch/basel/feature_slots_arm3/phage_projection/features.csv` into the canonical
    `phage_projection` slot, retire the Guelin-derived TL17 artifact, and re-run CH04 /
    CH05 / CH07 / CH08 / CH09 under the new slot. Baselines should shift slightly; knowledge


### PR DESCRIPTION
## Summary
- Adds four tickets (CH10-CH13) to `plan.yml` to resolve the label-shift artifact surfaced in PR #453.
- CH10 reverts the neat-only positive filter to a sensitivity analysis and reruns CH04/CH07 canonical; supersedes #453.
- CH11 bundles the CH05 rerun with the CH09 isotonic refit under the reverted pre-filter canonical.
- CH12 reruns CH08 SX12/SX13 wave-2 re-audit under the reverted pre-filter canonical.
- CH13 is the Arm 3 Moriniere receptor-fraction canonical migration (renumbered from the tentative "CH10" references left in merged docs before CH10 was claimed for the filter revert).
- Fixes the stale "CH10 = Arm 3 migration" references across merged docs to point at CH13.

Docs-only planning PR — no code changes. Implementation lands in the CH10-CH13 PRs.

## Test plan
- [x] `plan.yml` parses cleanly and renders via `render_plan`; CH10-CH13 show as pending with correct titles.
- [x] `knowledge.yml` renders via `render_knowledge`; chisel-baseline context now points at CH13.
- [ ] Reviewer confirms ticket numbering (priority-ordered: CH10 first to unblock everything downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)