### PR TITLE
[ORCH][CH10] Revert neat-only positive filter + rerun CH04/CH07

### DIFF
--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -242,16 +242,21 @@ Architecture choices, calibration, and performance bounds.
     0.1652 (model alone: **−1.47 pp AUC regression**, −0.98 pp Brier improvement); (filter model / filter labels) =
     0.8217 / 0.1435. The −0.98 pp Brier improvement that survives decomposition is addressed by the CH09 isotonic
     calibration layer without the label-policy cost. Reviewer artifacts: .scratch/chisel_review/caseXcase_chisel.py,
-    caseXcase_prior_vs_canonical.md. **Downstream impact.** CH05 (CH11 rerun), CH07 (rerun bundled into CH10), CH08
-    (CH12 rerun), and CH09 isotonic refit (bundled into CH11) were all anchored to the deprecated post-filter canonical
-    and are re-running under the reverted pre-filter default. CH11/CH12 preserve the deprecated post-filter artifacts in
-    `_post_filter/` side-directories for sensitivity comparison. The filter remains available as an opt-in CLI flag
-    (`--drop-high-titer-only-positives`) but is not the default in any eval script. The
-    `moriniere-receptor-fractions-validated` knowledge unit cites post-filter CH05 numbers; CH11 will re-cite under the
-    reverted canonical. **SUPERSEDES: PR #453** (commit c22faf7, merged 2026-04-21) — #453 amended the knowledge unit to
-    disclose the label-shift artifact but kept the filter as canonical. CH10 demotes the filter entirely. **Canonical
-    artifacts:** lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json, ch04_predictions.csv
-    (pair-level), ch04_per_row_predictions.csv (per-row), and ch04_feature_importance.csv.*
+    caseXcase_prior_vs_canonical.md. **Downstream impact.** CH05 (CH11 rerun), CH08 (CH12 rerun), and CH09 isotonic
+    refit (bundled into CH11) were anchored to the deprecated post-filter canonical and are re-running under the
+    reverted pre-filter default. CH07 rerun was bundled into CH10 and completed 2026-04-21: aggregate 10×10 both-axis
+    AUC **0.7634 [0.7581, 0.7689]**, Brier **0.1902 [0.1874, 0.1927]** on 36,643 unified-panel pairs under the Arm 3
+    phage_projection slot — −1.15 pp vs the deprecated post-filter 0.7749, directionally consistent with the label-shift
+    mechanism (filter trivialized eval labels) and now the load-bearing cold- start deployability number. CH11/CH12
+    preserve the deprecated post-filter artifacts in `_post_filter/` side-directories for sensitivity comparison. The
+    filter remains available as an opt-in CLI flag (`--drop-high-titer-only-positives`) but is not the default in any
+    eval script. The `moriniere-receptor-fractions-validated` knowledge unit cites post-filter CH05 numbers; CH11 will
+    re-cite under the reverted canonical. **SUPERSEDES: PR #453** (commit c22faf7, merged 2026-04-21) — #453 amended the
+    knowledge unit to disclose the label-shift artifact but kept the filter as canonical. CH10 demotes the filter
+    entirely. **Canonical artifacts:** lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json,
+    ch04_predictions.csv (pair-level), ch04_per_row_predictions.csv (per-row), ch04_feature_importance.csv;
+    lyzortx/generated_outputs/ch07_both_axis_holdout/ch07_aggregate.json, ch07_pair_predictions.csv,
+    ch07_per_row_predictions.csv, ch07_cell_metrics.csv, ch07_cross_source_breakdown.csv, ch07_cell_distribution.png.*
 - **`spandex-final-baseline`**: HISTORICAL (SPANDEX-era). Superseded as the active canonical by chisel-baseline (CH04).
   SPANDEX final configuration — GT03 all_gates_rfe + AX02 per-phage blending on SX05-corrected MLC 0-3 labels, 10-fold
   CV bacteria-axis on the 369×96 panel: **AUC 0.8699 [0.8570, 0.8819], Brier 0.1248 [0.1187, 0.1309]** within-panel,

--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -144,20 +144,24 @@ What works, what doesn't, leakage risks, and encoding decisions.
     (O-antigen/capsule blocking, intracellular defenses, injection efficiency) dominate host-range determination in
     clinical isolates. This means receptor identity is necessary but far from sufficient for predicting strain-level
     lysis.*
-- **`moriniere-receptor-fractions-validated`**: CH06 Arm 3 validates Moriniere 2026 per-receptor k-mer-fraction vectors
-  (13 dim, one fraction per receptor class, = `|kmers(R) ∩ kmers(P)| / |kmers(R)|`) as the canonical panel-independent
-  replacement for the Guelin-derived TL17 `phage_projection` slot. On the CH05 unified 148-phage panel (post-filter
-  canonical), Arm 3 delivers BASEL bacteria-axis AUC 0.7374 (+1.45 pp vs 0.7229 baseline, meets the CH06 acceptance
-  criterion >0.7152), rescues the 13 BASEL zero-vector-TL17 phages by +4.36 pp on phage-axis (0.6901 → 0.7337) with no
-  Guelin regression (±0.15 pp). Arm 2 (MMseqs2 pairwise proteome similarity) and Arm 4 (tail-restricted TL17 BLAST) were
-  both null — Arm 2 cannibalized non-zero-projection BASEL while rescuing zero-proj BASEL; Arm 4 produced a strict
-  subset of baseline TL17 hits. The aggregation level is the mechanism: raw 815 k-mers were null in SX12
-  (`kmer-receptor-expansion-neutral`) because they are information-redundant with TL17 at the sequence level, but
-  aggregation to 13 per-receptor-class normalized fractions removes that redundancy by forcing the model to see
-  class-level probabilities rather than re-derive them. Moriniere's classifier was trained on 260 non-Guelin reference
-  phages, so the feature basis is panel-independent at source. [validated; source: CH06 Arm 3, 2026-04-20 CH06
-  close-out; see also: chisel-unified-kfold-baseline, receptor-specificity-solved, kmer-receptor-expansion-neutral,
-  plm-rbp-redundant, panel-size-ceiling, deployment-goal]
+- **`moriniere-receptor-fractions-validated`**: **CAVEAT (2026-04-21, CH10 revert):** numbers below were computed on the
+  CH05 unified panel under the deprecated post-filter frame. CH11 will re-run CH05 (and CH13 will re-run CH06 arms if
+  needed) under the reverted pre-filter canonical; directional findings (Arm 3 meets acceptance, Arms 2/4 null) are
+  expected to survive since Arm 3's rescue is on BASEL zero-vector phages and the filter only touches Guelin training
+  rows. Treat headline numbers as post-filter-frame estimates pending the CH11 rerun. CH06 Arm 3 validates Moriniere
+  2026 per-receptor k-mer-fraction vectors (13 dim, one fraction per receptor class, = `|kmers(R) ∩ kmers(P)| /
+  |kmers(R)|`) as the canonical panel-independent replacement for the Guelin-derived TL17 `phage_projection` slot. On
+  the CH05 unified 148-phage panel (post-filter canonical), Arm 3 delivers BASEL bacteria-axis AUC 0.7374 (+1.45 pp vs
+  0.7229 baseline, meets the CH06 acceptance criterion >0.7152), rescues the 13 BASEL zero-vector-TL17 phages by +4.36
+  pp on phage-axis (0.6901 → 0.7337) with no Guelin regression (±0.15 pp). Arm 2 (MMseqs2 pairwise proteome similarity)
+  and Arm 4 (tail-restricted TL17 BLAST) were both null — Arm 2 cannibalized non-zero-projection BASEL while rescuing
+  zero-proj BASEL; Arm 4 produced a strict subset of baseline TL17 hits. The aggregation level is the mechanism: raw 815
+  k-mers were null in SX12 (`kmer-receptor-expansion-neutral`) because they are information-redundant with TL17 at the
+  sequence level, but aggregation to 13 per-receptor-class normalized fractions removes that redundancy by forcing the
+  model to see class-level probabilities rather than re-derive them. Moriniere's classifier was trained on 260
+  non-Guelin reference phages, so the feature basis is panel-independent at source. [validated; source: CH06 Arm 3,
+  2026-04-20 CH06 close-out; see also: chisel-unified-kfold-baseline, receptor-specificity-solved,
+  kmer-receptor-expansion-neutral, plm-rbp-redundant, panel-size-ceiling, deployment-goal]
   - *Plan.yml pre-registered Arm 3 as "expected null" citing `same-receptor-uncorrelated-hosts` (Tsx phages Jaccard
     0.091 on host ranges) and Moriniere's K-12-only training (no capsule/O-antigen). Both characterizations are correct
     about what receptor-class probabilities do NOT encode, but the CH06 acceptance criterion is absolute cross-panel
@@ -184,60 +188,70 @@ Architecture choices, calibration, and performance bounds.
 - **`tl18-flawed-baseline`**: TL18 model (0.823 AUC) is not a valid baseline: DefenseFinder version drift inflated 17.3%
   of feature importance, and 5 soft-leaky pairwise features contributed ~5.5%. [validated; source: TL18 audit; see also:
   autoresearch-baseline]
