### PR TITLE
[ORCH][CH12] CH08 SX12/SX13 wave-2 re-audit under reverted pre-filter canonical

### DIFF
--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -3,7 +3,7 @@
 <!-- Last consolidated: 2026-04-19T16:00:00+02:00 -->
 <!-- Source: lyzortx/research_notes/lab_notebooks -->
 
-**67 knowledge units** across 7 themes (48 active, 19 dead ends)
+**67 knowledge units** across 7 themes (49 active, 18 dead ends)
 
 ## Data & Labels
 
@@ -656,26 +656,46 @@ Compressed lessons from approaches that didn't work.
   (37,788/37,788 pairs match after name normalization). Our data is already in their framework. No new training pairs
   available from GenoPHI for existing phages. [validated; source: GT09; see also: genophi-benchmark,
   raw-interactions-authority]
-- **`kmer-receptor-expansion-neutral`**: Moriniere 2026's 815 receptor-predictive 5-mers fail to lift performance
-  regardless of encoding path: as intermediate-classifier features (GT06: AUC 0.824 vs 0.823, delta CI [-0.005, +0.005])
-  or as direct phage-side features (SX12: AUC 0.8722 vs 0.8699, delta +0.23 pp, CIs overlap). The Moriniere 815-kmer
-  approach is exhausted on this panel. [validated; source: GT06, SX12; see also: omp-score-homogeneity,
-  pairwise-cross-terms-dead-end, receptor-specificity-solved, plm-rbp-redundant, narrow-host-prior-collapse,
-  panel-size-ceiling]
-  - *Two failure modes overlap. (1) The k-mers were selected to discriminate receptor class on K-12 derivatives
-    (BW25113/BL21) which lack capsule/O-antigen — they predict what we already know (receptor identity), not what we
-    need (strain-level capsule penetration). (2) The k-mers are information-redundant with phage_projection (TL17 BLAST)
-    — both encode phage sequence similarity at different granularities. SX12 RFE keeps 95/815 k-mers (11.7%) but they
-    contribute ~5% of total importance vs 22% for depo×capsule; zero k-mers appear in the top-20 features. Per-bacterium
-    analysis: ~10 genuine wins (e.g., IAI78 +0.12 nDCG, ECOR-25 +0.17) exactly offset by ~10 genuine losses (e.g.,
-    ECOR-19 -0.36, EDL933 -0.24). NILS53 (the canonical narrow-host case) gains +0.011 nDCG — k-mers do not break
-    narrow-host prior collapse. Not a LightGBM shortcoming; a feature-redundancy + panel-size ceiling.*
+- **`kmer-receptor-expansion-neutral`**: **REOPENED under CHISEL (CH08 wave-2 re-audit, CH12 pre-filter re-anchoring).**
+  On the SPANDEX panel with pair-level `any_lysis` training the 815-kmer slot was neutral (SX12: AUC 0.8722 vs 0.8699,
+  delta +0.23 pp, CIs overlap). Under CHISEL per-row binary training with the pre-filter CH04 canonical as baseline, the
+  same phage-side k-mer slot now delivers **+0.72 pp AUC (CI [+0.36, +1.05])** with disjoint-from-zero CI on 35,266
+  shared pairs (CH08 SX12 variant arm, CH12 rerun 2026-04-21). The delta is smaller than the post-filter CH08
+  measurement (+1.16 pp, CI [+0.72, +1.55]) — so a slice of the earlier headline was label-shift from the deprecated
+  filter — but the pre-filter +0.72 pp signal survives with CI disjoint from zero, which invalidates the SPANDEX-era
+  "neutral" framing under the CHISEL training unit. GT06 (k-mers as intermediate-classifier features for directed
+  cross-terms) remains null per its own delta CI [-0.005, +0.005] — that failure mode is about the host-side OMP
+  homogeneity blocking the cross-term, not about the k-mers themselves. Brier is unchanged in both directions (CH08
+  pre-filter SX12 Brier delta −0.0005, CI [−0.0028, +0.0017]), which means the lift is pure discrimination (AUC) with no
+  calibration side-effect. Downstream: the "feature-redundancy + panel-size ceiling" framing for k-mers stands for GT06
+  directed use, but the phage-side direct-slot use is NOT neutral under per-row binary training. [validated; source:
+  GT06, SX12, CH08, 2026-04-20 wave-2 re-audit, CH12, 2026-04-21 pre-filter re-anchoring; see also:
+  omp-score-homogeneity, pairwise-cross-terms-dead-end, receptor-specificity-solved, plm-rbp-redundant,
+  narrow-host-prior-collapse, panel-size-ceiling, moriniere-receptor-fractions-validated, chisel-baseline]
+  - *Original SPANDEX-era failure modes (retained, context-dependent): (1) the k-mers were selected to discriminate
+    receptor class on K-12 derivatives (BW25113/BL21) which lack capsule/O-antigen, so they primarily predict receptor
+    identity rather than strain-level capsule penetration; (2) information redundancy with phage_projection (TL17
+    BLAST). Under CHISEL per-row binary training the redundancy is partial rather than full — with concentration as a
+    feature and score ∈ {0, 1} per replicate, the additional phage-receptor signal from 815-kmer presence adds
+    discriminative power that was invisible when the rollup collapsed replicates into any_lysis. RFE still keeps only
+    ~95/815 kmers at ~5% importance, so the effect size is real but small. CH12 pre-filter re-audit preserves the
+    directional finding: lift is +0.72 pp with CI disjoint from zero even after demoting the filter (which had been
+    inflating it to +1.16 pp under post-filter). This makes the k-mer slot a live candidate for canonical inclusion
+    alongside Arm 3 per-receptor-fractions — CH13 should evaluate whether Arm 3 alone subsumes the k-mer signal or
+    whether both should coexist. Canonical artifacts:
+    lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_combined_summary.json, ch08_sx12_delta.json,
+    ch08_sx12_predictions.csv. Sensitivity-column artifacts under ch08_wave2_reaudit_post_filter/.*
 - **`host-omp-variation-unpredictive`**: Host-side OMP allelic variation is substantial (369 clinical E. coli span BTUB
   28 MMseqs2 99%-identity clusters, OMPC 49, 5546 retained 5-mers across 12 core OMPs) but does not predict lysis. Four
   arms tested in SX13 (k-mers marginal, k-mers × phage k-mers cross-term, cluster IDs, plus baseline) all land within
-  ±0.4 pp of SX10 on all metrics. [validated; source: SX13; see also: omp-score-homogeneity,
+  ±0.4 pp of SX10 on all metrics. **CONFIRMED null under CHISEL (CH08 wave-2 re-audit; CH12 pre-filter re-anchoring,
+  2026-04-21):** the host-OMP k-mer slot variant delivers ΔAUC +0.02 pp (CI [−0.13, +0.17]) and ΔBrier −0.007 pp (CI
+  [−0.09, +0.08]) on 35,266 shared pairs against the pre-filter CH04 baseline — both CIs span zero, both deltas are
+  sub-pp. The null survives under per-row binary training with concentration as a feature; OMP-variation-matters-for-
+  narrow-phages remains biologically plausible but undetectable in this panel. [validated; source: SX13, CH08,
+  2026-04-20 wave-2 re-audit, CH12, 2026-04-21 pre-filter re-anchoring; see also: omp-score-homogeneity,
   pairwise-cross-terms-dead-end, kmer-receptor-expansion-neutral, narrow-host-prior-collapse,
-  same-receptor-uncorrelated-hosts]
+  same-receptor-uncorrelated-hosts, chisel-baseline]
   - *Permutation test on cross_term aggregate delta: 73% of random prediction swaps are as extreme — signal
     indistinguishable from noise. Small directional signal in the marginal arm for moderate-narrow-host deciles (lysis
     5-11%, mean +1-2 pp nDCG across ~70 bacteria), biologically consistent with OMP-variation-matters-for-narrow-phages