-- **`chisel-baseline`**: CHISEL canonical baseline (CH04, updated 2026-04-20 with CH06-followup neat-only filter):
-  per-row binary training on every interpretable (bacterium, phage, log_dilution, replicate, X, Y) raw observation with
-  `pair_concentration__log10_pfu_ml` as a numeric feature (absolute log₁₀ pfu/ml encoding, replacing the earlier
-  relative log_dilution encoding — CH05 track-wide change), SX10 feature bundle otherwise unchanged (host_surface +
-  host_typing + host_stats + host_defense + phage_projection + phage_stats + pair_depo_capsule + pair_receptor_omp,
-  RFE-selected), **all-pairs only** (AX02 per-phage blending retired, see per-phage-retired-under-chisel), 10-fold
-  bacteria-axis CV under CH02 cv_group hashing, 369×96 panel. **Training label policy includes the neat-only positive
-  filter**: Guelin pairs whose every score='1' observation is at log_dilution=0 (neat) have their positive rows dropped
-  as candidate-non-productive per Gaborieau 2024 Methods ("clearing at high titer can be non-productive"). Filter drops
-  7,574 rows across 4,428 Guelin pairs (~20% of Guelin positives). BASEL source is exempt — its single observation per
-  pair is at log_dilution=0 by construction. Evaluation: each held-out pair scored at its max observed log10_pfu_ml
-  (Guelin neat 8.7, BASEL 9.0) with bacterium-level bootstrap CIs (1000 resamples). Result: **AUC 0.8217 [0.8054,
-  0.8365], Brier 0.1435 [0.1363, 0.1508]**. This is the active reference point for all future CHISEL arms. [validated;
-  source: CH04, 2026-04-19 CHISEL baseline; CH06-followup, 2026-04-20 filter adoption; see also: spandex-final-baseline,
-  cv-group-leakage-fixed, label-policy-binary, ranking-metrics-retired, per-phage-retired-under-chisel, deployment-goal]
-  - *Baseline movement over CHISEL: CH02 revalidated SX10 (pair-level any_lysis, 10-fold cv_group hashing, per-phage
+- **`chisel-baseline`**: CHISEL canonical baseline (CH04, reverted 2026-04-21 — see CH10 below): per-row binary training
+  on every interpretable (bacterium, phage, log_dilution, replicate, X, Y) raw observation with score ∈ {0, 1} and
+  `pair_concentration__log10_pfu_ml` as a numeric feature (absolute log₁₀ pfu/ml encoding — Guelin {4.7, 6.7, 7.7, 8.7};
+  BASEL 9.0 per Maffei 2021 / 2025), SX10 feature bundle (host_surface + host_typing + host_stats + host_defense +
+  phage_projection + phage_stats + pair_depo_capsule + pair_receptor_omp, RFE-selected), **all-pairs only** (AX02
+  per-phage blending retired, see per-phage-retired-under-chisel), 10-fold bacteria-axis CV under CH02 cv_group hashing,
+  369×96 panel. **No neat-only positive filter** — every raw observation with score ∈ {0, 1} trains. Evaluation: each
+  held-out pair scored at its max observed log10_pfu_ml with bacterium-level bootstrap CIs (1000 resamples). Result:
+  **AUC 0.8083 [0.7943, 0.8216], Brier 0.1751 [0.1677, 0.1824]** (n=35,266 pairs, 8,675 score='n' rows dropped). This is
+  the active reference point for all future CHISEL arms. [validated; source: CH04, 2026-04-19 CHISEL baseline; CH10,
+  2026-04-21 filter revert; see also: spandex-final-baseline, cv-group-leakage-fixed, label-policy-binary,
+  ranking-metrics-retired, per-phage-retired-under-chisel, deployment-goal]
+  - ***Baseline movement over CHISEL.** CH02 revalidated SX10 (pair-level any_lysis, 10-fold cv_group hashing, per-phage
     blending enabled) = AUC 0.8521, Brier 0.1317. CH04 initial canonical (per-row binary, all-pairs only, concentration
-    feature, pre-filter) = AUC 0.8084 [0.7944, 0.8217], Brier 0.1750 [0.1677, 0.1824] — ΔAUC −4.37 pp, ΔBrier +4.33 pp
-    vs CH02. CH04 post-CH06-followup (with neat-only filter) = AUC 0.8217, Brier 0.1435 — +1.3 pp AUC and −3.2 pp Brier
-    vs CH04 pre- filter. Three changes compound between CH02 and CH04 pre-filter: (a) per-row training replaces
-    pair-level any_lysis — every (bacterium, phage, log_dilution, replicate, X, Y) raw observation with score ∈ {0, 1}
-    becomes its own training row (rows with score = "n" are dropped as missing, not negative); (b) concentration enters
-    as a numeric feature (pair_concentration__log10_pfu_ml) so the model must predict at a specific concentration rather
-    than "does this pair ever lyse?"; (c) AX02 per-phage blending is retired (see per-phage-retired-under-chisel),
-    removing the bacterium-level memorization head that contributed to CH02's AUC under the bacteria-axis setup. The
-    CH06-followup filter adoption is the fourth adjustment: CH09 Arm 3 showed that dropping Guelin positives occurring
-    only at neat (the "clearing at high titer, possibly non-productive" candidate per Gaborieau 2024) yields a cleaner
-    discrimination surface. **The headline +1.3 pp AUC / −3.2 pp Brier vs pre-filter is NOT a pure model-quality gain**
-    — a 2026-04-21 post-hoc case-by-case decomposition (`.scratch/chisel_review/caseXcase_chisel.py`) shows that the
-    filter flips 4,428 pair eval labels 1→0 (12.6% of the 35,266-pair eval set). Mechanism: evaluation takes the label
-    from the pair's max-concentration observation; the filter removes the neat-only positive replicate in Guelin
-    training data and the same removal leaves a 0 replicate standing at eval time, so the pair appears as a trivial
-    negative instead of a narrow positive. The 2×2 decomposition on matched pairs: (prior model / prior labels) = 0.8084
-    AUC / 0.1750 Brier (headline); (prior model / canonical labels) = 0.8244 / 0.1916 (label-shift alone: +1.60 pp AUC
-    trivialization); (canonical model / prior labels) = 0.7937 / 0.1652 (model alone: **−1.47 pp AUC regression, −0.98
-    pp Brier improvement**); (canonical model / canonical labels) = 0.8217 / 0.1435 (file headline). On matched labels,
-    the filter-trained model has LOWER discrimination than the pre-filter model; the headline AUC gain is entirely a
-    population-easier artifact. Brier gain partially survives the decomposition (−0.98 pp genuine) because removing
-    neat-only positives from training makes the model predict lower probability on those pairs, which is correct once
-    the eval label flips to 0. ECE did NOT drop under the filter (+0.7 pp), consistent with the filter sharpening the
-    decision surface on the remaining (non-neat-only) positives rather than removing systematically over-inflated
-    predictions — see CH09 notebook entry for the directional-miss analysis. The filter adoption is still justified
-    (Gaborieau 2024 Methods explicitly admits clearing at high titer can be non-productive — we're correcting a
-    label-policy defect, not a model defect; and the −0.98 pp Brier improvement survives decomposition) but future
-    CHISEL comparisons must disclose this label-shift explicitly and cite the on-matched-labels AUC (0.7937 vs 0.8084)
-    when making model-quality claims. The (CH02 → CH04 pre-filter) diagnostic decomposition was done on the pre-filter
-    labels where evaluation distribution was nearly unchanged (27.4% positive at max-conc vs 27.6% pair-level any_lysis
-    — ~47 pair labels flip from the per-row vs any_lysis training-unit change alone), so the CH02 → CH04 pre-filter ΔAUC
-    is still a training-side signal. Concentration feature is the #4 ranked feature by mean LightGBM importance (280.5
-    under the post-filter canonical, 328.7 pre-filter), retained by RFE in all 30 fold × seed fits. Subsequent CHISEL
-    tickets (CH05 phage-axis, CH07 both-axis, CH08 feature re-audit, CH09 calibration layer) all anchor to the
-    post-filter canonical. The filter default can be reversed via `--no-drop-high-titer-only-positives` for sensitivity
-    analysis. Canonical artifacts: lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json,
-    ch04_predictions.csv (pair-level), ch04_per_row_predictions.csv (per-row), and ch04_feature_importance.csv.*
+    feature, no filter) = AUC 0.8084 [0.7944, 0.8217], Brier 0.1750 [0.1677, 0.1824] — ΔAUC −4.37 pp, ΔBrier +4.33 pp vs
+    CH02. Three changes compound between CH02 and CH04: (a) per-row training replaces pair-level any_lysis — every
+    (bacterium, phage, log_dilution, replicate, X, Y) raw observation with score ∈ {0, 1} becomes its own training row
+    (rows with score = "n" are dropped as missing, not negative); (b) concentration enters as a numeric feature
+    (pair_concentration__log10_pfu_ml) so the model must predict at a specific concentration rather than "does this pair
+    ever lyse?"; (c) AX02 per-phage blending is retired (see per-phage-retired-under-chisel), removing the
+    bacterium-level memorization head that contributed to CH02's AUC under the bacteria-axis setup. The evaluation
+    distribution is nearly unchanged between CH02 and CH04 (27.4% positive at max-conc vs 27.6% pair-level any_lysis),
+    so the CH02 → CH04 ΔAUC is a training-side signal. Concentration feature is the #4 ranked feature by mean LightGBM
+    importance (328.7), retained by RFE in all 30 fold × seed fits. The CH10 rerun on 2026-04-21 under
+    `drop_high_titer_only_positives=False` reproduces 0.8084 to 4 decimal places (AUC 0.808276 [0.794313, 0.821614],
+    Brier 0.175055 [0.167748, 0.182384], elapsed 1442 s). **Why the neat-only positive filter is NOT canonical (CH10
+    revert, 2026-04-21).** PR #444 (CH06-followup) adopted a training-side filter that dropped Guelin positive rows for
+    pairs whose every score='1' observation occurred only at log_dilution=0 (neat, ~5×10⁸ pfu/ml) — 7,574 rows across
+    4,428 pairs (~20% of Guelin positives). The filter's stated rationale was Gaborieau 2024 Methods ("clearing at high
+    titer *could* be non-productive"). Under it CH04 headline shifted to AUC 0.8217, Brier 0.1435 (+1.3 pp AUC, −3.2 pp
+    Brier). PR #453 disclosed a label-shift mechanism but kept the filter as canonical. CH10 reverses that decision
+    after four objections held up in review: (i) WRONG PROXY — Gaborieau 2024 flag plaques-vs-clearing as the phenotype
+    concern ("Clearing of the bacterial lawn at high phage concentration *could* result from productive lysis … or from
+    another mechanism such as lysis from without, or abortive infection"); our binary {0, 1, n} score cannot distinguish
+    plaques from clearing, and "positive observed only at neat" is not the same as "ambiguous clearing". A narrow-host
+    pair that barely lyses at max titer is dropped identically to an abortive-infection artifact. (ii)
+    TESTING-COMPLETENESS BIAS — "positive only at neat" is also "positive at neat AND either untested or negative at
+    lower dilutions". A pair with sparser dilution sampling is more likely to be filtered than one with richer sampling;
+    that is a data-collection selection, not biology. (iii) BASEL INCONSISTENCY — BASEL single-titer at >10⁹ pfu/ml is
+    HIGHER than Guelin's neat 5×10⁸, but the filter exempts BASEL wholesale. If "high titer is suspect" were the
+    biological rationale, BASEL positives would be MORE suspect, not exempt. The real reason BASEL is exempt is
+    structural (single-titer design), which confirms the filter is about Guelin-specific dilution sampling density, not
+    biology. (iv) PAPER DOES NOT DROP — Gaborieau's MLC score treats MLC=1 ("lytic at highest titer only") as a valid
+    included rung in the published interaction matrix and in the "average MLC upon infection" / "productive lysis %"
+    downstream analyses. We unilaterally reclassified ~20% of Guelin positives as non-lytic, contrary to the paper's own
+    convention. On top of all four: on matched (pre-filter) eval labels, the filter-trained model REGRESSES −1.47 pp AUC
+    (0.8084 → 0.7937). The headline +1.33 pp AUC was entirely a label-population-easier artifact — evaluation takes the
+    label from the pair's max-concentration observation, so the filter's training-side drop of the neat-only replicate
+    leaves a 0 replicate standing at eval time, flipping 4,428 pair eval labels 1→0 (12.6% of the 35,266-pair eval set).
+    The 2×2 decomposition on matched pairs: (prior model / prior labels) = 0.8084 / 0.1750; (prior model / filter
+    labels) = 0.8244 / 0.1916 (label-shift alone: +1.60 pp AUC trivialization); (filter model / prior labels) = 0.7937 /
+    0.1652 (model alone: **−1.47 pp AUC regression**, −0.98 pp Brier improvement); (filter model / filter labels) =
+    0.8217 / 0.1435. The −0.98 pp Brier improvement that survives decomposition is addressed by the CH09 isotonic
+    calibration layer without the label-policy cost. Reviewer artifacts: .scratch/chisel_review/caseXcase_chisel.py,
+    caseXcase_prior_vs_canonical.md. **Downstream impact.** CH05 (CH11 rerun), CH07 (rerun bundled into CH10), CH08
+    (CH12 rerun), and CH09 isotonic refit (bundled into CH11) were all anchored to the deprecated post-filter canonical
+    and are re-running under the reverted pre-filter default. CH11/CH12 preserve the deprecated post-filter artifacts in
+    `_post_filter/` side-directories for sensitivity comparison. The filter remains available as an opt-in CLI flag
+    (`--drop-high-titer-only-positives`) but is not the default in any eval script. The
+    `moriniere-receptor-fractions-validated` knowledge unit cites post-filter CH05 numbers; CH11 will re-cite under the
+    reverted canonical. **SUPERSEDES: PR #453** (commit c22faf7, merged 2026-04-21) — #453 amended the knowledge unit to
+    disclose the label-shift artifact but kept the filter as canonical. CH10 demotes the filter entirely. **Canonical
+    artifacts:** lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json, ch04_predictions.csv
+    (pair-level), ch04_per_row_predictions.csv (per-row), and ch04_feature_importance.csv.*
 - **`spandex-final-baseline`**: HISTORICAL (SPANDEX-era). Superseded as the active canonical by chisel-baseline (CH04).
   SPANDEX final configuration — GT03 all_gates_rfe + AX02 per-phage blending on SX05-corrected MLC 0-3 labels, 10-fold
   CV bacteria-axis on the 369×96 panel: **AUC 0.8699 [0.8570, 0.8819], Brier 0.1248 [0.1187, 0.1309]** within-panel,
@@ -269,64 +283,72 @@ Architecture choices, calibration, and performance bounds.
     leakage). Future CHISEL tickets evaluating a single candidate arm can reuse
     `.agents/skills/case-by-case/compare_predictions.py` for per-bacterium audit and the sx14_eval.py pipeline for full
     four-stratum decomposition when narrow-host behaviour is specifically under investigation.*