@@ -684,7 +704,11 @@ Compressed lessons from approaches that didn't work.
     rescue. Top-3 hit rate moves from 92.2% to 93.3% under cross_term (+4 strains). The finding refines
     omp-score-homogeneity: HMM-score homogeneity was real, but escalating to finer representations doesn't rescue
     prediction — host-range variance lives downstream of OMP recognition (polysaccharide access, intracellular defenses,
-    co-evolutionary dynamics).*
+    co-evolutionary dynamics). CH08/CH12 re-audit upholds the null under the CHISEL per-row training unit and under both
+    label-frame variants: post-filter CH08 reported ΔAUC +0.17 pp with CI spanning zero, and pre-filter CH12 tightens to
+    +0.02 pp (even more definitively null). Canonical artifacts:
+    lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_sx13_delta.json, ch08_sx13_predictions.csv. Sensitivity-column
+    artifacts under ch08_wave2_reaudit_post_filter/.*
 - **`label-vision-reading-spot-checked-dead`**: Using a vision model to re-read the ambiguous 'n' plaque-image scores
   (the plate crops backing the ~10% of training rows labeled negative but with uninterpretable raw scores) was evaluated
   via manual spot checks before 2026-04 and did not look promising enough to justify a full re-read pipeline. Do not

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -1243,35 +1243,69 @@ themes:
 
       - id: kmer-receptor-expansion-neutral
         statement: >
-          Moriniere 2026's 815 receptor-predictive 5-mers fail to lift performance regardless of
-          encoding path: as intermediate-classifier features (GT06: AUC 0.824 vs 0.823,
-          delta CI [-0.005, +0.005]) or as direct phage-side features (SX12: AUC 0.8722 vs 0.8699,
-          delta +0.23 pp, CIs overlap). The Moriniere 815-kmer approach is exhausted on this
-          panel.
-        sources: [GT06, SX12]
-        status: dead-end
+          **REOPENED under CHISEL (CH08 wave-2 re-audit, CH12 pre-filter re-anchoring).**
+          On the SPANDEX panel with pair-level `any_lysis` training the 815-kmer slot was
+          neutral (SX12: AUC 0.8722 vs 0.8699, delta +0.23 pp, CIs overlap). Under CHISEL
+          per-row binary training with the pre-filter CH04 canonical as baseline, the same
+          phage-side k-mer slot now delivers **+0.72 pp AUC (CI [+0.36, +1.05])** with
+          disjoint-from-zero CI on 35,266 shared pairs (CH08 SX12 variant arm, CH12 rerun
+          2026-04-21). The delta is smaller than the post-filter CH08 measurement
+          (+1.16 pp, CI [+0.72, +1.55]) — so a slice of the earlier headline was
+          label-shift from the deprecated filter — but the pre-filter +0.72 pp signal
+          survives with CI disjoint from zero, which invalidates the SPANDEX-era
+          "neutral" framing under the CHISEL training unit. GT06 (k-mers as
+          intermediate-classifier features for directed cross-terms) remains null per
+          its own delta CI [-0.005, +0.005] — that failure mode is about the
+          host-side OMP homogeneity blocking the cross-term, not about the k-mers
+          themselves. Brier is unchanged in both directions (CH08 pre-filter SX12
+          Brier delta −0.0005, CI [−0.0028, +0.0017]), which means the lift is pure
+          discrimination (AUC) with no calibration side-effect. Downstream: the
+          "feature-redundancy + panel-size ceiling" framing for k-mers stands for
+          GT06 directed use, but the phage-side direct-slot use is NOT neutral
+          under per-row binary training.
+        sources: [GT06, SX12, CH08, 2026-04-20 wave-2 re-audit, CH12, 2026-04-21
+                  pre-filter re-anchoring]
+        status: active
         confidence: validated
         context: >