-- **`chisel-unified-kfold-baseline`**: CHISEL unified Guelin+BASEL k-fold baseline (CH05, updated 2026-04-20 with
-  CH06-followup neat-only filter adoption): per-row binary training on the unified 148-phage × 369-bacteria panel
-  (36,643 pairs: 35,403 Guelin + 1,240 BASEL), SX10 feature bundle, all-pairs only (per-phage blending retired
-  track-wide per `per-phage-retired-under-chisel`), neat-only positive filter applied to Guelin training rows (see
-  chisel-baseline). Two axes: **bacteria-axis AUC 0.8218 [0.8063, 0.8368], Brier 0.1466 [0.1393, 0.1538]** (10-fold CH02
-  cv_group hash; all 148 phages in training per fold); **phage-axis AUC 0.8919 [0.8650, 0.9166], Brier 0.1181 [0.1012,
-  0.1359]** (10-fold StratifiedKFold by ICTV family + "other" <10-phage bucket + "UNKNOWN" no-family bucket — 40% of
-  folds are pseudo-family catch-alls; calling it "ICTV-stratified" without that qualifier misleads). Three separate
-  findings stand in place of the earlier "cross-source AUC parity" headline: **(1) phage-axis discrimination parity**
-  (Guelin 0.8922 vs BASEL 0.8822, |ΔAUC| 0.0100 — still a weak non-rejection on 52 BASEL phages with CI 3× wider than
-  Guelin's, not positive evidence of transfer; the filter widened the gap slightly from 0.0032 pre-filter because
-  Guelin's discrimination sharpened more than BASEL's under the filter, which is expected — the filter only touches
-  Guelin training rows); **(2) phage-axis calibration divergence** (Guelin Brier 0.1156 vs BASEL 0.1890, disjoint CIs,
-  BASEL mid-P reliability gap 21-27 pp wider than Guelin's in the 0.5-0.9 predicted-probability bins); **(3) BASEL
-  bacteria-axis deficit** (BASEL-only bacteria-axis AUC 0.7229 on the 1,240 BASEL pairs vs Guelin-only 0.8247 on the
-  same axis — a 10.2 pp BASEL-specific deficit essentially unchanged by the filter — pre-filter was 9.5 pp, the +0.7 pp
-  widening comes from Guelin sharpening under the filter more than BASEL does. Confirms the deficit is a feature-space /
-  panel-mismatch issue, not a label-noise issue, since a Guelin-only label-quality filter would not change BASEL's
-  absolute discrimination if BASEL's miscalibration lived in labels). Expected Calibration Error (ECE, weighted mean of
-  per-decile |observed−predicted| gaps) under the post-filter canonical: **bacteria-axis Guelin ECE 0.130, BASEL ECE
-  0.216; phage-axis Guelin ECE 0.130, BASEL ECE 0.237**. Two separable root-cause mechanisms, each diagnostically
-  distinct: **(A) Guelin mid-P miscalibration = training-label-vs-deployment-question mismatch, post-hoc fixable**.
-  Leave-one-fold-out isotonic regression on Guelin predictions closes Guelin ECE to 0.005-0.008 on both axes (~94-96%
-  ECE closure measured under the pre-filter CH09 canonical; the post-filter LOOF closure is re-derived as part of the
-  CH09 PR rebase and should remain in the same band — see the closure-metric note below for the reconciliation of ECE vs
-  max|gap| closure reporting). AUC preserved within 0.5 pp. The training label is more permissive than the deployment
-  target; Gaborieau 2024 Methods explicitly admits clearing at high titer can be non-productive. Two complementary
-  remedies: the CH06-followup filter adoption drops the most-likely non-productive Guelin positives at the training-side
-  (+1.3-1.6 pp AUC lift on both axes); the CH09 post-hoc isotonic calibration layer remaps probabilities to observed
-  frequencies (closes Guelin ECE 94-96%). Remedies compose: filter sharpens discrimination, isotonic fixes remaining
-  miscalibration. Connects to `ambiguous-label-noise`. **(B) BASEL's additional miscalibration = TL17-bias on the
-  phage-side feature slot, NOT threshold**. Applying the Guelin-fitted isotonic calibrator to BASEL closes only part of
-  the gap — magnitude depends on which closure metric one uses (see closure-metric note below); residual BASEL ECE after
-  transfer is ~0.11 bacteria-axis / 0.13 phage-axis, still ~20× Guelin's calibrated ECE. Threshold-mismatch remedy does
-  NOT rescue BASEL's extra miscalibration. Root cause isolated to the 39/52 BASEL phages whose `phage_projection`
-  vectors are non-zero (Brier 0.31 bacteria-axis pre-filter): their projection vectors map into Guelin-derived TL17
-  neighborhoods associated with broad-host lysis but carry narrower actual host ranges. The 13/52 BASEL phages with
-  zero-vector projection calibrate correctly (Brier 0.12) because the model has no phage signal to misuse and falls back
-  to the host-side prior. Requires panel- independent phage features (CH06 Arms 2-4 target), not calibration.
-  Straboviridae exclusion closes only 1.5 pp of the 9.5 pp bacteria-axis BASEL deficit — family bias is not the driver.
-  **Closure-metric note (reconciles CH05 vs CH09 numbers).** Two valid closure metrics for BASEL calibration transfer,
-  which look different but are measuring different things: (i) **max|gap| closure** = reduction of the WORST-decile
-  |observed−predicted| gap after isotonic (CH05 pre-filter era reported bacteria-axis 51.6→32.6 pp = 36.8% closure,
-  phage-axis 48.3→32.0 pp = 33.8% closure); (ii) **ECE closure** = reduction of the ECE (weighted across all deciles)
-  after isotonic. Under the post-filter canonical (CH06-followup PR #444 + CH09 PR #443): CH09 reports bacteria-axis ECE
-  0.216→0.044 = **79.5%** closure and phage-axis ECE 0.237→0.111 = **53.2%** closure — both materially better than the
-  pre-filter CH09 numbers (61.8% / 44.5%), confirming the neat-only filter improves cross-panel calibration transfer,
-  not just discrimination. max|gap| closes less than ECE by construction because the worst-case decile resists shrinkage
-  more than the average decile; phage-axis BASEL reliability tables show the transferred calibrator still overshoots the
-  0.5-0.8 mid-P bins by +0.25-0.35 pp even when ECE has compressed by half. Both metrics are preserved here as valid
-  characterizations — earlier drafts that quoted "34-37% closure" without saying which metric were ambiguous (the 34-37%
-  range tracks max|gap|, not ECE). Residual BASEL ECE after transfer **0.044 bacteria / 0.111 phage** is the
-  load-bearing number: BASEL remains ~6-17× worse-calibrated than Guelin under the shared calibrator (Guelin LOOF ECE ≈
-  0.007 on both axes), and TL17-bias remains the residual mechanism. This is the active CHISEL reference for two-axis
-  generalization and cross- source behaviour. [validated; source: CH05, 2026-04-19 CHISEL unified k-fold; CH06-followup,
-  2026-04-20 filter adoption; CH09, 2026-04-20 calibration layer; see also: chisel-baseline,
-  spandex-unified-kfold-baseline, per-phage-retired-under-chisel, cv-group-leakage-fixed, new-phage-generalization,
-  deployment-goal, plm-rbp-redundant, panel-size-ceiling]
+- **`chisel-unified-kfold-baseline`**: **CAVEAT (2026-04-21, CH10 revert):** the numbers below were computed under the
+  deprecated post-filter frame (CH06-followup neat-only positive filter enabled). CH11 will re-run CH05 and refit the
+  CH09 isotonic calibrator under the reverted pre-filter canonical — this unit's headline numbers will shift when CH11
+  lands. The filter is demoted to an opt-in sensitivity analysis; see chisel-baseline for the four reviewer objections.
+  Until CH11, cite these numbers with the "post-filter frame, pending CH11 rerun" qualifier. The three structural
+  findings below (phage-axis discrimination parity, phage-axis calibration divergence, BASEL bacteria-axis deficit) are
+  expected to qualitatively survive the rerun — the filter widened the Guelin–BASEL gap but did not introduce the BASEL
+  deficit, which is a panel-mismatch signal not a label-quality signal. CHISEL unified Guelin+BASEL k-fold baseline
+  (CH05, updated 2026-04-20 with CH06-followup neat-only filter adoption): per-row binary training on the unified
+  148-phage × 369-bacteria panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL), SX10 feature bundle, all-pairs only
+  (per-phage blending retired track-wide per `per-phage-retired-under-chisel`), neat-only positive filter applied to
+  Guelin training rows (see chisel-baseline). Two axes: **bacteria-axis AUC 0.8218 [0.8063, 0.8368], Brier 0.1466
+  [0.1393, 0.1538]** (10-fold CH02 cv_group hash; all 148 phages in training per fold); **phage-axis AUC 0.8919 [0.8650,
+  0.9166], Brier 0.1181 [0.1012, 0.1359]** (10-fold StratifiedKFold by ICTV family + "other" <10-phage bucket +
+  "UNKNOWN" no-family bucket — 40% of folds are pseudo-family catch-alls; calling it "ICTV-stratified" without that
+  qualifier misleads). Three separate findings stand in place of the earlier "cross-source AUC parity" headline: **(1)
+  phage-axis discrimination parity** (Guelin 0.8922 vs BASEL 0.8822, |ΔAUC| 0.0100 — still a weak non-rejection on 52
+  BASEL phages with CI 3× wider than Guelin's, not positive evidence of transfer; the filter widened the gap slightly
+  from 0.0032 pre-filter because Guelin's discrimination sharpened more than BASEL's under the filter, which is expected
+  — the filter only touches Guelin training rows); **(2) phage-axis calibration divergence** (Guelin Brier 0.1156 vs
+  BASEL 0.1890, disjoint CIs, BASEL mid-P reliability gap 21-27 pp wider than Guelin's in the 0.5-0.9
+  predicted-probability bins); **(3) BASEL bacteria-axis deficit** (BASEL-only bacteria-axis AUC 0.7229 on the 1,240
+  BASEL pairs vs Guelin-only 0.8247 on the same axis — a 10.2 pp BASEL-specific deficit essentially unchanged by the
+  filter — pre-filter was 9.5 pp, the +0.7 pp widening comes from Guelin sharpening under the filter more than BASEL
+  does. Confirms the deficit is a feature-space / panel-mismatch issue, not a label-noise issue, since a Guelin-only
+  label-quality filter would not change BASEL's absolute discrimination if BASEL's miscalibration lived in labels).
+  Expected Calibration Error (ECE, weighted mean of per-decile |observed−predicted| gaps) under the post-filter
+  canonical: **bacteria-axis Guelin ECE 0.130, BASEL ECE 0.216; phage-axis Guelin ECE 0.130, BASEL ECE 0.237**. Two
+  separable root-cause mechanisms, each diagnostically distinct: **(A) Guelin mid-P miscalibration =
+  training-label-vs-deployment-question mismatch, post-hoc fixable**. Leave-one-fold-out isotonic regression on Guelin
+  predictions closes Guelin ECE to 0.005-0.008 on both axes (~94-96% ECE closure measured under the pre-filter CH09
+  canonical; the post-filter LOOF closure is re-derived as part of the CH09 PR rebase and should remain in the same band
+  — see the closure-metric note below for the reconciliation of ECE vs max|gap| closure reporting). AUC preserved within
+  0.5 pp. The training label is more permissive than the deployment target; Gaborieau 2024 Methods explicitly admits
+  clearing at high titer can be non-productive. Two complementary remedies: the CH06-followup filter adoption drops the
+  most-likely non-productive Guelin positives at the training-side (+1.3-1.6 pp AUC lift on both axes); the CH09
+  post-hoc isotonic calibration layer remaps probabilities to observed frequencies (closes Guelin ECE 94-96%). Remedies
+  compose: filter sharpens discrimination, isotonic fixes remaining miscalibration. Connects to `ambiguous-label-noise`.
+  **(B) BASEL's additional miscalibration = TL17-bias on the phage-side feature slot, NOT threshold**. Applying the
+  Guelin-fitted isotonic calibrator to BASEL closes only part of the gap — magnitude depends on which closure metric one
+  uses (see closure-metric note below); residual BASEL ECE after transfer is ~0.11 bacteria-axis / 0.13 phage-axis,
+  still ~20× Guelin's calibrated ECE. Threshold-mismatch remedy does NOT rescue BASEL's extra miscalibration. Root cause
+  isolated to the 39/52 BASEL phages whose `phage_projection` vectors are non-zero (Brier 0.31 bacteria-axis
+  pre-filter): their projection vectors map into Guelin-derived TL17 neighborhoods associated with broad-host lysis but
+  carry narrower actual host ranges. The 13/52 BASEL phages with zero-vector projection calibrate correctly (Brier 0.12)
+  because the model has no phage signal to misuse and falls back to the host-side prior. Requires panel- independent
+  phage features (CH06 Arms 2-4 target), not calibration. Straboviridae exclusion closes only 1.5 pp of the 9.5 pp
+  bacteria-axis BASEL deficit — family bias is not the driver. **Closure-metric note (reconciles CH05 vs CH09
+  numbers).** Two valid closure metrics for BASEL calibration transfer, which look different but are measuring different
+  things: (i) **max|gap| closure** = reduction of the WORST-decile |observed−predicted| gap after isotonic (CH05
+  pre-filter era reported bacteria-axis 51.6→32.6 pp = 36.8% closure, phage-axis 48.3→32.0 pp = 33.8% closure); (ii)
+  **ECE closure** = reduction of the ECE (weighted across all deciles) after isotonic. Under the post-filter canonical
+  (CH06-followup PR #444 + CH09 PR #443): CH09 reports bacteria-axis ECE 0.216→0.044 = **79.5%** closure and phage-axis
+  ECE 0.237→0.111 = **53.2%** closure — both materially better than the pre-filter CH09 numbers (61.8% / 44.5%),
+  confirming the neat-only filter improves cross-panel calibration transfer, not just discrimination. max|gap| closes
+  less than ECE by construction because the worst-case decile resists shrinkage more than the average decile; phage-axis
+  BASEL reliability tables show the transferred calibrator still overshoots the 0.5-0.8 mid-P bins by +0.25-0.35 pp even
+  when ECE has compressed by half. Both metrics are preserved here as valid characterizations — earlier drafts that
+  quoted "34-37% closure" without saying which metric were ambiguous (the 34-37% range tracks max|gap|, not ECE).
+  Residual BASEL ECE after transfer **0.044 bacteria / 0.111 phage** is the load-bearing number: BASEL remains ~6-17×
+  worse-calibrated than Guelin under the shared calibrator (Guelin LOOF ECE ≈ 0.007 on both axes), and TL17-bias remains
+  the residual mechanism. This is the active CHISEL reference for two-axis generalization and cross- source behaviour.
+  [validated; source: CH05, 2026-04-19 CHISEL unified k-fold; CH06-followup, 2026-04-20 filter adoption; CH09,
+  2026-04-20 calibration layer; see also: chisel-baseline, spandex-unified-kfold-baseline,
+  per-phage-retired-under-chisel, cv-group-leakage-fixed, new-phage-generalization, deployment-goal, plm-rbp-redundant,
+  panel-size-ceiling]
   - ***Baseline movement across CHISEL tickets** (numbers here reference the 148×369 unified panel unless otherwise
     noted): - CH05 initial canonical (pre-filter, absolute log₁₀ pfu/ml encoding):   bacteria-axis AUC 0.8061 [0.7917,
     0.8199] / Brier 0.1778; phage-axis AUC   0.8850 [0.8617, 0.9062] / Brier 0.1348; cross-source phage-axis Guelin

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -444,22 +444,31 @@ themes:
           without the label-policy cost. Reviewer artifacts:
           .scratch/chisel_review/caseXcase_chisel.py, caseXcase_prior_vs_canonical.md.
 
-          **Downstream impact.** CH05 (CH11 rerun), CH07 (rerun bundled into CH10), CH08
-          (CH12 rerun), and CH09 isotonic refit (bundled into CH11) were all anchored to
-          the deprecated post-filter canonical and are re-running under the reverted
-          pre-filter default. CH11/CH12 preserve the deprecated post-filter artifacts in
-          `_post_filter/` side-directories for sensitivity comparison. The filter remains
-          available as an opt-in CLI flag (`--drop-high-titer-only-positives`) but is not
-          the default in any eval script. The `moriniere-receptor-fractions-validated`
-          knowledge unit cites post-filter CH05 numbers; CH11 will re-cite under the
-          reverted canonical. **SUPERSEDES: PR #453** (commit c22faf7, merged
-          2026-04-21) — #453 amended the knowledge unit to disclose the label-shift
-          artifact but kept the filter as canonical. CH10 demotes the filter entirely.
+          **Downstream impact.** CH05 (CH11 rerun), CH08 (CH12 rerun), and CH09 isotonic
+          refit (bundled into CH11) were anchored to the deprecated post-filter canonical
+          and are re-running under the reverted pre-filter default. CH07 rerun was
+          bundled into CH10 and completed 2026-04-21: aggregate 10×10 both-axis AUC
+          **0.7634 [0.7581, 0.7689]**, Brier **0.1902 [0.1874, 0.1927]** on 36,643
+          unified-panel pairs under the Arm 3 phage_projection slot — −1.15 pp vs the
+          deprecated post-filter 0.7749, directionally consistent with the label-shift
+          mechanism (filter trivialized eval labels) and now the load-bearing cold-
+          start deployability number. CH11/CH12 preserve the deprecated post-filter
+          artifacts in `_post_filter/` side-directories for sensitivity comparison. The
+          filter remains available as an opt-in CLI flag
+          (`--drop-high-titer-only-positives`) but is not the default in any eval
+          script. The `moriniere-receptor-fractions-validated` knowledge unit cites
+          post-filter CH05 numbers; CH11 will re-cite under the reverted canonical.
+          **SUPERSEDES: PR #453** (commit c22faf7, merged 2026-04-21) — #453 amended
+          the knowledge unit to disclose the label-shift artifact but kept the filter
+          as canonical. CH10 demotes the filter entirely.
 
           **Canonical artifacts:**
           lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json,
-          ch04_predictions.csv (pair-level), ch04_per_row_predictions.csv (per-row), and
-          ch04_feature_importance.csv.
+          ch04_predictions.csv (pair-level), ch04_per_row_predictions.csv (per-row),
+          ch04_feature_importance.csv;
+          lyzortx/generated_outputs/ch07_both_axis_holdout/ch07_aggregate.json,
+          ch07_pair_predictions.csv, ch07_per_row_predictions.csv, ch07_cell_metrics.csv,
+          ch07_cross_source_breakdown.csv, ch07_cell_distribution.png.
         relates_to: [spandex-final-baseline, cv-group-leakage-fixed, label-policy-binary,
                      ranking-metrics-retired, per-phage-retired-under-chisel,
                      deployment-goal]

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -287,6 +287,14 @@ themes:
 
       - id: moriniere-receptor-fractions-validated
         statement: >
+          **CAVEAT (2026-04-21, CH10 revert):** numbers below were computed on the
+          CH05 unified panel under the deprecated post-filter frame. CH11 will re-run
+          CH05 (and CH13 will re-run CH06 arms if needed) under the reverted pre-filter
+          canonical; directional findings (Arm 3 meets acceptance, Arms 2/4 null) are
+          expected to survive since Arm 3's rescue is on BASEL zero-vector phages and
+          the filter only touches Guelin training rows. Treat headline numbers as
+          post-filter-frame estimates pending the CH11 rerun.
+
           CH06 Arm 3 validates Moriniere 2026 per-receptor k-mer-fraction vectors (13 dim,
           one fraction per receptor class, = `|kmers(R) ∩ kmers(P)| / |kmers(R)|`) as the
           canonical panel-independent replacement for the Guelin-derived TL17 `phage_projection`
@@ -351,85 +359,104 @@ themes:
 
       - id: chisel-baseline
         statement: >
-          CHISEL canonical baseline (CH04, updated 2026-04-20 with CH06-followup neat-only
-          filter): per-row binary training on every interpretable (bacterium, phage,
-          log_dilution, replicate, X, Y) raw observation with `pair_concentration__log10_pfu_ml`
-          as a numeric feature (absolute log₁₀ pfu/ml encoding, replacing the earlier
-          relative log_dilution encoding — CH05 track-wide change), SX10 feature bundle
-          otherwise unchanged (host_surface + host_typing + host_stats + host_defense +
-          phage_projection + phage_stats + pair_depo_capsule + pair_receptor_omp,
-          RFE-selected), **all-pairs only** (AX02 per-phage blending retired, see
-          per-phage-retired-under-chisel), 10-fold bacteria-axis CV under CH02 cv_group
-          hashing, 369×96 panel. **Training label policy includes the neat-only positive
-          filter**: Guelin pairs whose every score='1' observation is at log_dilution=0
-          (neat) have their positive rows dropped as candidate-non-productive per
-          Gaborieau 2024 Methods ("clearing at high titer can be non-productive"). Filter
-          drops 7,574 rows across 4,428 Guelin pairs (~20% of Guelin positives). BASEL
-          source is exempt — its single observation per pair is at log_dilution=0 by
-          construction. Evaluation: each held-out pair scored at its max observed
-          log10_pfu_ml (Guelin neat 8.7, BASEL 9.0) with bacterium-level bootstrap CIs
-          (1000 resamples). Result: **AUC 0.8217 [0.8054, 0.8365], Brier 0.1435 [0.1363,
-          0.1508]**. This is the active reference point for all future CHISEL arms.
-        sources: [CH04, 2026-04-19 CHISEL baseline; CH06-followup, 2026-04-20 filter adoption]
+          CHISEL canonical baseline (CH04, reverted 2026-04-21 — see CH10 below): per-row
+          binary training on every interpretable (bacterium, phage, log_dilution, replicate,
+          X, Y) raw observation with score ∈ {0, 1} and `pair_concentration__log10_pfu_ml`
+          as a numeric feature (absolute log₁₀ pfu/ml encoding — Guelin {4.7, 6.7, 7.7, 8.7};
+          BASEL 9.0 per Maffei 2021 / 2025), SX10 feature bundle (host_surface + host_typing
+          + host_stats + host_defense + phage_projection + phage_stats + pair_depo_capsule
+          + pair_receptor_omp, RFE-selected), **all-pairs only** (AX02 per-phage blending
+          retired, see per-phage-retired-under-chisel), 10-fold bacteria-axis CV under CH02
+          cv_group hashing, 369×96 panel. **No neat-only positive filter** — every raw
+          observation with score ∈ {0, 1} trains. Evaluation: each held-out pair scored at
+          its max observed log10_pfu_ml with bacterium-level bootstrap CIs (1000 resamples).
+          Result: **AUC 0.8083 [0.7943, 0.8216], Brier 0.1751 [0.1677, 0.1824]** (n=35,266
+          pairs, 8,675 score='n' rows dropped). This is the active reference point for all
+          future CHISEL arms.
+        sources: [CH04, 2026-04-19 CHISEL baseline; CH10, 2026-04-21 filter revert]
         status: active
         confidence: validated
         context: >
-          Baseline movement over CHISEL: CH02 revalidated SX10 (pair-level any_lysis, 10-fold
-          cv_group hashing, per-phage blending enabled) = AUC 0.8521, Brier 0.1317. CH04
-          initial canonical (per-row binary, all-pairs only, concentration feature,
-          pre-filter) = AUC 0.8084 [0.7944, 0.8217], Brier 0.1750 [0.1677, 0.1824] — ΔAUC
-          −4.37 pp, ΔBrier +4.33 pp vs CH02. CH04 post-CH06-followup (with neat-only
-          filter) = AUC 0.8217, Brier 0.1435 — +1.3 pp AUC and −3.2 pp Brier vs CH04 pre-
-          filter. Three changes compound between CH02 and CH04 pre-filter: (a) per-row
-          training replaces pair-level any_lysis — every (bacterium, phage, log_dilution,
-          replicate, X, Y) raw observation with score ∈ {0, 1} becomes its own training
-          row (rows with score = "n" are dropped as missing, not negative); (b)
-          concentration enters as a numeric feature (pair_concentration__log10_pfu_ml) so
-          the model must predict at a specific concentration rather than "does this pair
-          ever lyse?"; (c) AX02 per-phage blending is retired (see
+          **Baseline movement over CHISEL.** CH02 revalidated SX10 (pair-level any_lysis,
+          10-fold cv_group hashing, per-phage blending enabled) = AUC 0.8521, Brier 0.1317.
+          CH04 initial canonical (per-row binary, all-pairs only, concentration feature,
+          no filter) = AUC 0.8084 [0.7944, 0.8217], Brier 0.1750 [0.1677, 0.1824] — ΔAUC
+          −4.37 pp, ΔBrier +4.33 pp vs CH02. Three changes compound between CH02 and CH04:
+          (a) per-row training replaces pair-level any_lysis — every (bacterium, phage,
+          log_dilution, replicate, X, Y) raw observation with score ∈ {0, 1} becomes its
+          own training row (rows with score = "n" are dropped as missing, not negative);
+          (b) concentration enters as a numeric feature (pair_concentration__log10_pfu_ml)
+          so the model must predict at a specific concentration rather than "does this
+          pair ever lyse?"; (c) AX02 per-phage blending is retired (see
           per-phage-retired-under-chisel), removing the bacterium-level memorization head