-          Two failure modes overlap. (1) The k-mers were selected to discriminate receptor class
-          on K-12 derivatives (BW25113/BL21) which lack capsule/O-antigen — they predict what we
-          already know (receptor identity), not what we need (strain-level capsule penetration).
-          (2) The k-mers are information-redundant with phage_projection (TL17 BLAST) — both
-          encode phage sequence similarity at different granularities. SX12 RFE keeps 95/815
-          k-mers (11.7%) but they contribute ~5% of total importance vs 22% for depo×capsule;
-          zero k-mers appear in the top-20 features. Per-bacterium analysis: ~10 genuine wins
-          (e.g., IAI78 +0.12 nDCG, ECOR-25 +0.17) exactly offset by ~10 genuine losses (e.g.,
-          ECOR-19 -0.36, EDL933 -0.24). NILS53 (the canonical narrow-host case) gains +0.011
-          nDCG — k-mers do not break narrow-host prior collapse. Not a LightGBM shortcoming;
-          a feature-redundancy + panel-size ceiling.
-        relates_to: [omp-score-homogeneity, pairwise-cross-terms-dead-end, receptor-specificity-solved, plm-rbp-redundant, narrow-host-prior-collapse, panel-size-ceiling]
+          Original SPANDEX-era failure modes (retained, context-dependent):
+          (1) the k-mers were selected to discriminate receptor class on K-12 derivatives
+          (BW25113/BL21) which lack capsule/O-antigen, so they primarily predict
+          receptor identity rather than strain-level capsule penetration; (2) information
+          redundancy with phage_projection (TL17 BLAST). Under CHISEL per-row binary
+          training the redundancy is partial rather than full — with concentration as a
+          feature and score ∈ {0, 1} per replicate, the additional phage-receptor signal
+          from 815-kmer presence adds discriminative power that was invisible when the
+          rollup collapsed replicates into any_lysis. RFE still keeps only ~95/815 kmers
+          at ~5% importance, so the effect size is real but small. CH12 pre-filter
+          re-audit preserves the directional finding: lift is +0.72 pp with CI disjoint
+          from zero even after demoting the filter (which had been inflating it to
+          +1.16 pp under post-filter). This makes the k-mer slot a live candidate for
+          canonical inclusion alongside Arm 3 per-receptor-fractions — CH13 should
+          evaluate whether Arm 3 alone subsumes the k-mer signal or whether both
+          should coexist. Canonical artifacts:
+          lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_combined_summary.json,
+          ch08_sx12_delta.json, ch08_sx12_predictions.csv. Sensitivity-column
+          artifacts under ch08_wave2_reaudit_post_filter/.
+        relates_to: [omp-score-homogeneity, pairwise-cross-terms-dead-end,
+                     receptor-specificity-solved, plm-rbp-redundant,
+                     narrow-host-prior-collapse, panel-size-ceiling,
+                     moriniere-receptor-fractions-validated, chisel-baseline]
 
       - id: host-omp-variation-unpredictive
         statement: >
           Host-side OMP allelic variation is substantial (369 clinical E. coli span BTUB 28 MMseqs2
           99%-identity clusters, OMPC 49, 5546 retained 5-mers across 12 core OMPs) but does not
           predict lysis. Four arms tested in SX13 (k-mers marginal, k-mers × phage k-mers cross-term,
-          cluster IDs, plus baseline) all land within ±0.4 pp of SX10 on all metrics.
-        sources: [SX13]
+          cluster IDs, plus baseline) all land within ±0.4 pp of SX10 on all metrics. **CONFIRMED
+          null under CHISEL (CH08 wave-2 re-audit; CH12 pre-filter re-anchoring, 2026-04-21):**
+          the host-OMP k-mer slot variant delivers ΔAUC +0.02 pp (CI [−0.13, +0.17]) and
+          ΔBrier −0.007 pp (CI [−0.09, +0.08]) on 35,266 shared pairs against the pre-filter
+          CH04 baseline — both CIs span zero, both deltas are sub-pp. The null survives under
+          per-row binary training with concentration as a feature; OMP-variation-matters-for-
+          narrow-phages remains biologically plausible but undetectable in this panel.
+        sources: [SX13, CH08, 2026-04-20 wave-2 re-audit, CH12, 2026-04-21 pre-filter
+                  re-anchoring]
         status: dead-end
         confidence: validated
         context: >
@@ -1285,8 +1319,14 @@ themes:
           under cross_term (+4 strains). The finding refines omp-score-homogeneity: HMM-score
           homogeneity was real, but escalating to finer representations doesn't rescue prediction —
           host-range variance lives downstream of OMP recognition (polysaccharide access, intracellular
-          defenses, co-evolutionary dynamics).
-        relates_to: [omp-score-homogeneity, pairwise-cross-terms-dead-end, kmer-receptor-expansion-neutral, narrow-host-prior-collapse, same-receptor-uncorrelated-hosts]
+          defenses, co-evolutionary dynamics). CH08/CH12 re-audit upholds the null under the
+          CHISEL per-row training unit and under both label-frame variants: post-filter CH08
+          reported ΔAUC +0.17 pp with CI spanning zero, and pre-filter CH12 tightens to
+          +0.02 pp (even more definitively null). Canonical artifacts:
+          lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_sx13_delta.json,
+          ch08_sx13_predictions.csv. Sensitivity-column artifacts under
+          ch08_wave2_reaudit_post_filter/.
+        relates_to: [omp-score-homogeneity, pairwise-cross-terms-dead-end, kmer-receptor-expansion-neutral, narrow-host-prior-collapse, same-receptor-uncorrelated-hosts, chisel-baseline]
 
       - id: label-vision-reading-spot-checked-dead
         statement: >

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -2170,3 +2170,105 @@ pipeline is panel-independent).
   `lyzortx/generated_outputs/ch09_calibration_layer_post_filter/` — preserved
   post-filter (deprecated) artifacts for sensitivity comparison.
 - `.scratch/ch11_logs/ch05_rerun.log` — local CH05 run log.