-          that contributed to CH02's AUC under the bacteria-axis setup. The CH06-followup
-          filter adoption is the fourth adjustment: CH09 Arm 3 showed that dropping
-          Guelin positives occurring only at neat (the "clearing at high titer, possibly
-          non-productive" candidate per Gaborieau 2024) yields a cleaner discrimination
-          surface. **The headline +1.3 pp AUC / −3.2 pp Brier vs pre-filter is NOT a
-          pure model-quality gain** — a 2026-04-21 post-hoc case-by-case decomposition
-          (`.scratch/chisel_review/caseXcase_chisel.py`) shows that the filter flips
-          4,428 pair eval labels 1→0 (12.6% of the 35,266-pair eval set). Mechanism:
-          evaluation takes the label from the pair's max-concentration observation;
-          the filter removes the neat-only positive replicate in Guelin training data
-          and the same removal leaves a 0 replicate standing at eval time, so the pair
-          appears as a trivial negative instead of a narrow positive. The 2×2 decomposition
-          on matched pairs: (prior model / prior labels) = 0.8084 AUC / 0.1750 Brier
-          (headline); (prior model / canonical labels) = 0.8244 / 0.1916 (label-shift
-          alone: +1.60 pp AUC trivialization); (canonical model / prior labels) = 0.7937
-          / 0.1652 (model alone: **−1.47 pp AUC regression, −0.98 pp Brier improvement**);
-          (canonical model / canonical labels) = 0.8217 / 0.1435 (file headline).
-          On matched labels, the filter-trained model has LOWER discrimination than
-          the pre-filter model; the headline AUC gain is entirely a population-easier
-          artifact. Brier gain partially survives the decomposition (−0.98 pp genuine)
-          because removing neat-only positives from training makes the model predict
-          lower probability on those pairs, which is correct once the eval label flips
-          to 0. ECE did NOT drop under the filter (+0.7 pp), consistent with the filter
-          sharpening the decision surface on the remaining (non-neat-only) positives
-          rather than removing systematically over-inflated predictions — see CH09
-          notebook entry for the directional-miss analysis. The filter adoption is
-          still justified (Gaborieau 2024 Methods explicitly admits clearing at high
-          titer can be non-productive — we're correcting a label-policy defect, not
-          a model defect; and the −0.98 pp Brier improvement survives decomposition)
-          but future CHISEL comparisons must disclose this label-shift explicitly and
-          cite the on-matched-labels AUC (0.7937 vs 0.8084) when making model-quality
-          claims. The (CH02 → CH04 pre-filter) diagnostic decomposition was done on
-          the pre-filter labels where evaluation distribution was nearly unchanged
-          (27.4% positive at max-conc vs 27.6% pair-level any_lysis — ~47 pair labels
-          flip from the per-row vs any_lysis training-unit change alone), so the CH02
-          → CH04 pre-filter ΔAUC is still a training-side signal. Concentration
-          feature is the #4 ranked feature by mean LightGBM importance (280.5 under the
-          post-filter canonical, 328.7 pre-filter), retained by RFE in all 30 fold × seed
-          fits. Subsequent CHISEL tickets (CH05 phage-axis, CH07 both-axis, CH08 feature
-          re-audit, CH09 calibration layer) all anchor to the post-filter canonical. The
-          filter default can be reversed via `--no-drop-high-titer-only-positives` for
-          sensitivity analysis. Canonical artifacts:
+          that contributed to CH02's AUC under the bacteria-axis setup. The evaluation
+          distribution is nearly unchanged between CH02 and CH04 (27.4% positive at
+          max-conc vs 27.6% pair-level any_lysis), so the CH02 → CH04 ΔAUC is a
+          training-side signal. Concentration feature is the #4 ranked feature by mean
+          LightGBM importance (328.7), retained by RFE in all 30 fold × seed fits. The
+          CH10 rerun on 2026-04-21 under `drop_high_titer_only_positives=False`
+          reproduces 0.8084 to 4 decimal places (AUC 0.808276 [0.794313, 0.821614],
+          Brier 0.175055 [0.167748, 0.182384], elapsed 1442 s).
+
+          **Why the neat-only positive filter is NOT canonical (CH10 revert, 2026-04-21).**
+          PR #444 (CH06-followup) adopted a training-side filter that dropped Guelin
+          positive rows for pairs whose every score='1' observation occurred only at
+          log_dilution=0 (neat, ~5×10⁸ pfu/ml) — 7,574 rows across 4,428 pairs (~20% of
+          Guelin positives). The filter's stated rationale was Gaborieau 2024 Methods
+          ("clearing at high titer *could* be non-productive"). Under it CH04 headline
+          shifted to AUC 0.8217, Brier 0.1435 (+1.3 pp AUC, −3.2 pp Brier). PR #453
+          disclosed a label-shift mechanism but kept the filter as canonical. CH10
+          reverses that decision after four objections held up in review:
+          (i) WRONG PROXY — Gaborieau 2024 flag plaques-vs-clearing as the phenotype
+          concern ("Clearing of the bacterial lawn at high phage concentration *could*
+          result from productive lysis … or from another mechanism such as lysis from
+          without, or abortive infection"); our binary {0, 1, n} score cannot distinguish
+          plaques from clearing, and "positive observed only at neat" is not the same as
+          "ambiguous clearing". A narrow-host pair that barely lyses at max titer is
+          dropped identically to an abortive-infection artifact.
+          (ii) TESTING-COMPLETENESS BIAS — "positive only at neat" is also "positive at
+          neat AND either untested or negative at lower dilutions". A pair with sparser
+          dilution sampling is more likely to be filtered than one with richer sampling;
+          that is a data-collection selection, not biology.
+          (iii) BASEL INCONSISTENCY — BASEL single-titer at >10⁹ pfu/ml is HIGHER than
+          Guelin's neat 5×10⁸, but the filter exempts BASEL wholesale. If "high titer is
+          suspect" were the biological rationale, BASEL positives would be MORE suspect,
+          not exempt. The real reason BASEL is exempt is structural (single-titer design),
+          which confirms the filter is about Guelin-specific dilution sampling density,
+          not biology.
+          (iv) PAPER DOES NOT DROP — Gaborieau's MLC score treats MLC=1 ("lytic at
+          highest titer only") as a valid included rung in the published interaction
+          matrix and in the "average MLC upon infection" / "productive lysis %"
+          downstream analyses. We unilaterally reclassified ~20% of Guelin positives
+          as non-lytic, contrary to the paper's own convention.
+          On top of all four: on matched (pre-filter) eval labels, the filter-trained
+          model REGRESSES −1.47 pp AUC (0.8084 → 0.7937). The headline +1.33 pp AUC was
+          entirely a label-population-easier artifact — evaluation takes the label from
+          the pair's max-concentration observation, so the filter's training-side drop
+          of the neat-only replicate leaves a 0 replicate standing at eval time, flipping
+          4,428 pair eval labels 1→0 (12.6% of the 35,266-pair eval set). The 2×2
+          decomposition on matched pairs: (prior model / prior labels) = 0.8084 / 0.1750;
+          (prior model / filter labels) = 0.8244 / 0.1916 (label-shift alone: +1.60 pp
+          AUC trivialization); (filter model / prior labels) = 0.7937 / 0.1652 (model
+          alone: **−1.47 pp AUC regression**, −0.98 pp Brier improvement); (filter model
+          / filter labels) = 0.8217 / 0.1435. The −0.98 pp Brier improvement that
+          survives decomposition is addressed by the CH09 isotonic calibration layer
+          without the label-policy cost. Reviewer artifacts:
+          .scratch/chisel_review/caseXcase_chisel.py, caseXcase_prior_vs_canonical.md.
+
+          **Downstream impact.** CH05 (CH11 rerun), CH07 (rerun bundled into CH10), CH08
+          (CH12 rerun), and CH09 isotonic refit (bundled into CH11) were all anchored to
+          the deprecated post-filter canonical and are re-running under the reverted
+          pre-filter default. CH11/CH12 preserve the deprecated post-filter artifacts in
+          `_post_filter/` side-directories for sensitivity comparison. The filter remains
+          available as an opt-in CLI flag (`--drop-high-titer-only-positives`) but is not
+          the default in any eval script. The `moriniere-receptor-fractions-validated`
+          knowledge unit cites post-filter CH05 numbers; CH11 will re-cite under the
+          reverted canonical. **SUPERSEDES: PR #453** (commit c22faf7, merged
+          2026-04-21) — #453 amended the knowledge unit to disclose the label-shift
+          artifact but kept the filter as canonical. CH10 demotes the filter entirely.
+
+          **Canonical artifacts:**
           lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json,
           ch04_predictions.csv (pair-level), ch04_per_row_predictions.csv (per-row), and
           ch04_feature_importance.csv.