+
+### 2026-04-21 20:53 CEST: CH12 — CH08 SX12/SX13 wave-2 re-audit under reverted pre-filter canonical
+
+#### Executive summary
+
+Re-ran `ch08_wave2_reaudit` with the CH10-reverted default
+(`drop_high_titer_only_positives=False`) and the pre-filter CH04 canonical (AUC
+0.8083) as the paired-bootstrap baseline reference. Two decisions:
+**SX12 reopened** (Moriniere 815-kmer phage-side slot lifts AUC by +0.72 pp,
+CI [+0.36, +1.05] — disjoint from zero, invalidates the SPANDEX-era
+"kmer-receptor-expansion-neutral" dead-end under CHISEL per-row training);
+**SX13 confirmed null** (host-OMP k-mer slot lifts AUC by +0.02 pp,
+CI [−0.13, +0.17] — CI spans zero, tightens the SPANDEX SX13 null under the
+CHISEL training unit).
+
+#### Changes
+
+- **CH08 rerun**: `python -m lyzortx.pipeline.autoresearch.ch08_wave2_reaudit`
+  with the (already CH10-flipped) `drop_high_titer_only_positives=False`
+  default. No code changes — the flag flip lives in the merged CH10 PR and
+  CH08's code paths consume it directly.
+- **Artifact swap**: `ch08_wave2_reaudit/` → `ch08_wave2_reaudit_post_filter/`
+  before the rerun; new pre-filter artifacts land at the canonical path.
+- **Knowledge model**:
+  `kmer-receptor-expansion-neutral` REOPENED (status dead-end → active;
+  statement + context rewritten to separate the SPANDEX failure mode from the
+  CHISEL re-audit findings; sources amended to include CH08/CH12).
+  `host-omp-variation-unpredictive` context amended with the CH08/CH12
+  pre-filter re-audit numbers; status remains dead-end (null confirmed).
+
+#### Results
+
+**CH12 re-audit deltas** (paired bacterium-level bootstrap, 1000 resamples,
+35,266 shared pairs, pre-filter CH04 canonical baseline):
+
+| Arm | Slot | Variant AUC | Δ AUC | 95% CI | Δ Brier | Δ Brier CI | Verdict |
+|---|---|---|---|---|---|---|---|
+| baseline | — | 0.8083 | — | — | — | — | reference |
+| **SX12** | phage_moriniere_kmer | 0.8154 | **+0.0072** | [+0.0036, +0.0105] | −0.00051 | [−0.0028, +0.0017] | **disjoint from zero; reopen** |
+| SX13 | host_omp_kmer | 0.8085 | +0.00018 | [−0.0013, +0.0017] | −0.00007 | [−0.0009, +0.0008] | null |
+
+**Post-filter sensitivity column** (CH08 original merged numbers, now at
+`ch08_wave2_reaudit_post_filter/`): SX12 +0.0116 AUC [+0.0072, +0.0155],
+SX13 +0.00173 AUC [+0.00049, +0.00303]. Pre-filter vs post-filter delta
+deltas: SX12 −0.0044 AUC (filter had been inflating the k-mer lift),
+SX13 −0.00156 AUC (filter had been making the null look marginally
+positive).
+
+**n_common_pairs**: 35,266 on both arms, matching CH04's `n_pairs_evaluated`
+(8,675 score='n' rows dropped as missing).
+
+**Elapsed**: 3,570 s (59.5 min).
+
+#### Interpretation
+
+- **SX12 reopen is the headline decision.** The SPANDEX-era SX12 null
+  (+0.23 pp, CIs overlap) was measured with pair-level `any_lysis` labels and
+  nDCG scoring on the MLC-graded frame. Under CHISEL per-row binary training
+  with concentration as a feature and AUC+Brier scoring, the same phage-side
+  k-mer slot delivers +0.72 pp AUC with disjoint-from-zero CI. The redundancy
+  argument from the original unit (k-mers overlap phage_projection TL17) is
+  partial rather than full under per-row training: with 9 rows per
+  (bacterium, phage) pair at different concentrations, the additional
+  k-mer presence signal adds discrimination that was invisible when the
+  rollup collapsed replicates. RFE still keeps only ~95/815 k-mers at ~5%
+  importance, so effect size is small but robust.
+- **Post-filter had been overselling.** Under CH08's original merged post-filter
+  frame, SX12 delta was +1.16 pp — the CH12 pre-filter re-audit shows
+  ~38% of that lift was label-shift artifact from the CH06-followup filter.
+  The remaining +0.72 pp is the honest CHISEL SX12 signal. This is a second
+  example (alongside the BASEL improvement in CH11) of the pre-filter
+  frame revealing that the merged post-filter numbers were inflated by
+  label-population trivialization.
+- **SX13 null is real.** +0.02 pp with CI spanning zero is the definitive
+  dismissal of host-OMP k-mer features under CHISEL — even tighter than
+  the post-filter +0.17 pp null. `host-omp-variation-unpredictive` remains
+  dead-end; the refinement noted in the original unit (host-range variance
+  lives downstream of OMP recognition) stands.
+- **CH13 implication.** SX12's survival under pre-filter means the Arm 3
+  per-receptor-fraction slot (CH06 validation) and the 815-kmer slot may
+  have partially overlapping signal. CH13's canonical migration should
+  benchmark (a) Arm 3 alone, (b) Arm 3 + 815-kmer, (c) 815-kmer alone vs
+  baseline TL17 to establish whether the two coexist or Arm 3 subsumes the
+  k-mer lift.
+
+#### Next steps
+
+- **CH12 remaining:** open PR closing #458; self-review via `review-ml-pr`
+  subagent; merge. Orchestrator ticks → CH13 dispatched.
+- **CH13:** canonical Arm 3 `phage_projection` migration + rerun CH04/CH05/
+  CH07/CH08/CH09 under the new slot. Scope includes benchmark of Arm 3 vs
+  Arm 3 + 815-kmer coexistence per CH12 SX12 reopen.
+
+#### Artifacts
+
+- `lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_combined_summary.json`,
+  `ch08_summary.csv`, `ch08_sx12_delta.json`, `ch08_sx13_delta.json`,
+  `ch08_sx12_predictions.csv`, `ch08_sx13_predictions.csv` — pre-filter
+  CH12 canonical.
+- `lyzortx/generated_outputs/ch08_wave2_reaudit_post_filter/` — preserved
+  post-filter (deprecated) artifacts for sensitivity comparison.
+- `.scratch/ch12_logs/ch08_rerun.log` — local CH08 run log.

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
@@ -14,7 +14,7 @@ one of its two root causes (phage-side TL17 bias) into a panel-independent featu
 
 **2026-04-21 CH11 rerun:** CH05 + CH09 isotonic refit completed under the reverted
 pre-filter canonical with the Arm 3 `phage_projection` slot override. Headline
-numbers below are now canonical; CH08 (CH12) is the last remaining rerun.
+numbers below are now canonical; all filter-revert reruns complete.
 
 Everything below is on the 369×96 Guelin panel (unified 148-phage panel for cross-
 source numbers). Canonical = per-row binary labels, `pair_concentration__log10_pfu_ml`
@@ -111,15 +111,20 @@ re-litigate):
 
 And what surprised us on re-audit:
 
-+ **CH08 SX12 (Moriniere 815 phage 5-mers, top-100 variance pre-filter)**: **non-null.**
-  +1.16 pp AUC [+0.82, +1.51] under CHISEL per-row training, disjoint CI. Reopens the
-  SPANDEX-era `kmer-receptor-expansion-neutral` null. Not a blocker for the Arm 3
-  migration — the two findings are complementary (Arm 3 = panel-independent aggregates;
-  SX12 kmers = raw-feature additive lift on Guelin).
-+ **CH08 SX13 (host OMP 5546 5-mers, top-100 variance pre-filter)**: barely-non-null.
-  +0.17 pp AUC [+0.03, +0.31]. Reopens `host-omp-variation-unpredictive` but the effect
-  is consistent with phylogroup-correlated lineage noise rather than OMP-specific
-  host-range signal.
++ **CH08 SX12 (Moriniere 815 phage 5-mers, top-100 variance pre-filter)**: **non-null,
+  re-audited under pre-filter canonical.** Post-filter (CH08 original) reported
+  +1.16 pp AUC [+0.82, +1.51]; CH12 pre-filter re-audit tightens to **+0.72 pp AUC
+  [+0.36, +1.05]** — still disjoint from zero but ~38% of the lift was
+  label-shift artifact from the CH06-followup filter. Reopens the SPANDEX-era
+  `kmer-receptor-expansion-neutral` null under CHISEL per-row training. Not a
+  blocker for the Arm 3 migration — the two findings are complementary (Arm 3 =
+  panel-independent aggregates; SX12 kmers = raw-feature additive lift on Guelin).
++ **CH08 SX13 (host OMP 5546 5-mers, top-100 variance pre-filter)**: **null
+  confirmed** under CH12 pre-filter re-audit. Post-filter reported marginally-positive
+  +0.17 pp AUC [+0.03, +0.31]; pre-filter tightens to **+0.02 pp AUC [−0.13, +0.17]**,
+  CI now spans zero. The marginal post-filter signal was entirely filter-driven
+  label-shift — `host-omp-variation-unpredictive` remains dead-end under both
+  label frames.
 
 ## Open follow-ups
 