@@ -497,6 +524,19 @@ themes:
 
       - id: chisel-unified-kfold-baseline
         statement: >
+          **CAVEAT (2026-04-21, CH10 revert):** the numbers below were computed under
+          the deprecated post-filter frame (CH06-followup neat-only positive filter
+          enabled). CH11 will re-run CH05 and refit the CH09 isotonic calibrator under
+          the reverted pre-filter canonical — this unit's headline numbers will shift
+          when CH11 lands. The filter is demoted to an opt-in sensitivity analysis;
+          see chisel-baseline for the four reviewer objections. Until CH11, cite these
+          numbers with the "post-filter frame, pending CH11 rerun" qualifier. The
+          three structural findings below (phage-axis discrimination parity, phage-axis
+          calibration divergence, BASEL bacteria-axis deficit) are expected to
+          qualitatively survive the rerun — the filter widened the Guelin–BASEL gap
+          but did not introduce the BASEL deficit, which is a panel-mismatch signal
+          not a label-quality signal.
+
           CHISEL unified Guelin+BASEL k-fold baseline (CH05, updated 2026-04-20 with
           CH06-followup neat-only filter adoption): per-row binary training on the unified
           148-phage × 369-bacteria panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL), SX10

--- a/lyzortx/pipeline/autoresearch/ch04_eval.py
+++ b/lyzortx/pipeline/autoresearch/ch04_eval.py
@@ -99,7 +99,7 @@ BOOTSTRAP_RANDOM_STATE = 42
 def build_clean_row_training_frame(
     row_frame: pd.DataFrame,
     *,
-    drop_high_titer_only_positives: bool = True,
+    drop_high_titer_only_positives: bool = False,
 ) -> pd.DataFrame:
     """Drop score=='n' rows, cast score to {0, 1}, attach CH04 label + concentration feature.
 
@@ -343,7 +343,7 @@ def run_ch04_eval(
     candidate_dir: Path,
     max_folds: Optional[int] = None,
     num_workers: int = 3,
-    drop_high_titer_only_positives: bool = True,
+    drop_high_titer_only_positives: bool = False,
 ) -> dict[str, object]:
     """Run the full CH04 evaluation.
 
@@ -354,8 +354,11 @@ def run_ch04_eval(
     dispatches the three SEEDS through `multiprocessing.Pool`. Determinism is
     preserved across all valid `num_workers` values.
 
-    `drop_high_titer_only_positives` enables the CH09 Arm 3 label-threshold
-    sensitivity filter (see `build_clean_row_training_frame`).
+    `drop_high_titer_only_positives` (default False as of CH10) enables the
+    demoted neat-only sensitivity filter (see `build_clean_row_training_frame`).
+    The CH06-followup adopted it as canonical; CH10 reverted that decision —
+    callers that want the post-filter numbers for sensitivity comparison must
+    opt in explicitly.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     start_time = datetime.now(timezone.utc)
@@ -596,14 +599,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--drop-high-titer-only-positives",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=False,
         help=(
             "Drop Guelin positive rows for pairs where every score='1' observation occurs "
-            "at log_dilution=0 (neat). Proxy for 'clearing at high titer, possibly "
-            "non-productive' (Gaborieau 2024). ENABLED BY DEFAULT as of the CH06 "
-            "follow-up filter adoption — CH09 Arm 3 showed this filter yields +1.3 pp AUC "
-            "and -3.2 pp Brier on the CH04 baseline. Pass --no-drop-high-titer-only-positives "
-            "to reproduce the pre-adoption baseline for sensitivity comparison."
+            "at log_dilution=0 (neat). Opt-in sensitivity analysis (CH10 demoted it from "
+            "canonical — see track_CHISEL notebook 2026-04-21 entry). The filter trivializes "
+            "4,428 pair eval labels 1→0 and regresses on-matched-labels AUC by 1.47 pp; the "
+            "headline post-filter AUC gain was a label-population artifact. Default OFF: "
+            "canonical training uses every interpretable score ∈ {0, 1} observation."
         ),
     )
     return parser.parse_args(argv)

--- a/lyzortx/pipeline/autoresearch/ch05_eval.py
+++ b/lyzortx/pipeline/autoresearch/ch05_eval.py
@@ -526,7 +526,7 @@ def run_ch05_eval(
     basel_log10_pfu_ml: float = BASEL_LOG10_PFU_ML,
     max_folds: Optional[int] = None,
     num_workers: int = 3,
-    drop_high_titer_only_positives: bool = True,
+    drop_high_titer_only_positives: bool = False,
 ) -> dict[str, object]:
     """Run the full CH05 two-axis evaluation.
 
@@ -535,9 +535,10 @@ def run_ch05_eval(
     see `run_ch04_eval` for the contract.
 
     `drop_high_titer_only_positives` inherits from CH04 — see
-    `build_clean_row_training_frame`. Enabled by default under the CH06 follow-up
-    filter adoption; pass `False` (CLI: `--no-drop-high-titer-only-positives`) to
-    reproduce the pre-adoption baseline.
+    `build_clean_row_training_frame`. Disabled by default as of CH10 (filter
+    demoted to opt-in sensitivity analysis); pass `True` (CLI:
+    `--drop-high-titer-only-positives`) to reproduce the deprecated post-filter
+    numbers.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     start_time = datetime.now(timezone.utc)
@@ -750,11 +751,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--drop-high-titer-only-positives",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=False,
         help=(
             "Drop Guelin positive rows for pairs where every score='1' observation occurs "
-            "at log_dilution=0 (neat). ENABLED BY DEFAULT as of the CH06 follow-up filter "
-            "adoption. Pass --no-drop-high-titer-only-positives for the pre-adoption baseline."
+            "at log_dilution=0 (neat). Opt-in sensitivity analysis (CH10 demoted it from "
+            "canonical). Default OFF."
         ),
     )
     return parser.parse_args(argv)

--- a/lyzortx/pipeline/autoresearch/ch06_arm2_mmseqs_proteome.py
+++ b/lyzortx/pipeline/autoresearch/ch06_arm2_mmseqs_proteome.py
@@ -378,7 +378,7 @@ def run_arm2_training_eval(
     device_type: str = "cpu",
     max_folds: int | None = None,
     num_workers: int = 3,
-    drop_high_titer_only_positives: bool = True,
+    drop_high_titer_only_positives: bool = False,
 ) -> dict[str, object]:
     """Run CH05's two-axis evaluation with the Arm 2 phage_projection slot.
 