### PR DESCRIPTION
## Summary

Re-ran `ch08_wave2_reaudit` with the CH10-reverted default and the pre-filter
CH04 canonical (AUC 0.8083) as the paired-bootstrap baseline reference.

**Results** (1000 paired bacterium-level bootstrap resamples, 35,266 shared pairs):

| Arm | Slot | Variant AUC | Δ AUC | 95% CI | Verdict |
|---|---|---|---|---|---|
| baseline | — | 0.8083 | — | — | pre-filter CH04 ref |
| **SX12** | phage_moriniere_kmer | 0.8154 | **+0.0072** | [+0.0036, +0.0105] | **disjoint — reopen** |
| SX13 | host_omp_kmer | 0.8085 | +0.00018 | [−0.0013, +0.0017] | null |

**Decisions:**

- **SX12 → REOPEN `kmer-receptor-expansion-neutral`** under CHISEL per-row
  training. SPANDEX-era framing (+0.23 pp, CIs overlap) was specific to pair-
  level any_lysis + nDCG; under per-row binary training with concentration as
  a feature, the k-mer slot delivers +0.72 pp AUC with disjoint-from-zero CI.
- **SX13 → CONFIRM `host-omp-variation-unpredictive` null.** CI now tighter
  than post-filter's marginal-positive read; host-OMP k-mer slot does not
  lift discrimination under CHISEL.

**Post-filter sensitivity**: SX12 +1.16 pp (post-filter) vs +0.72 pp (pre-filter)
— ~38% of the post-filter lift was label-shift artifact from the CH06-followup
filter. SX13 marginal +0.17 pp (post-filter) → +0.02 pp (pre-filter) — the
marginal post-filter signal was entirely filter-driven. Second example
(alongside CH11's BASEL improvement) where the pre-filter frame reveals the
deprecated post-filter numbers were inflated by label-population trivialization.

**CH13 implication**: SX12's surviving lift under pre-filter means Arm 3
per-receptor-fractions and the 815-kmer phage slot may have partially
overlapping signal. CH13's canonical migration should benchmark Arm 3 alone,
Arm 3 + 815-kmer, and 815-kmer alone to establish coexistence vs subsumption.

## Knowledge updates

- `kmer-receptor-expansion-neutral`: status dead-end → active; statement +
  context rewritten to separate SPANDEX failure mode from CHISEL re-audit.
- `host-omp-variation-unpredictive`: context amended with CH12 numbers;
  status remains dead-end.

Post-filter artifacts preserved at `ch08_wave2_reaudit_post_filter/`.

Closes #458

## Test plan

- [x] `pytest lyzortx/tests/` — 520 passed
- [x] CH08 rerun: SX12 + SX13 deltas bootstrap from ch08_{sx12,sx13}_predictions.csv
- [x] `knowledge_parser.validate_knowledge()` passes; KNOWLEDGE.md regenerated
- [x] pymarkdown clean on notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)