--- a/lyzortx/pipeline/autoresearch/ch06_arm3_moriniere_receptor.py
+++ b/lyzortx/pipeline/autoresearch/ch06_arm3_moriniere_receptor.py
@@ -206,7 +206,7 @@ def run_arm3_training_eval(
     device_type: str = "cpu",
     max_folds: int | None = None,
     num_workers: int = 3,
-    drop_high_titer_only_positives: bool = True,
+    drop_high_titer_only_positives: bool = False,
 ) -> dict[str, object]:
     """Run CH05's two-axis evaluation with the Arm 3 phage_projection slot."""
     from lyzortx.pipeline.autoresearch.candidate_replay import load_module_from_path

--- a/lyzortx/pipeline/autoresearch/ch06_arm4_tail_restricted_tl17.py
+++ b/lyzortx/pipeline/autoresearch/ch06_arm4_tail_restricted_tl17.py
@@ -448,7 +448,7 @@ def run_arm4_training_eval(
     device_type: str = "cpu",
     max_folds: int | None = None,
     num_workers: int = 3,
-    drop_high_titer_only_positives: bool = True,
+    drop_high_titer_only_positives: bool = False,
 ) -> dict[str, object]:
     """Run CH05 two-axis eval with the Arm 4 phage_projection slot."""
     from lyzortx.pipeline.autoresearch.candidate_replay import load_module_from_path

--- a/lyzortx/pipeline/autoresearch/ch07_both_axis_holdout.py
+++ b/lyzortx/pipeline/autoresearch/ch07_both_axis_holdout.py
@@ -196,7 +196,7 @@ def run_ch07_eval(
     phage_slots_dir: Path = ARM3_SLOTS_DIR,
     basel_log10_pfu_ml: float = BASEL_LOG10_PFU_ML,
     num_workers: int = 3,
-    drop_high_titer_only_positives: bool = True,
+    drop_high_titer_only_positives: bool = False,
     max_cells: Optional[int] = None,
 ) -> dict[str, object]:
     """Run CH07 100-cell double cross-validation.
@@ -508,7 +508,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--drop-high-titer-only-positives",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=False,
+        help="Opt-in neat-only positive filter (CH10 demoted; default OFF).",
     )
     parser.add_argument(
         "--max-cells",

--- a/lyzortx/pipeline/autoresearch/ch08_wave2_reaudit.py
+++ b/lyzortx/pipeline/autoresearch/ch08_wave2_reaudit.py
@@ -419,7 +419,7 @@ def run_ch08_eval(
     phage_kmer_slot_path: Path = DEFAULT_PHAGE_KMER_SLOT_PATH,
     host_omp_kmer_slot_path: Path = DEFAULT_HOST_OMP_KMER_SLOT_PATH,
     num_workers: int = 3,
-    drop_high_titer_only_positives: bool = True,
+    drop_high_titer_only_positives: bool = False,
     max_folds: Optional[int] = None,
 ) -> dict[str, object]:
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -602,7 +602,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--drop-high-titer-only-positives",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=False,
+        help="Opt-in neat-only positive filter (CH10 demoted; default OFF).",
     )
     return parser.parse_args(argv)
 

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -1867,3 +1867,144 @@ What does NOT survive:
 - `.scratch/chisel_review/caseXcase_chisel.py`,
   `caseXcase_prior_vs_canonical.md` — case-by-case comparison across
   pre/post-filter predictions with 2×2 decomposition.
+
+### 2026-04-21 13:15 CEST: CH10 — Revert neat-only positive filter to sensitivity analysis (supersedes #453)
+
+#### Executive summary
+
+Flipped `drop_high_titer_only_positives` from `True` to `False` as the default across
+CH04/CH05/CH07/CH08 and the three CH06 arm scripts, demoting the CH06-followup neat-only
+positive filter from "canonical training policy" to "opt-in sensitivity analysis".
+Re-ran CH04 canonical under the reverted default: **AUC 0.8083 [0.7943, 0.8216], Brier
+0.1751 [0.1677, 0.1824]** (n=35,266 pairs, 8,675 score='n' rows dropped, elapsed 1,442 s)
+— reproduces the prior-encoding pre-filter canonical (0.8084 / 0.1750) to 4 decimal
+places. Acceptance band [0.806, 0.811] ✓. CH07 100-cell both-axis rerun with the Arm 3
+slot is in flight (~4 h estimated). Supersedes PR #453 framing — the label-shift was
+real, but CH10 argues the correct remedy is removing the filter, not disclosing its
+shift.
+
+#### Problem
+
+PR #444 (CH06-followup) adopted a training-side filter that dropped Guelin positive
+rows for pairs whose every score='1' observation occurred only at log_dilution=0
+(neat, ~5×10⁸ pfu/ml). Stated rationale: Gaborieau 2024 Methods flagged "clearing at
+high titer can be non-productive". PR #453 disclosed that the filter's headline
++1.33 pp AUC was partly a label-shift artifact (4,428 pair eval labels flipped 1→0
+at max-conc, because the filter removed the neat-only positive replicate from
+training and the same rows act as label sources at eval) but kept the filter as
+canonical because the −0.98 pp on-matched-labels Brier improvement and the paper's
+label-policy framing justified it.
+
+On second review, four objections held up:
+
+1. **Wrong proxy.** Gaborieau 2024 flag plaques-vs-clearing as the phenotype concern
+   (`"Clearing of the bacterial lawn at high phage concentration *could* result from
+   productive lysis … or from another mechanism such as lysis from without, or
+   abortive infection"`). Our binary {0, 1, n} score cannot distinguish plaques from
+   clearing; "positive observed only at neat" is not the same as "ambiguous clearing".
+   A narrow-host pair that barely lyses at max titer is dropped identically to an
+   abortive-infection artifact.
+2. **Testing-completeness bias.** "Positive only at neat" is also "positive at neat
+   AND either untested or negative at lower dilutions". A pair with sparser dilution
+   sampling is more likely to be filtered than one with richer sampling — that is a
+   data-collection selection, not biology.
+3. **BASEL inconsistency.** BASEL single-titer at >10⁹ pfu/ml is HIGHER than Guelin's
+   neat 5×10⁸, but the filter exempts BASEL wholesale. If "high titer is suspect" were
+   the biological rationale, BASEL positives would be MORE suspect, not exempt. The
+   real reason BASEL is exempt is structural (single-titer design), which confirms
+   the filter is about Guelin-specific dilution sampling density, not biology.
+4. **Paper does not drop.** Gaborieau's MLC score treats MLC=1 ("lytic at highest
+   titer only") as a valid included rung in the published interaction matrix and in
+   the "average MLC upon infection" / "productive lysis %" downstream analyses. We
+   unilaterally reclassified ~20% of Guelin positives as non-lytic, contrary to the
+   paper's own convention.
+
+Plus the quantitative finding from PR #453 that also points at revert: on matched
+pre-filter eval labels, the filter-trained model regresses −1.47 pp AUC
+(0.8084 → 0.7937). The Brier gain that survives decomposition (−0.98 pp) is
+addressable by the CH09 isotonic calibrator without the label-policy cost.
+
+#### Design decisions
+
+- **Flip defaults, keep flag.** The filter logic in `build_clean_row_training_frame`
+  stays intact; every CLI keeps `--drop-high-titer-only-positives` (default False)
+  so sensitivity analyses can opt in. Changed files:
+  `ch04_eval.py`, `ch05_eval.py`, `ch07_both_axis_holdout.py`, `ch08_wave2_reaudit.py`,
+  `ch06_arm2_mmseqs_proteome.py`, `ch06_arm3_moriniere_receptor.py`,
+  `ch06_arm4_tail_restricted_tl17.py`. Help-text updated to point at the CH10 revert.
+- **CH04 + CH07 rerun in this ticket.** CH07's 0.7749 AUC is the recap's load-bearing
+  cold-start deployability number; cannot leave it citing a deprecated label frame.
+  Bundled both reruns into CH10 per reviewer guidance. CH05 (CH11) and CH08 (CH12)
+  are scheduled as follow-ups because they are longer (CH05 has a 40-fold structure;
+  CH08 was RFE-expensive historically). CH09 isotonic refit is bundled into CH11 so
+  the calibrator is refit on CH05-post-revert predictions in one PR.
+- **Knowledge amendment.** `chisel-baseline` statement + context rewritten: canonical
+  is pre-filter; the four objections verbatim in the context. `chisel-unified-kfold-
+  baseline` and `moriniere-receptor-fractions-validated` gain "post-filter frame,
+  pending CH11 rerun" caveats because they cite CH05-derived numbers that will
+  change when CH11 lands.
+- **CH06 arm defaults flipped.** Three arm scripts had the filter kwarg as `True` but
+  no CLI flag — all three were called via `run_ch05_with_...` helpers and would have
+  silently inherited the filter if re-run. Flipped to False for consistency with the
+  reverted canonical.
+
+#### Results
+
+CH04 rerun numbers (10-fold bacteria-axis CV, 3 seeds, 1000 bootstrap resamples):
+
+| Metric | Value | 95% CI |
+|---|---|---|
+| Aggregate AUC | 0.808276 | [0.794313, 0.821614] |
+| Aggregate Brier | 0.175055 | [0.167748, 0.182384] |
+| n_pairs_evaluated | 35,266 | — |
+| n_training_rows_dropped (score='n') | 8,675 | — |
+| Concentration feature importance | 328.7 | #4 mean rank across 30 fits |
+| Elapsed | 1,442 s | — |
+
+Reproduces the prior-encoding pre-filter canonical (0.8084 / 0.1750) to 4 decimal
+places, confirming (a) the encoding is deterministic under the flipped default and
+(b) no silent dependency on the filter leaked into CH04 intermediate steps between
+the CH04 initial and CH10 reruns.
+
+CH07 rerun was launched at 13:11 CEST with `--drop-high-titer-only-positives=False`
+and the Arm 3 phage_projection slot; expected ~4 h. Results will be folded into this
+entry when the run completes.
+
+#### Interpretation
+
+- The four objections are structural, not quantitative. Even if the filter's
+  on-matched-labels AUC regression were smaller, (i)-(iv) stand as label-policy
+  defects. The quantitative finding (−1.47 pp AUC regression) only strengthens the
+  structural case.
+- The Brier-on-matched-labels gain (−0.98 pp) survives because removing neat-only
+  positives makes the model predict lower probability on those pairs, which is
+  correct once the label flips to 0. But isotonic calibration (CH09) gets the same
+  Brier gain without losing the 4,428 pairs of training signal or the paper's MLC=1
+  rung. Two different fixes for the same miscalibration; isotonic is the cleaner
+  one.
+- Downstream: CH11 reruns CH05 + refits the CH09 isotonic calibrator under the
+  reverted canonical; CH12 reruns CH08 SX12/SX13. Both preserve the deprecated
+  post-filter artifacts under `_post_filter/` side-directories so the sensitivity
+  comparison is reproducible.
+
+#### Next steps
+
+- **CH10 remaining:** monitor CH07 rerun (~4 h). Update this entry with CH07
+  aggregate AUC + per-cell distribution when the run completes. Open PR.
+- **CH11:** CH05 rerun + CH09 isotonic refit under pre-filter canonical.
+- **CH12:** CH08 SX12/SX13 rerun.
+- **CH13:** Arm 3 canonical `phage_projection` slot migration (previously
+  tentatively referred to as "CH10" in merged docs pre-revert; PR #454 renumbered).
+
+#### Artifacts
+
+- `lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json` —
+  pre-filter CH04 canonical (replaces the post-filter artifacts in place).
+- `lyzortx/generated_outputs/ch04_chisel_baseline/ch04_predictions.csv`,
+  `ch04_per_row_predictions.csv`, `ch04_feature_importance.csv` — pre-filter
+  pair-level / per-row predictions + feature importance.
+- `lyzortx/generated_outputs/ch07_both_axis_holdout/` — pending CH07 rerun.
+- `.scratch/chisel_review/caseXcase_chisel.py`,
+  `caseXcase_prior_vs_canonical.md` — 2×2 decomposition from PR #453 (retained
+  as evidence for the label-shift finding that motivated the revert).
+- `.scratch/ch10_logs/ch04_rerun.log`, `ch07_rerun.log` — local run logs.

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -1878,9 +1878,11 @@ positive filter from "canonical training policy" to "opt-in sensitivity analysis
 Re-ran CH04 canonical under the reverted default: **AUC 0.8083 [0.7943, 0.8216], Brier
 0.1751 [0.1677, 0.1824]** (n=35,266 pairs, 8,675 score='n' rows dropped, elapsed 1,442 s)
 — reproduces the prior-encoding pre-filter canonical (0.8084 / 0.1750) to 4 decimal
-places. Acceptance band [0.806, 0.811] ✓. CH07 100-cell both-axis rerun with the Arm 3
-slot is in flight (~4 h estimated). Supersedes PR #453 framing — the label-shift was
-real, but CH10 argues the correct remedy is removing the filter, not disclosing its
+places. Acceptance band [0.806, 0.811] ✓. CH07 100-cell both-axis rerun completed
+(elapsed 4h 43min): **aggregate AUC 0.7634 [0.7581, 0.7689], Brier 0.1902 [0.1874,
+0.1927]** on 36,643 pairs; −1.15 pp vs the deprecated post-filter 0.7749 — directionally
+consistent with the label-shift mechanism. Supersedes PR #453 framing — the label-shift
+was real, but CH10 argues the correct remedy is removing the filter, not disclosing its
 shift.
 
 #### Problem
@@ -1966,9 +1968,31 @@ places, confirming (a) the encoding is deterministic under the flipped default a
 (b) no silent dependency on the filter leaked into CH04 intermediate steps between
 the CH04 initial and CH10 reruns.
 
-CH07 rerun was launched at 13:11 CEST with `--drop-high-titer-only-positives=False`
-and the Arm 3 phage_projection slot; expected ~4 h. Results will be folded into this
-entry when the run completes.
+CH07 rerun numbers (10×10 both-axis CV, Arm 3 phage_projection slot, 3 seeds per cell,
+1000 pair-level bootstrap resamples):
+
+| Metric | Value | 95% CI |
+|---|---|---|
+| Aggregate AUC | 0.763444 | [0.758131, 0.768938] |
+| Aggregate Brier | 0.190156 | [0.187399, 0.192666] |
+| Guelin AUC | 0.765402 | [0.759986, 0.771000] |
+| BASEL AUC | 0.719314 | [0.682223, 0.758009] |
+| Per-cell AUC mean | 0.7663 | std 0.0438, median 0.7686 |
+| Per-cell AUC range | [0.6378, 0.8989] | 100 cells, all with defined AUC |
+| n_pairs | 36,643 | (35,403 Guelin + 1,240 BASEL) |
+| Elapsed | 17,018 s | ~4 h 43 min |
+
+Aggregate AUC recomputed from `ch07_pair_predictions.csv` matches `ch07_aggregate.json`
+to 6 dp (0.763444 / 0.190156). Acceptance criterion ✓.
+
+Delta vs the deprecated post-filter CH07 (0.7749 aggregate AUC): **−1.15 pp**,
+disjoint from the post-filter band. Directionally consistent with the label-shift
+decomposition: the filter trivialized ~12.6 % of pair eval labels 1→0 (easier
+population); removing the filter restores those 4,428 positives as eval-time
+positives and the model re-prices discrimination at a noisier but honest level. The
+per-cell distribution is broad (min 0.6378, max 0.8989) — cold-start on
+simultaneously unseen bacteria × phage is high-variance by construction, and the
+pre-filter frame is the calibrated reporting point.
 
 #### Interpretation
 
@@ -1989,8 +2013,8 @@ entry when the run completes.
 
 #### Next steps
 
-- **CH10 remaining:** monitor CH07 rerun (~4 h). Update this entry with CH07
-  aggregate AUC + per-cell distribution when the run completes. Open PR.
+- **CH10 remaining:** open PR closing #455, self-review via `review-ml-pr`
+  subagent, merge.
 - **CH11:** CH05 rerun + CH09 isotonic refit under pre-filter canonical.
 - **CH12:** CH08 SX12/SX13 rerun.
 - **CH13:** Arm 3 canonical `phage_projection` slot migration (previously
@@ -2003,7 +2027,10 @@ entry when the run completes.
 - `lyzortx/generated_outputs/ch04_chisel_baseline/ch04_predictions.csv`,
   `ch04_per_row_predictions.csv`, `ch04_feature_importance.csv` — pre-filter
   pair-level / per-row predictions + feature importance.
-- `lyzortx/generated_outputs/ch07_both_axis_holdout/` — pending CH07 rerun.
+- `lyzortx/generated_outputs/ch07_both_axis_holdout/ch07_aggregate.json`,
+  `ch07_pair_predictions.csv`, `ch07_per_row_predictions.csv`, `ch07_cell_metrics.csv`,
+  `ch07_cross_source_breakdown.csv`, `ch07_cell_distribution.png` — pre-filter
+  CH07 canonical (in place of post-filter artifacts).
 - `.scratch/chisel_review/caseXcase_chisel.py`,
   `caseXcase_prior_vs_canonical.md` — 2×2 decomposition from PR #453 (retained
   as evidence for the label-shift finding that motivated the revert).

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
@@ -12,58 +12,65 @@ one of its two root causes (phage-side TL17 bias) into a panel-independent featu
 
 ## Headline outcomes
 
+**2026-04-21 CH10 revert:** CH04 and CH07 were re-run under the reverted pre-filter
+canonical (neat-only positive filter demoted to opt-in sensitivity analysis — see
+the CH10 section below). CH05/CH08/CH09 numbers in the table below are still under
+the deprecated post-filter frame and are scheduled to be refreshed by CH11 (CH05
++ CH09 refit) and CH12 (CH08).
+
 Everything below is on the 369×96 Guelin panel (unified 148-phage panel for cross-
-source numbers). "Post-filter canonical" = CH04 + CH06-followup: per-row binary labels,
-`pair_concentration__log10_pfu_ml` feature, all-pairs only (no per-phage blending),
-neat-only filter on Guelin training positives.
+source numbers). Canonical = per-row binary labels, `pair_concentration__log10_pfu_ml`
+feature (absolute log₁₀ pfu/ml), all-pairs only (no per-phage blending), NO neat-only
+filter.
 
-| Metric | Baseline | Number | 95% CI |
+| Metric | Frame | Number | 95% CI |
 |---|---|---|---|
-| CH04 Guelin bacteria-axis AUC | post-filter canonical | **0.8217** | [0.8054, 0.8365] |
-| CH04 Guelin bacteria-axis Brier | " | **0.1435** | [0.1363, 0.1508] |
-| CH05 unified bacteria-axis AUC | " (148-phage panel) | 0.8218 | [0.8063, 0.8368] |
-| CH05 unified phage-axis AUC | " | **0.8919** | [0.8650, 0.9166] |
-| CH05 BASEL bacteria-axis AUC (subset) | " | 0.7229 | 10.2 pp below Guelin |
-| CH07 both-axis AUC (Arm 3 slot) | post-filter + Moriniere receptor fractions | 0.7749 | [0.7687, 0.7814] |
-| CH07 per-cell AUC distribution | 100 cells | mean 0.781, median 0.780, std 0.053 | min 0.63, max 0.92 |
-| CH09 Guelin LOOF ECE (bact / phage) | post-hoc isotonic | 0.0074 / 0.0063 | target < 0.02 ✓ |
-| CH09 BASEL ECE closure (bact / phage) | cross-panel transfer | 79.5% / 53.2% | retains large residual TL17-bias mechanism |
+| CH04 Guelin bacteria-axis AUC | pre-filter (CH10) | **0.8083** | [0.7943, 0.8216] |
+| CH04 Guelin bacteria-axis Brier | pre-filter (CH10) | **0.1751** | [0.1677, 0.1824] |
+| CH05 unified bacteria-axis AUC | post-filter (pending CH11) | 0.8218 | [0.8063, 0.8368] |
+| CH05 unified phage-axis AUC | post-filter (pending CH11) | 0.8919 | [0.8650, 0.9166] |
+| CH05 BASEL bacteria-axis AUC (subset) | post-filter (pending CH11) | 0.7229 | 10.2 pp below Guelin |
+| CH07 both-axis AUC (Arm 3 slot) | pre-filter (CH10) | _CH10 rerun in flight_ | TBD |
+| CH09 Guelin LOOF ECE (bact / phage) | post-filter (pending CH11) | 0.0074 / 0.0063 | target < 0.02 ✓ |
+| CH09 BASEL ECE closure (bact / phage) | post-filter (pending CH11) | 79.5% / 53.2% | retains large residual TL17-bias mechanism |
 
-The load-bearing number for deployment: **cold-start AUC on simultaneously unseen
-bacterium × phage = 0.7749**, retaining 93% of the single-axis discrimination.
+The load-bearing cold-start number (both-axis AUC on simultaneously unseen
+bacterium × phage) was 0.7749 under the deprecated post-filter frame with the Arm 3
+slot. CH10 re-runs CH07 under the pre-filter canonical + Arm 3; the value will
+update when the rerun lands.
 
 ## What changed in the canonical pipeline
 
 Against the SPANDEX starting point:
 
-- **Training label**: any_lysis (pair-level rollup) → per-row binary, score ∈ {0, 1},
++ **Training label**: any_lysis (pair-level rollup) → per-row binary, score ∈ {0, 1},
   `score == "n"` dropped as missing (see `label-policy-binary`). Each (bacterium, phage,
   log_dilution, replicate) observation is a training row.
-- **Concentration**: implicit in the rollup → explicit numeric feature
++ **Concentration**: implicit in the rollup → explicit numeric feature
   `pair_concentration__log10_pfu_ml` with Guelin steps {4.7, 6.7, 7.7, 8.7} and BASEL
   constant 9.0 (absolute log₁₀ pfu/ml; conservative lower bound on Maffei 2021/2025
   >10⁹ pfu/ml working titer).
-- **Per-phage blending (AX02)**: dominant SPANDEX architectural gain +2 pp AUC →
++ **Per-phage blending (AX02)**: dominant SPANDEX architectural gain +2 pp AUC →
   **retired track-wide** (`per-phage-retired-under-chisel`). Not deployable for unseen
   phages, and the SPANDEX +2 pp was partly leakage and partly per-phage-head artifacts
   under per-row training.
-- **Fold hashing**: name-hashed (leaked 45/48 multi-bacterium cv_groups across folds) →
++ **Fold hashing**: name-hashed (leaked 45/48 multi-bacterium cv_groups across folds) →
   cv_group-hashed (see `cv-group-leakage-fixed`). All subsequent CHISEL results sit
   downstream of this fix.
-- **Scorecard**: nDCG + mAP + top-k + AUC + Brier → **AUC + Brier only**. Ranking
++ **Scorecard**: nDCG + mAP + top-k + AUC + Brier → **AUC + Brier only**. Ranking
   metrics are a product-layer concern; a biological model predicts `P(lysis | host, phage,
   concentration)` and downstream code turns calibrated probabilities into rankings
   (see `ranking-metrics-retired`).
-- **Calibration layer**: none → CH09 isotonic calibrator fitted on Guelin training-fold
++ **Calibration layer**: none → CH09 isotonic calibrator fitted on Guelin training-fold
   predictions, persisted as `ch09_calibrator.pkl`, closes Guelin ECE from 0.13 to
   0.007/0.006 on both axes (see `chisel-unified-kfold-baseline`).
-- **Phage-side feature slot**: Guelin-derived TL17 BLAST projection (zero-vector for
++ **Phage-side feature slot**: Guelin-derived TL17 BLAST projection (zero-vector for
   13/52 BASEL phages) → Moriniere per-receptor k-mer fractions (CH06 Arm 3,
   panel-independent 13-dim, BASEL zero-vec phage-axis +4.36 pp; see
   `moriniere-receptor-fractions-validated`). Canonical migration deferred to the
   follow-up CH13 ticket (currently a side-materialized artifact at
   `.scratch/basel/feature_slots_arm3/`).
-- **Both-axis cold-start**: never previously measured → CH07 reports 0.7749 on 100 cells
++ **Both-axis cold-start**: never previously measured → CH07 reports 0.7749 on 100 cells
   with pair-level bootstrap.
 
 ## Dead ends and null arms
@@ -71,40 +78,40 @@ Against the SPANDEX starting point:
 What was tested and found not to lift (one-liners for future tracks that might otherwise
 re-litigate):
 
-- **CH06 Arm 1 (OOD shrinkage toward base rate)**: null. Feature-space-level
++ **CH06 Arm 1 (OOD shrinkage toward base rate)**: null. Feature-space-level
   out-of-distribution-detector + shrinkage on phage projection features did not rescue
   BASEL calibration on either axis.
-- **CH06 Arm 2 (MMseqs2 pairwise proteome similarity, PCA-32)**: null on BASEL non-zero-
++ **CH06 Arm 2 (MMseqs2 pairwise proteome similarity, PCA-32)**: null on BASEL non-zero-
   projection phages (cannibalized RBP-specific signal), null on Guelin. Partially rescued
   the zero-projection subset but at the cost of the non-zero-projection group.
-- **CH06 Arm 4 (tail-protein-restricted TL17 BLAST)**: null. Strict subset of baseline
++ **CH06 Arm 4 (tail-protein-restricted TL17 BLAST)**: null. Strict subset of baseline
   TL17 hits — smaller matched region, no new information, no lift on any subset.
-- **SX11 ordinal losses**: not retired in CHISEL, but out of scope (chased MLC-graded
++ **SX11 ordinal losses**: not retired in CHISEL, but out of scope (chased MLC-graded
   potency which doesn't exist in the CHISEL label frame). Already null under SPANDEX.
-- **CH09 Arm 2 (cross-panel calibrator transfer)**: Guelin-fitted isotonic applied to
++ **CH09 Arm 2 (cross-panel calibrator transfer)**: Guelin-fitted isotonic applied to
   BASEL closes 79.5% of bacteria-axis ECE and 53.2% of phage-axis ECE, but residual BASEL
   ECE 0.044/0.111 is 6-17× Guelin's calibrated ECE — TL17-bias is a feature-level
   problem, not a threshold-level one.
-- **CH09 Arm 3 (label-threshold sensitivity)**: directional miss + label-shift artifact.
++ **CH09 Arm 3 (label-threshold sensitivity) — REVERTED by CH10 (2026-04-21).**
   Dropping Guelin neat-only positives gives headline +1.3 pp AUC, −3.2 pp Brier, +0.7 pp
   ECE — but a 2026-04-21 post-hoc decomposition found the filter also flips 4,428 pair
   eval labels 1→0 (12.6% of eval set), because evaluation pulls the label from the
   pair's max-concentration observation and the removed neat-only positive leaves a 0
   replicate standing. On matched (pre-filter) labels the filter-trained model has
   −1.47 pp AUC (regression) but −0.98 pp Brier (genuine improvement survives).
-  Adopted as canonical on Gaborieau-2024 label-policy grounds (neat-only positives
-  are candidate-non-productive) plus the Brier-on-matched-labels gain, NOT on
-  discrimination. See `chisel-baseline` knowledge unit for the 2×2 decomposition and
-  the corrected framing.
+  CH10 rolled the filter back to an opt-in sensitivity analysis after four reviewer
+  objections (wrong proxy, testing-completeness bias, BASEL inconsistency, paper
+  does not drop) — see the CH10 section in `track_CHISEL.md` and the revised
+  `chisel-baseline` unit for the full decomposition + objections.
 
 And what surprised us on re-audit:
 
-- **CH08 SX12 (Moriniere 815 phage 5-mers, top-100 variance pre-filter)**: **non-null.**
++ **CH08 SX12 (Moriniere 815 phage 5-mers, top-100 variance pre-filter)**: **non-null.**
   +1.16 pp AUC [+0.82, +1.51] under CHISEL per-row training, disjoint CI. Reopens the
   SPANDEX-era `kmer-receptor-expansion-neutral` null. Not a blocker for the Arm 3
   migration — the two findings are complementary (Arm 3 = panel-independent aggregates;
   SX12 kmers = raw-feature additive lift on Guelin).
-- **CH08 SX13 (host OMP 5546 5-mers, top-100 variance pre-filter)**: barely-non-null.
++ **CH08 SX13 (host OMP 5546 5-mers, top-100 variance pre-filter)**: barely-non-null.
   +0.17 pp AUC [+0.03, +0.31]. Reopens `host-omp-variation-unpredictive` but the effect
   is consistent with phylogroup-correlated lineage noise rather than OMP-specific
   host-range signal.
@@ -146,32 +153,34 @@ Each is a concrete, schedulable item — not a vague aspiration.
 
 Canonical generated-outputs directories (under `lyzortx/generated_outputs/`):
 
-- `ch02_cv_group_fix/` — CV fold-hashing fix + SX10 revalidation.
-- `ch03_row_expansion/` — per-row training matrix + any_lysis regression check.
-- `ch04_chisel_baseline/ch04_aggregate_metrics.json` — post-filter baseline,
-  bacteria-axis AUC 0.8217.
-- `ch05_unified_kfold/ch05_combined_summary.json` — unified Guelin+BASEL two-axis
++ `ch02_cv_group_fix/` — CV fold-hashing fix + SX10 revalidation.
++ `ch03_row_expansion/` — per-row training matrix + any_lysis regression check.
++ `ch04_chisel_baseline/ch04_aggregate_metrics.json` — CH10 pre-filter canonical,
+  bacteria-axis AUC 0.8083 [0.7943, 0.8216].
++ `ch05_unified_kfold/ch05_combined_summary.json` — unified Guelin+BASEL two-axis
   baseline.
-- `ch06_arm1_ood_shrinkage/`, `ch06_arm2_mmseqs_proteome/`,
++ `ch06_arm1_ood_shrinkage/`, `ch06_arm2_mmseqs_proteome/`,
   `ch06_arm3_moriniere_receptor/`, `ch06_arm4_tail_restricted_tl17/` — per-arm metrics
   JSON, prediction CSVs, cross-source breakdowns.
-- `ch07_both_axis_holdout/ch07_aggregate.json`, `.../ch07_cell_metrics.csv`,
++ `ch07_both_axis_holdout/ch07_aggregate.json`, `.../ch07_cell_metrics.csv`,
   `.../ch07_cell_distribution.png`.
-- `ch08_wave2_reaudit/ch08_summary.csv`, `.../ch08_sx12_delta.json`,
++ `ch08_wave2_reaudit/ch08_summary.csv`, `.../ch08_sx12_delta.json`,
   `.../ch08_sx13_delta.json`.
-- `ch09_calibration_layer/ch09_calibrator.pkl`, `.../ch09_calibration_report.json`,
++ `ch09_calibration_layer/ch09_calibrator.pkl`, `.../ch09_calibration_report.json`,
   `.../ch09_label_threshold_sensitivity.json`.
 
 Scripts that reproduce headline numbers:
 
-- `lyzortx/pipeline/autoresearch/ch04_eval.py` — CH04 post-filter canonical.
-- `lyzortx/pipeline/autoresearch/ch05_eval.py` — unified Guelin+BASEL k-fold.
-- `lyzortx/pipeline/autoresearch/ch06_arm3_moriniere_receptor.py` — Moriniere per-
++ `lyzortx/pipeline/autoresearch/ch04_eval.py` — CH04 pre-filter canonical (CH10);
+  pass `--drop-high-titer-only-positives` to reproduce the deprecated post-filter
+  numbers for sensitivity analysis.
++ `lyzortx/pipeline/autoresearch/ch05_eval.py` — unified Guelin+BASEL k-fold.
++ `lyzortx/pipeline/autoresearch/ch06_arm3_moriniere_receptor.py` — Moriniere per-
   receptor k-mer-fraction slot materializer + eval driver.
-- `lyzortx/pipeline/autoresearch/ch07_both_axis_holdout.py` — 100-cell both-axis CV.
-- `lyzortx/pipeline/autoresearch/ch08_wave2_reaudit.py` — SX12 + SX13 re-audit with
++ `lyzortx/pipeline/autoresearch/ch07_both_axis_holdout.py` — 100-cell both-axis CV.
++ `lyzortx/pipeline/autoresearch/ch08_wave2_reaudit.py` — SX12 + SX13 re-audit with
   top-100 variance pre-filter + paired bacterium-level bootstrap.
-- `lyzortx/pipeline/autoresearch/ch09_calibration_layer.py`,
++ `lyzortx/pipeline/autoresearch/ch09_calibration_layer.py`,
   `lyzortx/pipeline/autoresearch/ch09_arm3_analysis.py` — isotonic calibrator + label-
   threshold sensitivity.
 

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
@@ -30,14 +30,19 @@ filter.
 | CH05 unified bacteria-axis AUC | post-filter (pending CH11) | 0.8218 | [0.8063, 0.8368] |
 | CH05 unified phage-axis AUC | post-filter (pending CH11) | 0.8919 | [0.8650, 0.9166] |
 | CH05 BASEL bacteria-axis AUC (subset) | post-filter (pending CH11) | 0.7229 | 10.2 pp below Guelin |
-| CH07 both-axis AUC (Arm 3 slot) | pre-filter (CH10) | _CH10 rerun in flight_ | TBD |
+| CH07 both-axis AUC (Arm 3 slot) | pre-filter (CH10) | **0.7634** | [0.7581, 0.7689] |
+| CH07 both-axis Brier (Arm 3 slot) | pre-filter (CH10) | **0.1902** | [0.1874, 0.1927] |
 | CH09 Guelin LOOF ECE (bact / phage) | post-filter (pending CH11) | 0.0074 / 0.0063 | target < 0.02 ✓ |
 | CH09 BASEL ECE closure (bact / phage) | post-filter (pending CH11) | 79.5% / 53.2% | retains large residual TL17-bias mechanism |
 
 The load-bearing cold-start number (both-axis AUC on simultaneously unseen
-bacterium × phage) was 0.7749 under the deprecated post-filter frame with the Arm 3
-slot. CH10 re-runs CH07 under the pre-filter canonical + Arm 3; the value will
-update when the rerun lands.
+bacterium × phage) is **0.7634** [0.7581, 0.7689] under the pre-filter canonical +
+Arm 3 slot (CH10). Post-filter CH07 reported 0.7749; the −1.15 pp gap vs the
+post-filter number is consistent with the label-shift mechanism documented in the
+CH10 entry — the filter trivialised ~12.6 % of pair eval labels 1→0, producing a
+label-population-easier AUC. Cross-source: Guelin 0.7654 [0.7600, 0.7710] vs BASEL
+0.7193 [0.6822, 0.7580]; per-cell AUC mean 0.7663, std 0.0438, min 0.6378, max
+0.8989 across 100 cells (10 bacteria folds × 10 phage folds).
 
 ## What changed in the canonical pipeline
 


### PR DESCRIPTION
## Summary

**Supersedes PR #453** (commit c22faf7, merged 2026-04-21): #453 disclosed the
label-shift artifact in the CH06-followup neat-only positive filter but kept
the filter as canonical. CH10 demotes the filter entirely to an opt-in
sensitivity analysis after four reviewer objections held up.

**Four objections:**

1. **Wrong proxy.** Gaborieau 2024 Methods flag plaques-vs-clearing as the
   phenotype concern (*"Clearing of the bacterial lawn at high phage
   concentration **could** result from productive lysis ... or from another
   mechanism such as lysis from without, or abortive infection"*). Our binary
   {0, 1, n} score cannot distinguish plaques from clearing.
2. **Testing-completeness bias.** "Positive only at neat" is also "positive
   at neat AND either untested or negative at lower dilutions" — a data-
   collection selection, not biology.
3. **BASEL inconsistency.** BASEL single-titer at >10⁹ pfu/ml is HIGHER than
   Guelin's neat 5×10⁸, but the filter exempts BASEL. If "high titer is
   suspect" were the biological rationale, BASEL would be MORE suspect.
4. **Paper does not drop.** Gaborieau's MLC score treats MLC=1 ("lytic at
   highest titer only") as a valid rung in the published matrix and
   downstream "productive lysis %" analyses. We unilaterally reclassified
   ~20% of Guelin positives as non-lytic, contrary to the paper.

**Quantitative finding (from #453):** on matched pre-filter eval labels, the
filter-trained model regresses **−1.47 pp AUC** (0.8084 → 0.7937). The
headline +1.33 pp AUC was a label-population-easier artifact — the filter
flipped 4,428 pair eval labels 1→0 at max-concentration. The surviving
Brier improvement (−0.98 pp) is addressable by CH09 isotonic calibration
without the label-policy cost.

**Changes:**

- Flipped `drop_high_titer_only_positives` default from `True` to `False` in
  `ch04_eval.py`, `ch05_eval.py`, `ch07_both_axis_holdout.py`,
  `ch08_wave2_reaudit.py`, `ch06_arm2_mmseqs_proteome.py`,
  `ch06_arm3_moriniere_receptor.py`, `ch06_arm4_tail_restricted_tl17.py`.
- CLI `--drop-high-titer-only-positives` retained for opt-in sensitivity
  analyses.
- Reran CH04 canonical: **AUC 0.8083 [0.7943, 0.8216], Brier 0.1751
  [0.1677, 0.1824]** — reproduces the prior-encoding pre-filter canonical
  (0.8084 / 0.1750) to 4 dp. Acceptance band [0.806, 0.811] ✓.
- Reran CH07 both-axis 10×10 (Arm 3 slot): **aggregate AUC 0.7634
  [0.7581, 0.7689], Brier 0.1902 [0.1874, 0.1927]** on 36,643 unified-panel
  pairs. Aggregate AUC/Brier recompute from `ch07_pair_predictions.csv` to
  6 dp ✓. Delta vs deprecated post-filter (0.7749): −1.15 pp, directionally
  consistent with the label-shift mechanism.
- Rewrote `chisel-baseline` knowledge unit; added post-filter-frame
  caveats to `chisel-unified-kfold-baseline` and
  `moriniere-receptor-fractions-validated` (CH11 will re-cite under the
  reverted canonical).
- Logged in `track_CHISEL.md` entry "2026-04-21 13:15 CEST: CH10 — Revert
  neat-only positive filter to sensitivity analysis". Updated
  `track_CHISEL_recap.md` headline table with pre-filter CH04 + CH07 rows.

**Downstream:** CH11 (CH05 rerun + CH09 refit), CH12 (CH08 rerun), CH13
(Arm 3 canonical `phage_projection` migration) are the follow-up tickets
already in plan.yml (merged via #454).

Closes #455

## Test plan

- [x] `pytest lyzortx/tests/` — 519 passed
- [x] CH04 rerun: AUC 0.808276 within [0.806, 0.811] acceptance band
- [x] CH07 `ch07_aggregate.json` AUC recomputes from
      `ch07_pair_predictions.csv` to 6 dp (0.763444)
- [x] `knowledge_parser.validate_knowledge()` passes; KNOWLEDGE.md regenerated
- [x] pymarkdown clean on modified notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)