### PR TITLE
[ORCH][CH13] Arm 3 canonical phage_projection slot migration

### DIFF
--- a/lyzortx/KNOWLEDGE.md
+++ b/lyzortx/KNOWLEDGE.md
@@ -172,16 +172,26 @@ What works, what doesn't, leakage risks, and encoding decisions.
     says nothing about strain-level within-class ranking. Guelin numbers are flat (bacteria-axis 0.8247 → 0.8232,
     phage-axis 0.8922 → 0.8934), so Arm 3 does not damage the Guelin-heavy aggregate. BASEL non-zero-proj TL17 phages
     (n=39) also improve (+2.54 pp bact-axis, +0.54 pp phage-axis), so there is no zero-vs-non-zero trade-off — Arm 3
-    strictly dominates baseline TL17 on the BASEL side. **Canonical migration is deferred**: Arm 3 is currently a
-    side-materialized slot at `.scratch/basel/feature_slots_arm3/phage_projection/features.csv`; CH05 / CH07 / CH08 /
-    CH09 pipelines still read baseline TL17. A follow-up ticket (CH13 in plan.yml post the CH10-12 filter-revert
-    insertion) should make Arm 3 the default slot and re-run those pipelines. Supersedes the "panel-independent phage
-    features are the remaining lever" open question in `chisel-unified-kfold-baseline` (the lever exists; now the
-    question is migration cost + downstream calibration effects). Canonical artifacts:
+    strictly dominates baseline TL17 on the BASEL side. **Canonical migration complete (CH13, 2026-04-21):** Arm 3
+    per-receptor-class k-mer fractions are now the canonical `phage_projection` slot in both the autoresearch
+    Guelin-only cache (`lyzortx/generated_outputs/autoresearch/search_cache_v1/feature_slots/phage_projection/`, 96
+    phages) and the unified-panel slot root (`.scratch/basel/feature_slots/phage_projection/`, 148 phages). The
+    top-level `ar02_schema_manifest_v1.json` reserved-feature-column list was rewritten to the 13
+    `phage_projection__recep_frac_*` names. TL17 BLAST family-presence vectors are preserved at `phage_projection_tl17/`
+    side-dirs as an opt-in sensitivity fallback. CH04 under Arm 3 canonical: AUC 0.8094 [0.7956, 0.8226] — at-parity
+    with TL17 baseline 0.8083 on Guelin-only evaluation (no BASEL exposure). CH05/CH07/CH09 canonical artifacts from
+    CH11/CH10 were ALREADY produced under Arm 3 (via `--phage-slot-dir` override); post-migration they reproduce
+    bit-for-bit under the default, so no rerun was needed (verified: CH05 bacteria-axis CSV recomputes AUC 0.807921 =
+    CH11 JSON). CH08 rerun under Arm 3 canonical (CH13): SX12 phage 815-kmer lift tightens to +0.58 pp [+0.20, +0.94]
+    (was +0.72 pp under TL17 baseline in CH12) — still disjoint-from-zero, so the raw 815 kmers encode ~81% of their
+    lift beyond what Arm 3's 13-dim aggregation captures (the two slots coexist rather than being fully redundant).
+    Supersedes the "panel- independent phage features are the remaining lever" open question in
+    `chisel-unified-kfold-baseline`. Canonical artifacts:
     lyzortx/generated_outputs/ch06_arm3_moriniere_receptor/ch06_arm3_metrics.json,
     ch06_arm3_{bacteria,phage}_axis_predictions.csv, ch06_arm3_cross_source_breakdown.csv,
-    ch06_arm3_variance_preflight.json, and the slot file
-    .scratch/basel/feature_slots_arm3/phage_projection/features.csv.*
+    ch06_arm3_variance_preflight.json (original CH06 Arm 3 validation), the live canonical slot at
+    `.scratch/basel/feature_slots/phage_projection/features.csv` (148 phages) and
+    `lyzortx/generated_outputs/autoresearch/search_cache_v1/feature_slots/phage_projection/features.csv` (96 phages).*
 
 ## Model Architecture & Performance
 
@@ -190,18 +200,23 @@ Architecture choices, calibration, and performance bounds.
 - **`tl18-flawed-baseline`**: TL18 model (0.823 AUC) is not a valid baseline: DefenseFinder version drift inflated 17.3%
   of feature importance, and 5 soft-leaky pairwise features contributed ~5.5%. [validated; source: TL18 audit; see also:
   autoresearch-baseline]
-- **`chisel-baseline`**: CHISEL canonical baseline (CH04, reverted 2026-04-21 — see CH10 below): per-row binary training
-  on every interpretable (bacterium, phage, log_dilution, replicate, X, Y) raw observation with score ∈ {0, 1} and
-  `pair_concentration__log10_pfu_ml` as a numeric feature (absolute log₁₀ pfu/ml encoding — Guelin {4.7, 6.7, 7.7, 8.7};
-  BASEL 9.0 per Maffei 2021 / 2025), SX10 feature bundle (host_surface + host_typing + host_stats + host_defense +
-  phage_projection + phage_stats + pair_depo_capsule + pair_receptor_omp, RFE-selected), **all-pairs only** (AX02
-  per-phage blending retired, see per-phage-retired-under-chisel), 10-fold bacteria-axis CV under CH02 cv_group hashing,
-  369×96 panel. **No neat-only positive filter** — every raw observation with score ∈ {0, 1} trains. Evaluation: each
-  held-out pair scored at its max observed log10_pfu_ml with bacterium-level bootstrap CIs (1000 resamples). Result:
-  **AUC 0.8083 [0.7943, 0.8216], Brier 0.1751 [0.1677, 0.1824]** (n=35,266 pairs, 8,675 score='n' rows dropped). This is
-  the active reference point for all future CHISEL arms. [validated; source: CH04, 2026-04-19 CHISEL baseline; CH10,
-  2026-04-21 filter revert; see also: spandex-final-baseline, cv-group-leakage-fixed, label-policy-binary,
-  ranking-metrics-retired, per-phage-retired-under-chisel, deployment-goal]
+- **`chisel-baseline`**: CHISEL canonical baseline (CH04, re-run 2026-04-21 under CH13 with Arm 3 as canonical
+  `phage_projection` slot): per-row binary training on every interpretable (bacterium, phage, log_dilution, replicate,
+  X, Y) raw observation with score ∈ {0, 1} and `pair_concentration__log10_pfu_ml` as a numeric feature (absolute log₁₀
+  pfu/ml encoding — Guelin {4.7, 6.7, 7.7, 8.7}; BASEL 9.0 per Maffei 2021 / 2025), SX10 feature bundle (host_surface +
+  host_typing + host_stats + host_defense + phage_projection + phage_stats + pair_depo_capsule + pair_receptor_omp,
+  RFE-selected), **all-pairs only** (AX02 per-phage blending retired, see per-phage-retired-under-chisel), 10-fold
+  bacteria-axis CV under CH02 cv_group hashing, 369×96 panel. **No neat-only positive filter** — every raw observation
+  with score ∈ {0, 1} trains. Evaluation: each held-out pair scored at its max observed log10_pfu_ml with
+  bacterium-level bootstrap CIs (1000 resamples). Result: **AUC 0.8094 [0.7956, 0.8226], Brier 0.1749 [0.1679, 0.1825]**
+  (n=35,266 pairs, 8,675 score='n' rows dropped, concentration feature importance 322.5). Vs CH10 TL17-baseline CH04
+  (0.8083 / 0.1751): +0.11 pp AUC, −0.01 pp Brier — essentially at-parity on Guelin-only evaluation because both TL17
+  phage family presence vectors (33 cols) and Arm 3 per-receptor-class k-mer fractions (13 cols) encode the same
+  underlying receptor-binding information for the 96 Guelin phages; Arm 3's panel-independence benefit shows up on BASEL
+  cross-source (see chisel-unified-kfold-baseline). This is the active reference point for all future CHISEL arms.
+  [validated; source: CH04, 2026-04-19 CHISEL baseline; CH10, 2026-04-21 filter revert; CH13, 2026-04-21 Arm 3 canonical
+  migration; see also: spandex-final-baseline, cv-group-leakage-fixed, label-policy-binary, ranking-metrics-retired,
+  per-phage-retired-under-chisel, deployment-goal]
   - ***Baseline movement over CHISEL.** CH02 revalidated SX10 (pair-level any_lysis, 10-fold cv_group hashing, per-phage
     blending enabled) = AUC 0.8521, Brier 0.1317. CH04 initial canonical (per-row binary, all-pairs only, concentration
     feature, no filter) = AUC 0.8084 [0.7944, 0.8217], Brier 0.1750 [0.1677, 0.1824] — ΔAUC −4.37 pp, ΔBrier +4.33 pp vs
@@ -258,13 +273,15 @@ Architecture choices, calibration, and performance bounds.
     `_post_filter/` side-directories for sensitivity comparison. The filter remains available as an opt-in CLI flag
     (`--drop-high-titer-only-positives`) but is not the default in any eval script. **SUPERSEDES: PR #453** (commit
     c22faf7, merged 2026-04-21) — #453 amended the knowledge unit to disclose the label-shift artifact but kept the
-    filter as canonical. CH10 demotes the filter entirely. **Canonical artifacts:**
-    lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json, ch04_predictions.csv (pair-level),
-    ch04_per_row_predictions.csv (per-row), ch04_feature_importance.csv;
+    filter as canonical. CH10 demotes the filter entirely. **Canonical artifacts (all under Arm 3 phage_projection slot
+    since CH13):** lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json, ch04_predictions.csv
+    (pair-level), ch04_per_row_predictions.csv (per-row), ch04_feature_importance.csv;
     lyzortx/generated_outputs/ch07_both_axis_holdout/ch07_aggregate.json, ch07_pair_predictions.csv,
     ch07_per_row_predictions.csv, ch07_cell_metrics.csv, ch07_cross_source_breakdown.csv, ch07_cell_distribution.png;
     lyzortx/generated_outputs/ch05_unified_kfold/ch05_combined_summary.json and
-    ch09_calibration_layer/ch09_calibration_report.json (CH11 refit).*
+    ch09_calibration_layer/ch09_calibration_report.json;
+    lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_combined_summary.json (CH13 rerun). Pre-CH13 TL17-baseline runs
+    preserved at ch04_chisel_baseline_tl17/ and ch08_wave2_reaudit_tl17/ as a sensitivity column.*
 - **`spandex-final-baseline`**: HISTORICAL (SPANDEX-era). Superseded as the active canonical by chisel-baseline (CH04).
   SPANDEX final configuration — GT03 all_gates_rfe + AX02 per-phage blending on SX05-corrected MLC 0-3 labels, 10-fold
   CV bacteria-axis on the 369×96 panel: **AUC 0.8699 [0.8570, 0.8819], Brier 0.1248 [0.1187, 0.1309]** within-panel,
@@ -301,51 +318,52 @@ Architecture choices, calibration, and performance bounds.
   369-bacteria panel (36,643 pairs: 35,403 Guelin + 1,240 BASEL), SX10 feature bundle, all-pairs only (per-phage
   blending retired track-wide per `per-phage-retired-under-chisel`), **no neat-only positive filter** (demoted to opt-in
   sensitivity analysis — see chisel-baseline for the four reviewer objections), Arm 3 Moriniere per-receptor-fraction
-  slot override for `phage_projection` (`.scratch/basel/feature_slots_arm3/`). Two axes: **bacteria-axis AUC 0.8079
-  [0.7934, 0.8223], Brier 0.1763 [0.1688, 0.1840]** (10-fold CH02 cv_group hash; all 148 phages in training per fold);
-  **phage-axis AUC 0.8870 [0.8658, 0.9055], Brier 0.1352 [0.1227, 0.1489]** (10-fold StratifiedKFold by ICTV family +
-  "other" <10-phage bucket + "UNKNOWN" no-family bucket — 40% of folds are pseudo-family catch-alls; calling it
-  "ICTV-stratified" without that qualifier misleads). Three separate findings stand in place of the earlier
-  "cross-source AUC parity" headline: **(1) phage-axis discrimination parity** (Guelin 0.8871 vs BASEL 0.8952, |ΔAUC|
-  0.0081 — BASEL now *exceeds* Guelin by ~0.8 pp on phage-axis, though with a 3× wider CI; the revert narrowed the
-  Guelin–BASEL gap vs the deprecated post-filter frame where Guelin was artificially sharpened +1.0 pp relative to
-  BASEL); **(2) phage-axis calibration divergence** (Guelin Brier 0.1346 vs BASEL 0.1503 — disjoint CIs, BASEL
-  overpredicts in mid-P 0.5-0.8 bins by 25-35 pp even after isotonic transfer); **(3) BASEL bacteria-axis deficit**
-  (BASEL-only AUC 0.7392 on the 1,240 BASEL pairs vs Guelin-only 0.8104 on the same axis — **7.1 pp** BASEL-specific
-  deficit. The revert narrowed this from the deprecated post-filter 10.2 pp: BASEL sharpened +1.6 pp (0.7229→0.7392)
-  while Guelin fell −1.4 pp (0.8247→0.8104). The filter had been making Guelin look good by artificially removing "hard"
-  training labels — that gain did not transfer to BASEL, so the revert *improves* BASEL discrimination on both axes. The
-  7.1 pp residual deficit is real panel-mismatch on the phage-side feature slot, and is the load-bearing number for
-  CH13's Arm-3 canonical-slot migration scope). Expected Calibration Error (ECE, weighted mean of per-decile
-  |observed−predicted| gaps) on raw predictions: **bacteria-axis Guelin ECE 0.122, BASEL ECE 0.205; phage-axis Guelin
-  ECE 0.111, BASEL ECE 0.188**. Two separable root-cause mechanisms, each diagnostically distinct: **(A) Guelin mid-P
-  miscalibration = training-label-vs-deployment-question mismatch, post-hoc fixable**. Leave-one-fold-out isotonic
-  regression on Guelin predictions closes Guelin ECE to **0.0057 bacteria-axis / 0.0052 phage-axis** (~95% ECE closure),
-  AUC preserved within 0.5 pp. The raw reliability shape is specifically: deciles 6-9 overpredict lysis by 18-31 pp on
-  >10k rows combined — the model is systematically overconfident in the upper-P bins, which is what isotonic regression
-  exists to fix. The training label is more permissive than the deployment target; Gaborieau 2024 Methods admits
-  clearing at high titer can be non-productive — CH10 rejected the training-side filter remedy (see chisel-baseline),
-  leaving the CH09 post-hoc isotonic calibration layer as the sole remedy for Guelin mid-P miscalibration. **(B) BASEL's
-  additional miscalibration = TL17-bias on the phage-side feature slot, NOT threshold**. Applying the Guelin-fitted
-  isotonic calibrator to BASEL closes only part of the gap: **bacteria-axis ECE 0.205→0.073 = 64.3% closure; phage-axis
-  ECE 0.188→0.104 = 44.6% closure**. Residual BASEL ECE after transfer is ~0.073 bacteria / 0.104 phage — still ~13-20×
-  Guelin's LOOF-calibrated ECE. Threshold-mismatch remedy does NOT rescue BASEL's extra miscalibration. Root cause
-  isolated to the 39/52 BASEL phages whose `phage_projection` vectors are non-zero: their projection vectors map into
-  Guelin-derived TL17 neighborhoods associated with broad-host lysis but carry narrower actual host ranges. The 13/52
-  BASEL phages with zero-vector projection calibrate correctly because the model has no phage signal to misuse and falls
-  back to the host-side prior. Requires panel-independent phage features (Arm 3 slot is the CH06 validation of such a
-  feature set; CH13 canonicalizes it). Straboviridae exclusion closed only 1.5 pp of the original 9.5-10.2 pp
-  bacteria-axis BASEL deficit — family bias is not the driver. **Sensitivity-analysis columns (post-filter,
-  deprecated)**: if the CH06-followup neat-only filter is re-enabled as a training-side ablation, the same pipeline
-  produced bacteria-axis AUC 0.8218 / phage-axis AUC 0.8919; BASEL bact-axis 0.7229 (10.2 pp deficit); BASEL ECE closure
-  79.5% / 53.2%. CH10 demoted the filter to sensitivity-analysis-only per reviewer findings — see chisel-baseline.
-  Numbers preserved for reproducibility in ch05_unified_kfold_post_filter/ and ch09_calibration_layer_post_filter/;
-  production code paths default to the pre-filter canonical above. This is the active CHISEL reference for two-axis
-  generalization and cross- source behaviour. [validated; source: CH05, 2026-04-19 CHISEL unified k-fold; CH06-followup,
-  2026-04-20 filter adoption; CH09, 2026-04-20 calibration layer; CH11, 2026-04-21 reverted pre-filter rerun + isotonic
-  refit; see also: chisel-baseline, spandex-unified-kfold-baseline, per-phage-retired-under-chisel,
-  cv-group-leakage-fixed, new-phage-generalization, deployment-goal, plm-rbp-redundant, panel-size-ceiling,
-  chisel-post-hoc-calibration-layer]
+  slot as the canonical `phage_projection` slot (migrated by CH13 on 2026-04-21 — the CH11 numbers below were produced
+  via `--phage-slot-dir` override and reproduce bit-for-bit under the post-CH13 default, so no re-run needed). Two axes:
+  **bacteria-axis AUC 0.8079 [0.7934, 0.8223], Brier 0.1763 [0.1688, 0.1840]** (10-fold CH02 cv_group hash; all 148
+  phages in training per fold); **phage-axis AUC 0.8870 [0.8658, 0.9055], Brier 0.1352 [0.1227, 0.1489]** (10-fold
+  StratifiedKFold by ICTV family + "other" <10-phage bucket + "UNKNOWN" no-family bucket — 40% of folds are
+  pseudo-family catch-alls; calling it "ICTV-stratified" without that qualifier misleads). Three separate findings stand
+  in place of the earlier "cross-source AUC parity" headline: **(1) phage-axis discrimination parity** (Guelin 0.8871 vs
+  BASEL 0.8952, |ΔAUC| 0.0081 — BASEL now *exceeds* Guelin by ~0.8 pp on phage-axis, though with a 3× wider CI; the
+  revert narrowed the Guelin–BASEL gap vs the deprecated post-filter frame where Guelin was artificially sharpened +1.0
+  pp relative to BASEL); **(2) phage-axis calibration divergence** (Guelin Brier 0.1346 vs BASEL 0.1503 — disjoint CIs,
+  BASEL overpredicts in mid-P 0.5-0.8 bins by 25-35 pp even after isotonic transfer); **(3) BASEL bacteria-axis
+  deficit** (BASEL-only AUC 0.7392 on the 1,240 BASEL pairs vs Guelin-only 0.8104 on the same axis — **7.1 pp**
+  BASEL-specific deficit. The revert narrowed this from the deprecated post-filter 10.2 pp: BASEL sharpened +1.6 pp
+  (0.7229→0.7392) while Guelin fell −1.4 pp (0.8247→0.8104). The filter had been making Guelin look good by artificially
+  removing "hard" training labels — that gain did not transfer to BASEL, so the revert *improves* BASEL discrimination
+  on both axes. The 7.1 pp residual deficit is real panel-mismatch on the phage-side feature slot, and is the
+  load-bearing number for CH13's Arm-3 canonical-slot migration scope). Expected Calibration Error (ECE, weighted mean
+  of per-decile |observed−predicted| gaps) on raw predictions: **bacteria-axis Guelin ECE 0.122, BASEL ECE 0.205;
+  phage-axis Guelin ECE 0.111, BASEL ECE 0.188**. Two separable root-cause mechanisms, each diagnostically distinct:
+  **(A) Guelin mid-P miscalibration = training-label-vs-deployment-question mismatch, post-hoc fixable**.
+  Leave-one-fold-out isotonic regression on Guelin predictions closes Guelin ECE to **0.0057 bacteria-axis / 0.0052
+  phage-axis** (~95% ECE closure), AUC preserved within 0.5 pp. The raw reliability shape is specifically: deciles 6-9
+  overpredict lysis by 18-31 pp on >10k rows combined — the model is systematically overconfident in the upper-P bins,
+  which is what isotonic regression exists to fix. The training label is more permissive than the deployment target;
+  Gaborieau 2024 Methods admits clearing at high titer can be non-productive — CH10 rejected the training-side filter
+  remedy (see chisel-baseline), leaving the CH09 post-hoc isotonic calibration layer as the sole remedy for Guelin mid-P
+  miscalibration. **(B) BASEL's additional miscalibration = TL17-bias on the phage-side feature slot, NOT threshold**.
+  Applying the Guelin-fitted isotonic calibrator to BASEL closes only part of the gap: **bacteria-axis ECE 0.205→0.073 =
+  64.3% closure; phage-axis ECE 0.188→0.104 = 44.6% closure**. Residual BASEL ECE after transfer is ~0.073 bacteria /
+  0.104 phage — still ~13-20× Guelin's LOOF-calibrated ECE. Threshold-mismatch remedy does NOT rescue BASEL's extra
+  miscalibration. Root cause isolated to the 39/52 BASEL phages whose `phage_projection` vectors are non-zero: their
+  projection vectors map into Guelin-derived TL17 neighborhoods associated with broad-host lysis but carry narrower
+  actual host ranges. The 13/52 BASEL phages with zero-vector projection calibrate correctly because the model has no
+  phage signal to misuse and falls back to the host-side prior. Requires panel-independent phage features (Arm 3 slot is
+  the CH06 validation of such a feature set; CH13 canonicalizes it). Straboviridae exclusion closed only 1.5 pp of the
+  original 9.5-10.2 pp bacteria-axis BASEL deficit — family bias is not the driver. **Sensitivity-analysis columns
+  (post-filter, deprecated)**: if the CH06-followup neat-only filter is re-enabled as a training-side ablation, the same
+  pipeline produced bacteria-axis AUC 0.8218 / phage-axis AUC 0.8919; BASEL bact-axis 0.7229 (10.2 pp deficit); BASEL
+  ECE closure 79.5% / 53.2%. CH10 demoted the filter to sensitivity-analysis-only per reviewer findings — see
+  chisel-baseline. Numbers preserved for reproducibility in ch05_unified_kfold_post_filter/ and
+  ch09_calibration_layer_post_filter/; production code paths default to the pre-filter canonical above. This is the
+  active CHISEL reference for two-axis generalization and cross- source behaviour. [validated; source: CH05, 2026-04-19
+  CHISEL unified k-fold; CH06-followup, 2026-04-20 filter adoption; CH09, 2026-04-20 calibration layer; CH11, 2026-04-21
+  reverted pre-filter rerun + isotonic refit; see also: chisel-baseline, spandex-unified-kfold-baseline,
+  per-phage-retired-under-chisel, cv-group-leakage-fixed, new-phage-generalization, deployment-goal, plm-rbp-redundant,
+  panel-size-ceiling, chisel-post-hoc-calibration-layer]
   - ***Baseline movement across CHISEL tickets** (numbers here reference the 148×369 unified panel unless otherwise
     noted): - CH05 initial canonical (pre-filter, baseline TL17 phage_projection slot,   absolute log₁₀ pfu/ml
     encoding): bacteria-axis AUC 0.8061 [0.7917, 0.8199] /   Brier 0.1778; phage-axis AUC 0.8850 [0.8617, 0.9062] /
@@ -656,44 +674,50 @@ Compressed lessons from approaches that didn't work.
   (37,788/37,788 pairs match after name normalization). Our data is already in their framework. No new training pairs
   available from GenoPHI for existing phages. [validated; source: GT09; see also: genophi-benchmark,
   raw-interactions-authority]
-- **`kmer-receptor-expansion-neutral`**: **REOPENED under CHISEL (CH08 wave-2 re-audit, CH12 pre-filter re-anchoring).**
-  On the SPANDEX panel with pair-level `any_lysis` training the 815-kmer slot was neutral (SX12: AUC 0.8722 vs 0.8699,
-  delta +0.23 pp, CIs overlap). Under CHISEL per-row binary training with the pre-filter CH04 canonical as baseline, the
-  same phage-side k-mer slot now delivers **+0.72 pp AUC (CI [+0.36, +1.05])** with disjoint-from-zero CI on 35,266
-  shared pairs (CH08 SX12 variant arm, CH12 rerun 2026-04-21). The delta is smaller than the post-filter CH08
-  measurement (+1.16 pp, CI [+0.72, +1.55]) — so a slice of the earlier headline was label-shift from the deprecated
-  filter — but the pre-filter +0.72 pp signal survives with CI disjoint from zero, which invalidates the SPANDEX-era
-  "neutral" framing under the CHISEL training unit. GT06 (k-mers as intermediate-classifier features for directed
-  cross-terms) remains null per its own delta CI [-0.005, +0.005] — that failure mode is about the host-side OMP
-  homogeneity blocking the cross-term, not about the k-mers themselves. Brier is unchanged in both directions (CH08
-  pre-filter SX12 Brier delta −0.0005, CI [−0.0028, +0.0017]), which means the lift is pure discrimination (AUC) with no
-  calibration side-effect. Downstream: the "feature-redundancy + panel-size ceiling" framing for k-mers stands for GT06
-  directed use, but the phage-side direct-slot use is NOT neutral under per-row binary training. [validated; source:
-  GT06, SX12, CH08, 2026-04-20 wave-2 re-audit, CH12, 2026-04-21 pre-filter re-anchoring; see also:
+- **`kmer-receptor-expansion-neutral`**: **REOPENED under CHISEL (CH08 wave-2 re-audit; CH12 pre-filter re-anchoring;
+  CH13 Arm 3 canonical baseline).** On the SPANDEX panel with pair-level `any_lysis` training the 815-kmer slot was
+  neutral (SX12: AUC 0.8722 vs 0.8699, delta +0.23 pp, CIs overlap). Under CHISEL per-row binary training with the CH13
+  Arm 3 canonical baseline (CH04 AUC 0.8094), the same phage-side 815-kmer slot delivers **+0.58 pp AUC (CI [+0.20,
+  +0.94])** with disjoint-from-zero CI on 35,266 shared pairs. This invalidates the SPANDEX-era "neutral" framing under
+  the CHISEL training unit. GT06 (k-mers as intermediate-classifier features for directed cross-terms) remains null per
+  its own delta CI [−0.005, +0.005] — that failure mode is about host-side OMP homogeneity blocking the cross-term, not
+  about the k-mers themselves. Brier delta is null (−0.0002 CI [−0.0024, +0.0019]) — lift is pure discrimination with no
+  calibration side-effect. The delta size has shrunk across successive baselines: +1.16 pp (CH08 post-filter TL17
+  baseline) → +0.72 pp (CH12 pre-filter TL17 baseline, CI [+0.36, +1.05]) → **+0.58 pp (CH13 Arm 3 canonical
+  baseline)**. About 38% of the original headline was label-shift from the deprecated neat-only filter (closed in CH10);
+  another ~19% of the remaining signal is subsumed by Arm 3's 13-dim per-receptor-fraction aggregation of the same
+  k-mers — so ~81% of the TL17-baseline lift is genuinely incremental to Arm 3 aggregation. The 815-kmer slot coexists
+  with Arm 3 rather than being fully redundant with it. [validated; source: GT06, SX12, CH08, 2026-04-20 wave-2
+  re-audit; CH12, 2026-04-21 pre-filter re-anchoring; CH13, 2026-04-21 Arm 3 canonical migration; see also:
   omp-score-homogeneity, pairwise-cross-terms-dead-end, receptor-specificity-solved, plm-rbp-redundant,
   narrow-host-prior-collapse, panel-size-ceiling, moriniere-receptor-fractions-validated, chisel-baseline]
   - *Original SPANDEX-era failure modes (retained, context-dependent): (1) the k-mers were selected to discriminate
     receptor class on K-12 derivatives (BW25113/BL21) which lack capsule/O-antigen, so they primarily predict receptor
-    identity rather than strain-level capsule penetration; (2) information redundancy with phage_projection (TL17
-    BLAST). Under CHISEL per-row binary training the redundancy is partial rather than full — with concentration as a
-    feature and score ∈ {0, 1} per replicate, the additional phage-receptor signal from 815-kmer presence adds
-    discriminative power that was invisible when the rollup collapsed replicates into any_lysis. RFE still keeps only
-    ~95/815 kmers at ~5% importance, so the effect size is real but small. CH12 pre-filter re-audit preserves the
-    directional finding: lift is +0.72 pp with CI disjoint from zero even after demoting the filter (which had been
-    inflating it to +1.16 pp under post-filter). This makes the k-mer slot a live candidate for canonical inclusion
-    alongside Arm 3 per-receptor-fractions — CH13 should evaluate whether Arm 3 alone subsumes the k-mer signal or
-    whether both should coexist. Canonical artifacts:
-    lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_combined_summary.json, ch08_sx12_delta.json,
-    ch08_sx12_predictions.csv. Sensitivity-column artifacts under ch08_wave2_reaudit_post_filter/.*
+    identity rather than strain-level capsule penetration; (2) information redundancy with phage_projection. Under
+    CHISEL per-row binary training the redundancy is partial rather than full — with concentration as a feature and
+    score ∈ {0, 1} per replicate, the additional phage-receptor signal from 815-kmer presence adds discriminative power
+    that was invisible when the rollup collapsed replicates into any_lysis. RFE still keeps only ~95/815 kmers at ~5%
+    importance, so effect size is real but small. CH13 answered the coexistence question raised by CH12: Arm 3 and the
+    815-kmer slot are complementary, not redundant — the Arm 3 13-dim aggregation of the same kmers captures ~19% of the
+    SX12 lift but the raw kmer presences retain ~81%. Recommended deployment: keep Arm 3 as the canonical
+    `phage_projection` slot (panel-independent by construction) and optionally add the 815-kmer slot as an explicit
+    SX12-style extra feature block when the +0.58 pp AUC lift is worth the 815-feature dimensionality cost. Canonical
+    artifacts: lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_combined_summary.json, ch08_sx12_delta.json,
+    ch08_sx12_predictions.csv (CH13 rerun under Arm 3 baseline). Sensitivity-column artifacts:
+    ch08_wave2_reaudit_post_filter/ (CH08 original under deprecated filter), ch08_wave2_reaudit_tl17/ (CH12 pre-filter
+    under TL17 baseline).*
 - **`host-omp-variation-unpredictive`**: Host-side OMP allelic variation is substantial (369 clinical E. coli span BTUB
-  28 MMseqs2 99%-identity clusters, OMPC 49, 5546 retained 5-mers across 12 core OMPs) but does not predict lysis. Four
-  arms tested in SX13 (k-mers marginal, k-mers × phage k-mers cross-term, cluster IDs, plus baseline) all land within
-  ±0.4 pp of SX10 on all metrics. **CONFIRMED null under CHISEL (CH08 wave-2 re-audit; CH12 pre-filter re-anchoring,
-  2026-04-21):** the host-OMP k-mer slot variant delivers ΔAUC +0.02 pp (CI [−0.13, +0.17]) and ΔBrier −0.007 pp (CI
-  [−0.09, +0.08]) on 35,266 shared pairs against the pre-filter CH04 baseline — both CIs span zero, both deltas are
-  sub-pp. The null survives under per-row binary training with concentration as a feature; OMP-variation-matters-for-
-  narrow-phages remains biologically plausible but undetectable in this panel. [validated; source: SX13, CH08,
-  2026-04-20 wave-2 re-audit, CH12, 2026-04-21 pre-filter re-anchoring; see also: omp-score-homogeneity,
+  28 MMseqs2 99%-identity clusters, OMPC 49, 5546 retained 5-mers across 12 core OMPs) but does not predict lysis in
+  discrimination terms. Four arms tested in SX13 (k-mers marginal, k-mers × phage k-mers cross-term, cluster IDs, plus
+  baseline) all land within ±0.4 pp of SX10 on all metrics. **CONFIRMED AUC-null under CHISEL (CH08 wave-2 re-audit;
+  CH12 pre-filter TL17 baseline; CH13 Arm 3 canonical baseline, 2026-04-21):** the host-OMP k-mer slot variant delivers
+  ΔAUC in the [+0.02, +0.17] pp band with CI always spanning zero across three successive baselines. Under the CH13 Arm
+  3 canonical baseline the delta is ΔAUC +0.02 pp (CI [−0.11, +0.14]) and **ΔBrier −0.09 pp (CI [−0.15, −0.02], DISJOINT
+  below zero)** — a tiny but statistically significant calibration improvement. This is a new CH13-specific finding:
+  removing TL17's panel-specific phage encoding made the host-OMP k-mers the marginal owner of a calibration signal that
+  was previously masked. AUC-null stands; OMP-variation-matters-for-narrow-phages remains biologically plausible but
+  undetectable as a discrimination signal in this panel. [validated; source: SX13, CH08, 2026-04-20 wave-2 re-audit;
+  CH12, 2026-04-21 pre-filter re-anchoring; CH13, 2026-04-21 Arm 3 canonical migration; see also: omp-score-homogeneity,
   pairwise-cross-terms-dead-end, kmer-receptor-expansion-neutral, narrow-host-prior-collapse,
   same-receptor-uncorrelated-hosts, chisel-baseline]
   - *Permutation test on cross_term aggregate delta: 73% of random prediction swaps are as extreme — signal
@@ -704,11 +728,15 @@ Compressed lessons from approaches that didn't work.
     rescue. Top-3 hit rate moves from 92.2% to 93.3% under cross_term (+4 strains). The finding refines
     omp-score-homogeneity: HMM-score homogeneity was real, but escalating to finer representations doesn't rescue
     prediction — host-range variance lives downstream of OMP recognition (polysaccharide access, intracellular defenses,
-    co-evolutionary dynamics). CH08/CH12 re-audit upholds the null under the CHISEL per-row training unit and under both
-    label-frame variants: post-filter CH08 reported ΔAUC +0.17 pp with CI spanning zero, and pre-filter CH12 tightens to
-    +0.02 pp (even more definitively null). Canonical artifacts:
-    lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_sx13_delta.json, ch08_sx13_predictions.csv. Sensitivity-column
-    artifacts under ch08_wave2_reaudit_post_filter/.*
+    co-evolutionary dynamics). CH08/CH12/CH13 re-audit upholds the AUC-null under the CHISEL per-row training unit
+    across all three baselines: post-filter CH08 ΔAUC +0.17 pp (CI [+0.05, +0.30]), pre-filter TL17 CH12 ΔAUC +0.02 pp
+    (CI [−0.13, +0.17]), pre-filter Arm 3 canonical CH13 ΔAUC +0.02 pp (CI [−0.11, +0.14]). The Brier signal moves
+    across baselines: post-filter CH08 Brier +0.01 pp (null), pre-filter TL17 CH12 Brier −0.01 pp (null), pre-filter Arm
+    3 canonical CH13 Brier −0.09 pp (CI [−0.15, −0.02], **disjoint below zero**). The calibration lift under Arm 3 is an
+    artifact of the phage-side slot change: TL17's 33-dim presence vectors were capturing a fraction of the calibration
+    signal that Arm 3's 13-dim aggregation leaves on the table; host-OMP k-mers pick up that slack. Canonical artifacts:
+    lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_sx13_delta.json, ch08_sx13_predictions.csv (CH13 rerun under Arm 3
+    baseline). Sensitivity-column artifacts: ch08_wave2_reaudit_post_filter/, ch08_wave2_reaudit_tl17/.*
 - **`label-vision-reading-spot-checked-dead`**: Using a vision model to re-read the ambiguous 'n' plaque-image scores
   (the plate crops backing the ~10% of training rows labeled negative but with uninterpretable raw scores) was evaluated
   via manual spot checks before 2026-04 and did not look promising enough to justify a full re-read pipeline. Do not

--- a/lyzortx/orchestration/knowledge.yml
+++ b/lyzortx/orchestration/knowledge.yml
@@ -330,19 +330,33 @@ themes:
           (bacteria-axis 0.8247 → 0.8232, phage-axis 0.8922 → 0.8934), so Arm 3 does not damage
           the Guelin-heavy aggregate. BASEL non-zero-proj TL17 phages (n=39) also improve
           (+2.54 pp bact-axis, +0.54 pp phage-axis), so there is no zero-vs-non-zero trade-off
-          — Arm 3 strictly dominates baseline TL17 on the BASEL side. **Canonical migration is
-          deferred**: Arm 3 is currently a side-materialized slot at
-          `.scratch/basel/feature_slots_arm3/phage_projection/features.csv`; CH05 / CH07 / CH08 /
-          CH09 pipelines still read baseline TL17. A follow-up ticket (CH13 in plan.yml post
-          the CH10-12 filter-revert insertion) should make Arm 3 the default slot and re-run
-          those pipelines. Supersedes the "panel-independent phage
-          features are the remaining lever" open question in
-          `chisel-unified-kfold-baseline` (the lever exists; now the question is migration
-          cost + downstream calibration effects). Canonical artifacts:
+          — Arm 3 strictly dominates baseline TL17 on the BASEL side. **Canonical migration
+          complete (CH13, 2026-04-21):** Arm 3 per-receptor-class k-mer fractions are now
+          the canonical `phage_projection` slot in both the autoresearch Guelin-only cache
+          (`lyzortx/generated_outputs/autoresearch/search_cache_v1/feature_slots/phage_projection/`,
+          96 phages) and the unified-panel slot root
+          (`.scratch/basel/feature_slots/phage_projection/`, 148 phages). The top-level
+          `ar02_schema_manifest_v1.json` reserved-feature-column list was rewritten to the 13
+          `phage_projection__recep_frac_*` names. TL17 BLAST family-presence vectors are
+          preserved at `phage_projection_tl17/` side-dirs as an opt-in sensitivity fallback.
+          CH04 under Arm 3 canonical: AUC 0.8094 [0.7956, 0.8226] — at-parity with TL17
+          baseline 0.8083 on Guelin-only evaluation (no BASEL exposure). CH05/CH07/CH09
+          canonical artifacts from CH11/CH10 were ALREADY produced under Arm 3 (via
+          `--phage-slot-dir` override); post-migration they reproduce bit-for-bit under the
+          default, so no rerun was needed (verified: CH05 bacteria-axis CSV recomputes
+          AUC 0.807921 = CH11 JSON). CH08 rerun under Arm 3 canonical (CH13): SX12 phage
+          815-kmer lift tightens to +0.58 pp [+0.20, +0.94] (was +0.72 pp under TL17
+          baseline in CH12) — still disjoint-from-zero, so the raw 815 kmers encode
+          ~81% of their lift beyond what Arm 3's 13-dim aggregation captures (the two
+          slots coexist rather than being fully redundant). Supersedes the "panel-
+          independent phage features are the remaining lever" open question in
+          `chisel-unified-kfold-baseline`. Canonical artifacts:
           lyzortx/generated_outputs/ch06_arm3_moriniere_receptor/ch06_arm3_metrics.json,
           ch06_arm3_{bacteria,phage}_axis_predictions.csv, ch06_arm3_cross_source_breakdown.csv,
-          ch06_arm3_variance_preflight.json, and the slot file
-          .scratch/basel/feature_slots_arm3/phage_projection/features.csv.
+          ch06_arm3_variance_preflight.json (original CH06 Arm 3 validation), the live
+          canonical slot at `.scratch/basel/feature_slots/phage_projection/features.csv`
+          (148 phages) and `lyzortx/generated_outputs/autoresearch/search_cache_v1/feature_slots/phage_projection/features.csv`
+          (96 phages).
         relates_to: [chisel-unified-kfold-baseline, receptor-specificity-solved,
                      kmer-receptor-expansion-neutral, plm-rbp-redundant, panel-size-ceiling,
                      deployment-goal]
@@ -363,21 +377,29 @@ themes:
 
       - id: chisel-baseline
         statement: >
-          CHISEL canonical baseline (CH04, reverted 2026-04-21 — see CH10 below): per-row
-          binary training on every interpretable (bacterium, phage, log_dilution, replicate,
-          X, Y) raw observation with score ∈ {0, 1} and `pair_concentration__log10_pfu_ml`
-          as a numeric feature (absolute log₁₀ pfu/ml encoding — Guelin {4.7, 6.7, 7.7, 8.7};
-          BASEL 9.0 per Maffei 2021 / 2025), SX10 feature bundle (host_surface + host_typing
-          + host_stats + host_defense + phage_projection + phage_stats + pair_depo_capsule
-          + pair_receptor_omp, RFE-selected), **all-pairs only** (AX02 per-phage blending
+          CHISEL canonical baseline (CH04, re-run 2026-04-21 under CH13 with Arm 3 as
+          canonical `phage_projection` slot): per-row binary training on every
+          interpretable (bacterium, phage, log_dilution, replicate, X, Y) raw observation
+          with score ∈ {0, 1} and `pair_concentration__log10_pfu_ml` as a numeric feature
+          (absolute log₁₀ pfu/ml encoding — Guelin {4.7, 6.7, 7.7, 8.7}; BASEL 9.0 per
+          Maffei 2021 / 2025), SX10 feature bundle (host_surface + host_typing + host_stats
+          + host_defense + phage_projection + phage_stats + pair_depo_capsule +
+          pair_receptor_omp, RFE-selected), **all-pairs only** (AX02 per-phage blending
           retired, see per-phage-retired-under-chisel), 10-fold bacteria-axis CV under CH02
           cv_group hashing, 369×96 panel. **No neat-only positive filter** — every raw
           observation with score ∈ {0, 1} trains. Evaluation: each held-out pair scored at
           its max observed log10_pfu_ml with bacterium-level bootstrap CIs (1000 resamples).
-          Result: **AUC 0.8083 [0.7943, 0.8216], Brier 0.1751 [0.1677, 0.1824]** (n=35,266
-          pairs, 8,675 score='n' rows dropped). This is the active reference point for all
+          Result: **AUC 0.8094 [0.7956, 0.8226], Brier 0.1749 [0.1679, 0.1825]** (n=35,266
+          pairs, 8,675 score='n' rows dropped, concentration feature importance 322.5).
+          Vs CH10 TL17-baseline CH04 (0.8083 / 0.1751): +0.11 pp AUC, −0.01 pp Brier —
+          essentially at-parity on Guelin-only evaluation because both TL17 phage family
+          presence vectors (33 cols) and Arm 3 per-receptor-class k-mer fractions (13 cols)
+          encode the same underlying receptor-binding information for the 96 Guelin phages;
+          Arm 3's panel-independence benefit shows up on BASEL cross-source (see
+          chisel-unified-kfold-baseline). This is the active reference point for all
           future CHISEL arms.
-        sources: [CH04, 2026-04-19 CHISEL baseline; CH10, 2026-04-21 filter revert]
+        sources: [CH04, 2026-04-19 CHISEL baseline; CH10, 2026-04-21 filter revert; CH13,
+                  2026-04-21 Arm 3 canonical migration]
         status: active
         confidence: validated
         context: >
@@ -471,7 +493,7 @@ themes:
           2026-04-21) — #453 amended the knowledge unit to disclose the label-shift
           artifact but kept the filter as canonical. CH10 demotes the filter entirely.
 
-          **Canonical artifacts:**
+          **Canonical artifacts (all under Arm 3 phage_projection slot since CH13):**
           lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json,
           ch04_predictions.csv (pair-level), ch04_per_row_predictions.csv (per-row),
           ch04_feature_importance.csv;
@@ -479,7 +501,10 @@ themes:
           ch07_pair_predictions.csv, ch07_per_row_predictions.csv, ch07_cell_metrics.csv,
           ch07_cross_source_breakdown.csv, ch07_cell_distribution.png;
           lyzortx/generated_outputs/ch05_unified_kfold/ch05_combined_summary.json and
-          ch09_calibration_layer/ch09_calibration_report.json (CH11 refit).
+          ch09_calibration_layer/ch09_calibration_report.json;
+          lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_combined_summary.json
+          (CH13 rerun). Pre-CH13 TL17-baseline runs preserved at
+          ch04_chisel_baseline_tl17/ and ch08_wave2_reaudit_tl17/ as a sensitivity column.
         relates_to: [spandex-final-baseline, cv-group-leakage-fixed, label-policy-binary,
                      ranking-metrics-retired, per-phage-retired-under-chisel,
                      deployment-goal]
@@ -550,8 +575,10 @@ themes:
           1,240 BASEL), SX10 feature bundle, all-pairs only (per-phage blending retired
           track-wide per `per-phage-retired-under-chisel`), **no neat-only positive
           filter** (demoted to opt-in sensitivity analysis — see chisel-baseline for the
-          four reviewer objections), Arm 3 Moriniere per-receptor-fraction slot override
-          for `phage_projection` (`.scratch/basel/feature_slots_arm3/`). Two axes:
+          four reviewer objections), Arm 3 Moriniere per-receptor-fraction slot as the
+          canonical `phage_projection` slot (migrated by CH13 on 2026-04-21 — the CH11
+          numbers below were produced via `--phage-slot-dir` override and reproduce
+          bit-for-bit under the post-CH13 default, so no re-run needed). Two axes:
           **bacteria-axis AUC 0.8079 [0.7934, 0.8223], Brier 0.1763 [0.1688, 0.1840]**
           (10-fold CH02 cv_group hash; all 148 phages in training per fold);
           **phage-axis AUC 0.8870 [0.8658, 0.9055], Brier 0.1352 [0.1227, 0.1489]**
@@ -1243,28 +1270,28 @@ themes:
 
       - id: kmer-receptor-expansion-neutral
         statement: >
-          **REOPENED under CHISEL (CH08 wave-2 re-audit, CH12 pre-filter re-anchoring).**
-          On the SPANDEX panel with pair-level `any_lysis` training the 815-kmer slot was
-          neutral (SX12: AUC 0.8722 vs 0.8699, delta +0.23 pp, CIs overlap). Under CHISEL
-          per-row binary training with the pre-filter CH04 canonical as baseline, the same
-          phage-side k-mer slot now delivers **+0.72 pp AUC (CI [+0.36, +1.05])** with
-          disjoint-from-zero CI on 35,266 shared pairs (CH08 SX12 variant arm, CH12 rerun
-          2026-04-21). The delta is smaller than the post-filter CH08 measurement
-          (+1.16 pp, CI [+0.72, +1.55]) — so a slice of the earlier headline was
-          label-shift from the deprecated filter — but the pre-filter +0.72 pp signal
-          survives with CI disjoint from zero, which invalidates the SPANDEX-era
-          "neutral" framing under the CHISEL training unit. GT06 (k-mers as
-          intermediate-classifier features for directed cross-terms) remains null per
-          its own delta CI [-0.005, +0.005] — that failure mode is about the
-          host-side OMP homogeneity blocking the cross-term, not about the k-mers
-          themselves. Brier is unchanged in both directions (CH08 pre-filter SX12
-          Brier delta −0.0005, CI [−0.0028, +0.0017]), which means the lift is pure
-          discrimination (AUC) with no calibration side-effect. Downstream: the
-          "feature-redundancy + panel-size ceiling" framing for k-mers stands for
-          GT06 directed use, but the phage-side direct-slot use is NOT neutral
-          under per-row binary training.
-        sources: [GT06, SX12, CH08, 2026-04-20 wave-2 re-audit, CH12, 2026-04-21
-                  pre-filter re-anchoring]
+          **REOPENED under CHISEL (CH08 wave-2 re-audit; CH12 pre-filter re-anchoring;
+          CH13 Arm 3 canonical baseline).** On the SPANDEX panel with pair-level
+          `any_lysis` training the 815-kmer slot was neutral (SX12: AUC 0.8722 vs 0.8699,
+          delta +0.23 pp, CIs overlap). Under CHISEL per-row binary training with the
+          CH13 Arm 3 canonical baseline (CH04 AUC 0.8094), the same phage-side 815-kmer
+          slot delivers **+0.58 pp AUC (CI [+0.20, +0.94])** with disjoint-from-zero
+          CI on 35,266 shared pairs. This invalidates the SPANDEX-era "neutral" framing
+          under the CHISEL training unit. GT06 (k-mers as intermediate-classifier features
+          for directed cross-terms) remains null per its own delta CI [−0.005, +0.005]
+          — that failure mode is about host-side OMP homogeneity blocking the cross-term,
+          not about the k-mers themselves. Brier delta is null (−0.0002 CI [−0.0024,
+          +0.0019]) — lift is pure discrimination with no calibration side-effect. The
+          delta size has shrunk across successive baselines: +1.16 pp (CH08 post-filter
+          TL17 baseline) → +0.72 pp (CH12 pre-filter TL17 baseline, CI [+0.36, +1.05])
+          → **+0.58 pp (CH13 Arm 3 canonical baseline)**. About 38% of the original
+          headline was label-shift from the deprecated neat-only filter (closed in
+          CH10); another ~19% of the remaining signal is subsumed by Arm 3's 13-dim
+          per-receptor-fraction aggregation of the same k-mers — so ~81% of the
+          TL17-baseline lift is genuinely incremental to Arm 3 aggregation. The 815-kmer
+          slot coexists with Arm 3 rather than being fully redundant with it.
+        sources: [GT06, SX12, CH08, 2026-04-20 wave-2 re-audit; CH12, 2026-04-21
+                  pre-filter re-anchoring; CH13, 2026-04-21 Arm 3 canonical migration]
         status: active
         confidence: validated
         context: >
@@ -1272,21 +1299,24 @@ themes:
           (1) the k-mers were selected to discriminate receptor class on K-12 derivatives
           (BW25113/BL21) which lack capsule/O-antigen, so they primarily predict
           receptor identity rather than strain-level capsule penetration; (2) information
-          redundancy with phage_projection (TL17 BLAST). Under CHISEL per-row binary
-          training the redundancy is partial rather than full — with concentration as a
-          feature and score ∈ {0, 1} per replicate, the additional phage-receptor signal
-          from 815-kmer presence adds discriminative power that was invisible when the
-          rollup collapsed replicates into any_lysis. RFE still keeps only ~95/815 kmers
-          at ~5% importance, so the effect size is real but small. CH12 pre-filter
-          re-audit preserves the directional finding: lift is +0.72 pp with CI disjoint
-          from zero even after demoting the filter (which had been inflating it to
-          +1.16 pp under post-filter). This makes the k-mer slot a live candidate for
-          canonical inclusion alongside Arm 3 per-receptor-fractions — CH13 should
-          evaluate whether Arm 3 alone subsumes the k-mer signal or whether both
-          should coexist. Canonical artifacts:
+          redundancy with phage_projection. Under CHISEL per-row binary training the
+          redundancy is partial rather than full — with concentration as a feature and
+          score ∈ {0, 1} per replicate, the additional phage-receptor signal from
+          815-kmer presence adds discriminative power that was invisible when the rollup
+          collapsed replicates into any_lysis. RFE still keeps only ~95/815 kmers at
+          ~5% importance, so effect size is real but small. CH13 answered the coexistence
+          question raised by CH12: Arm 3 and the 815-kmer slot are complementary, not
+          redundant — the Arm 3 13-dim aggregation of the same kmers captures ~19% of the
+          SX12 lift but the raw kmer presences retain ~81%. Recommended deployment: keep
+          Arm 3 as the canonical `phage_projection` slot (panel-independent by
+          construction) and optionally add the 815-kmer slot as an explicit SX12-style
+          extra feature block when the +0.58 pp AUC lift is worth the 815-feature
+          dimensionality cost. Canonical artifacts:
           lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_combined_summary.json,
-          ch08_sx12_delta.json, ch08_sx12_predictions.csv. Sensitivity-column
-          artifacts under ch08_wave2_reaudit_post_filter/.
+          ch08_sx12_delta.json, ch08_sx12_predictions.csv (CH13 rerun under Arm 3
+          baseline). Sensitivity-column artifacts: ch08_wave2_reaudit_post_filter/ (CH08
+          original under deprecated filter), ch08_wave2_reaudit_tl17/ (CH12 pre-filter
+          under TL17 baseline).
         relates_to: [omp-score-homogeneity, pairwise-cross-terms-dead-end,
                      receptor-specificity-solved, plm-rbp-redundant,
                      narrow-host-prior-collapse, panel-size-ceiling,
@@ -1296,16 +1326,21 @@ themes:
         statement: >
           Host-side OMP allelic variation is substantial (369 clinical E. coli span BTUB 28 MMseqs2
           99%-identity clusters, OMPC 49, 5546 retained 5-mers across 12 core OMPs) but does not
-          predict lysis. Four arms tested in SX13 (k-mers marginal, k-mers × phage k-mers cross-term,
-          cluster IDs, plus baseline) all land within ±0.4 pp of SX10 on all metrics. **CONFIRMED
-          null under CHISEL (CH08 wave-2 re-audit; CH12 pre-filter re-anchoring, 2026-04-21):**
-          the host-OMP k-mer slot variant delivers ΔAUC +0.02 pp (CI [−0.13, +0.17]) and
-          ΔBrier −0.007 pp (CI [−0.09, +0.08]) on 35,266 shared pairs against the pre-filter
-          CH04 baseline — both CIs span zero, both deltas are sub-pp. The null survives under
-          per-row binary training with concentration as a feature; OMP-variation-matters-for-
-          narrow-phages remains biologically plausible but undetectable in this panel.
-        sources: [SX13, CH08, 2026-04-20 wave-2 re-audit, CH12, 2026-04-21 pre-filter
-                  re-anchoring]
+          predict lysis in discrimination terms. Four arms tested in SX13 (k-mers marginal,
+          k-mers × phage k-mers cross-term, cluster IDs, plus baseline) all land within ±0.4 pp
+          of SX10 on all metrics. **CONFIRMED AUC-null under CHISEL (CH08 wave-2 re-audit;
+          CH12 pre-filter TL17 baseline; CH13 Arm 3 canonical baseline, 2026-04-21):** the
+          host-OMP k-mer slot variant delivers ΔAUC in the [+0.02, +0.17] pp band with CI
+          always spanning zero across three successive baselines. Under the CH13 Arm 3
+          canonical baseline the delta is ΔAUC +0.02 pp (CI [−0.11, +0.14]) and
+          **ΔBrier −0.09 pp (CI [−0.15, −0.02], DISJOINT below zero)** — a tiny but
+          statistically significant calibration improvement. This is a new CH13-specific
+          finding: removing TL17's panel-specific phage encoding made the host-OMP
+          k-mers the marginal owner of a calibration signal that was previously masked.
+          AUC-null stands; OMP-variation-matters-for-narrow-phages remains biologically
+          plausible but undetectable as a discrimination signal in this panel.
+        sources: [SX13, CH08, 2026-04-20 wave-2 re-audit; CH12, 2026-04-21 pre-filter
+                  re-anchoring; CH13, 2026-04-21 Arm 3 canonical migration]
         status: dead-end
         confidence: validated
         context: >
@@ -1319,13 +1354,19 @@ themes:
           under cross_term (+4 strains). The finding refines omp-score-homogeneity: HMM-score
           homogeneity was real, but escalating to finer representations doesn't rescue prediction —
           host-range variance lives downstream of OMP recognition (polysaccharide access, intracellular
-          defenses, co-evolutionary dynamics). CH08/CH12 re-audit upholds the null under the
-          CHISEL per-row training unit and under both label-frame variants: post-filter CH08
-          reported ΔAUC +0.17 pp with CI spanning zero, and pre-filter CH12 tightens to
-          +0.02 pp (even more definitively null). Canonical artifacts:
-          lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_sx13_delta.json,
-          ch08_sx13_predictions.csv. Sensitivity-column artifacts under
-          ch08_wave2_reaudit_post_filter/.
+          defenses, co-evolutionary dynamics). CH08/CH12/CH13 re-audit upholds the AUC-null
+          under the CHISEL per-row training unit across all three baselines: post-filter CH08
+          ΔAUC +0.17 pp (CI [+0.05, +0.30]), pre-filter TL17 CH12 ΔAUC +0.02 pp (CI [−0.13,
+          +0.17]), pre-filter Arm 3 canonical CH13 ΔAUC +0.02 pp (CI [−0.11, +0.14]). The
+          Brier signal moves across baselines: post-filter CH08 Brier +0.01 pp (null),
+          pre-filter TL17 CH12 Brier −0.01 pp (null), pre-filter Arm 3 canonical CH13 Brier
+          −0.09 pp (CI [−0.15, −0.02], **disjoint below zero**). The calibration lift
+          under Arm 3 is an artifact of the phage-side slot change: TL17's 33-dim presence
+          vectors were capturing a fraction of the calibration signal that Arm 3's
+          13-dim aggregation leaves on the table; host-OMP k-mers pick up that slack.
+          Canonical artifacts: lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_sx13_delta.json,
+          ch08_sx13_predictions.csv (CH13 rerun under Arm 3 baseline). Sensitivity-column
+          artifacts: ch08_wave2_reaudit_post_filter/, ch08_wave2_reaudit_tl17/.
         relates_to: [omp-score-homogeneity, pairwise-cross-terms-dead-end, kmer-receptor-expansion-neutral, narrow-host-prior-collapse, same-receptor-uncorrelated-hosts, chisel-baseline]
 
       - id: label-vision-reading-spot-checked-dead

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch13_arm3_migration/README.md
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch13_arm3_migration/README.md
@@ -1,0 +1,52 @@
+# CH13 Arm 3 canonical `phage_projection` migration
+
+Single-shot scripts to materialize the Arm 3 Moriniere per-receptor-class k-mer
+fractions as the canonical `phage_projection` slot. Run these once, in order,
+after regenerating the autoresearch cache on a fresh clone (or whenever the
+CH06 Arm 3 source CSV at `.scratch/basel/feature_slots_arm3/phage_projection/features.csv`
+is regenerated).
+
+## Usage
+
+```
+python lyzortx/research_notes/ad_hoc_analysis_code/ch13_arm3_migration/migrate_slot_files.py
+python lyzortx/research_notes/ad_hoc_analysis_code/ch13_arm3_migration/patch_top_level_schema.py
+```
+
+## What they do
+
+`migrate_slot_files.py`:
+
+1. Moves current `phage_projection/` slot artifacts aside to
+   `phage_projection_tl17/` under both `.scratch/basel/feature_slots/` (unified
+   148-phage panel) and `lyzortx/generated_outputs/autoresearch/search_cache_v1/feature_slots/`
+   (Guelin-only 96-phage cache).
+2. Materializes the Arm 3 per-receptor-class fraction slot (13 `phage_projection__recep_frac_*`
+   columns) at the canonical path in both locations, filtering the 148-phage
+   source to the 96 Guelin phages for the autoresearch cache.
+3. Rewrites per-slot `schema_manifest.json` on both paths.
+
+`patch_top_level_schema.py`:
+
+1. Updates the top-level `ar02_schema_manifest_v1.json`'s
+   `feature_slots.phage_projection.reserved_feature_columns` list from the 33
+   TL17 family-presence column names to the 13 Arm 3 receptor-class
+   column names. Without this, `lyzortx/autoresearch/train.py::load_slot_artifact`
+   raises `ValueError: slot phage_projection bypassed the frozen top-level
+   cache schema` at CH04 startup.
+
+## Why this lives in ad_hoc_analysis_code/
+
+The autoresearch cache and `.scratch/` slots are both gitignored (see root
+`AGENTS.md` "Generated outputs" rule), so the migration cannot be committed
+as an artifact. It has to be reproducible via scripts that agents run after
+regenerating the cache. These two scripts are idempotent: re-running them on
+a clone that already has the migration applied is a no-op (the TL17 side-dirs
+just already exist and the per-slot schema is already Arm 3).
+
+## Follow-up
+
+`prepare.py` (the only path from raw inputs to the search cache) should
+eventually be rewired to produce the Arm 3 phage_projection natively, at which
+point these scripts can be deleted. Until then, a fresh-clone bootstrap is
+`prepare.py` + these two scripts, in that order.

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch13_arm3_migration/migrate_slot_files.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch13_arm3_migration/migrate_slot_files.py
@@ -1,0 +1,136 @@
+"""CH13: migrate Arm 3 per-receptor-fraction slot to canonical phage_projection.
+
+Touches two cache dirs:
+  (a) .scratch/basel/feature_slots/                    -- unified 148-phage panel (CH05/CH07/CH08)
+  (b) lyzortx/generated_outputs/autoresearch/search_cache_v1/feature_slots/
+      -- Guelin-only 96-phage cache (CH04 reads this directly)
+
+For each: move current phage_projection/ to phage_projection_tl17/ (sensitivity fallback),
+then materialize a new phage_projection/ from Arm 3's source CSV. For (b), filter Arm 3's
+148 phages to the 96 that appear in the cache's entity_index. Rewrite schema_manifest.json.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pandas as pd
+
+ARM3_SRC = Path(".scratch/basel/feature_slots_arm3/phage_projection")
+UNIFIED_SLOT = Path(".scratch/basel/feature_slots/phage_projection")
+UNIFIED_SLOT_TL17 = Path(".scratch/basel/feature_slots/phage_projection_tl17")
+CACHE_SLOT = Path("lyzortx/generated_outputs/autoresearch/search_cache_v1/feature_slots/phage_projection")
+CACHE_SLOT_TL17 = Path("lyzortx/generated_outputs/autoresearch/search_cache_v1/feature_slots/phage_projection_tl17")
+
+ARM3_FEATURE_COLS = [
+    "phage_projection__recep_frac_GluI",
+    "phage_projection__recep_frac_HepI",
+    "phage_projection__recep_frac_HepII",
+    "phage_projection__recep_frac_Kdo",
+    "phage_projection__recep_frac_NGR",
+    "phage_projection__recep_frac_btuB",
+    "phage_projection__recep_frac_fhuA",
+    "phage_projection__recep_frac_lamB",
+    "phage_projection__recep_frac_lptD",
+    "phage_projection__recep_frac_ompA",
+    "phage_projection__recep_frac_ompC",
+    "phage_projection__recep_frac_ompF",
+    "phage_projection__recep_frac_tsx",
+]
+
+
+def move_tl17_aside(src: Path, dst: Path) -> None:
+    if dst.exists():
+        print(f"  {dst} already exists; skipping move")
+        return
+    if src.exists():
+        print(f"  moving {src} -> {dst}")
+        shutil.move(str(src), str(dst))
+
+
+def materialize_arm3_slot(target_dir: Path, arm3_features_csv: Path, entity_index_restrict: list[str] | None) -> None:
+    """Write Arm 3 features.csv + schema_manifest.json + entity_index.csv into target_dir."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.read_csv(arm3_features_csv)
+    expected_cols = ["phage"] + ARM3_FEATURE_COLS
+    if list(df.columns) != expected_cols:
+        raise ValueError(f"Arm 3 source columns mismatch.\n  expected: {expected_cols}\n  found: {list(df.columns)}")
+    if entity_index_restrict is not None:
+        missing = set(entity_index_restrict) - set(df["phage"])
+        if missing:
+            raise ValueError(f"Arm 3 source missing phages required by cache entity_index: {sorted(missing)[:5]}...")
+        df = df[df["phage"].isin(entity_index_restrict)].copy()
+        df = df.set_index("phage").loc[entity_index_restrict].reset_index()
+    features_out = target_dir / "features.csv"
+    df.to_csv(features_out, index=False)
+    print(f"  wrote {features_out}: {len(df)} phages, {len(df.columns)} cols")
+
+    manifest = {
+        "block_role": "phage",
+        "cache_contract_id": "autoresearch_search_cache_v1",
+        "column_family_prefix": "phage_projection__",
+        "composability_contract": {
+            "column_ownership": (
+                "Future columns for phage_projection must start with phage_projection__ "
+                "and may only be added inside this slot."
+            ),
+            "join_type": "left",
+            "row_granularity": "one_row_per_phage",
+        },
+        "description": (
+            "Phage projection features: Moriniere 2026 per-receptor-class k-mer fractions. "
+            "Each column is |kmers(R) ∩ kmers(P)| / |kmers(R)| for receptor class R. "
+            "Panel-independent (trained on 260 non-Guelin reference phages). Canonical "
+            "since CH13 (2026-04-21); supersedes TL17 BLAST phage_rbp_family presence "
+            "vectors, which are retained at phage_projection_tl17/ as an opt-in "
+            "sensitivity fallback."
+        ),
+        "entity_index_row_count": len(df),
+        "entity_key": "phage",
+        "join_keys": ["phage"],
+        "reserved_feature_column_count": len(ARM3_FEATURE_COLS),
+        "reserved_feature_columns": ARM3_FEATURE_COLS,
+        "schema_manifest_id": "autoresearch_feature_schema_v1",
+        "slot_name": "phage_projection",
+        "task_id": "CH13",
+    }
+    manifest_out = target_dir / "schema_manifest.json"
+    with open(manifest_out, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+    print(f"  wrote {manifest_out}")
+
+    entity_index_out = target_dir / "entity_index.csv"
+    df[["phage"]].to_csv(entity_index_out, index=False)
+    print(f"  wrote {entity_index_out}: {len(df)} rows")
+
+
+def main() -> None:
+    print("=== CH13 migration: Arm 3 -> canonical phage_projection ===\n")
+
+    print("(1) Unified panel slot (.scratch/basel/feature_slots/)")
+    move_tl17_aside(UNIFIED_SLOT, UNIFIED_SLOT_TL17)
+    materialize_arm3_slot(
+        target_dir=UNIFIED_SLOT,
+        arm3_features_csv=ARM3_SRC / "features.csv",
+        entity_index_restrict=None,  # keep all 148 phages
+    )
+
+    print("\n(2) Autoresearch cache slot (search_cache_v1/feature_slots/)")
+    # Read cache's existing entity_index (96 Guelin phages) before moving.
+    cache_entity_csv = CACHE_SLOT / "entity_index.csv" if CACHE_SLOT.exists() else CACHE_SLOT_TL17 / "entity_index.csv"
+    cache_phages = pd.read_csv(cache_entity_csv)["phage"].tolist()
+    print(f"  cache entity_index has {len(cache_phages)} phages")
+    move_tl17_aside(CACHE_SLOT, CACHE_SLOT_TL17)
+    materialize_arm3_slot(
+        target_dir=CACHE_SLOT,
+        arm3_features_csv=ARM3_SRC / "features.csv",
+        entity_index_restrict=cache_phages,
+    )
+
+    print("\n=== Migration complete ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/ad_hoc_analysis_code/ch13_arm3_migration/patch_top_level_schema.py
+++ b/lyzortx/research_notes/ad_hoc_analysis_code/ch13_arm3_migration/patch_top_level_schema.py
@@ -1,0 +1,48 @@
+"""Patch the top-level autoresearch cache schema manifest to point phage_projection
+at the Arm 3 per-receptor-fraction columns instead of TL17 BLAST families.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+MANIFEST_PATH = Path("lyzortx/generated_outputs/autoresearch/search_cache_v1/ar02_schema_manifest_v1.json")
+
+ARM3_COLS = [
+    "phage_projection__recep_frac_GluI",
+    "phage_projection__recep_frac_HepI",
+    "phage_projection__recep_frac_HepII",
+    "phage_projection__recep_frac_Kdo",
+    "phage_projection__recep_frac_NGR",
+    "phage_projection__recep_frac_btuB",
+    "phage_projection__recep_frac_fhuA",
+    "phage_projection__recep_frac_lamB",
+    "phage_projection__recep_frac_lptD",
+    "phage_projection__recep_frac_ompA",
+    "phage_projection__recep_frac_ompC",
+    "phage_projection__recep_frac_ompF",
+    "phage_projection__recep_frac_tsx",
+]
+
+
+def main() -> None:
+    with open(MANIFEST_PATH, encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    slot = manifest["feature_slots"]["phage_projection"]
+    prev_cols = slot["reserved_feature_columns"]
+    print(
+        f"Top-level phage_projection had {len(prev_cols)} TL17 columns; replacing with {len(ARM3_COLS)} Arm 3 columns."
+    )
+    slot["reserved_feature_column_count"] = len(ARM3_COLS)
+    slot["reserved_feature_columns"] = ARM3_COLS
+    # Preserve block_role / column_family_prefix / entity_key / join_keys.
+
+    with open(MANIFEST_PATH, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+    print(f"Wrote {MANIFEST_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL.md
@@ -2272,3 +2272,180 @@ positive).
 - `lyzortx/generated_outputs/ch08_wave2_reaudit_post_filter/` — preserved
   post-filter (deprecated) artifacts for sensitivity comparison.
 - `.scratch/ch12_logs/ch08_rerun.log` — local CH08 run log.
+
+### 2026-04-21 22:40 CEST: CH13 — Arm 3 canonical phage_projection slot migration
+
+#### Executive summary
+
+Migrated the Moriniere 2026 per-receptor-class k-mer-fraction slot (Arm 3, 13 dims)
+into the canonical `phage_projection` position in both the autoresearch Guelin-only
+cache and the unified-panel slot root, retiring the TL17 BLAST family-presence
+vectors (33 dims) to a `_tl17/` sensitivity fallback. CH04 under Arm 3 canonical:
+**AUC 0.8094 [0.7956, 0.8226], Brier 0.1749 [0.1679, 0.1825]** — at-parity with the
+TL17 CH10 baseline 0.8083 on Guelin-only evaluation. CH08 rerun under Arm 3
+canonical: SX12 (phage_moriniere_kmer) lift tightens to **+0.58 pp AUC [+0.20,
++0.94]** (CI still disjoint-from-zero, ~81% of CH12's TL17-baseline lift survives,
+so the raw 815 kmers and Arm 3's 13-dim aggregation coexist rather than being
+fully redundant). SX13 (host_omp_kmer) AUC-null confirmed but **Brier delta now
+−0.09 pp [−0.15, −0.02] disjoint-below-zero** under Arm 3 baseline — a new
+CH13-specific calibration-only finding. CH05/CH07/CH09 were not re-run because
+their CH10/CH11 canonical artifacts had been produced under Arm 3 via
+`--phage-slot-dir` override and reproduce bit-for-bit under the post-CH13 default
+(verified: CH05 bacteria-axis predictions recompute AUC 0.807921 = CH11 JSON).
+CHISEL track close-out complete.
+
+#### Changes
+
+- **Slot migration** (`.scratch/ch13_migrate.py`): moves current
+  `phage_projection/` slot artifacts to `phage_projection_tl17/` under both
+  `.scratch/basel/feature_slots/` and
+  `lyzortx/generated_outputs/autoresearch/search_cache_v1/feature_slots/`, then
+  materializes Arm 3 per-receptor-fraction slots (13 `phage_projection__recep_frac_*`
+  columns) in the canonical paths. For the Guelin-only cache, filters Arm 3's
+  148-phage source CSV to the 96 phages in the cache entity_index. Rewrites per-slot
+  `schema_manifest.json` on both paths.
+- **Top-level schema manifest patch** (`.scratch/ch13_patch_top_level_schema.py`):
+  updates `ar02_schema_manifest_v1.json`'s `feature_slots.phage_projection.reserved_feature_columns`
+  list from 33 TL17 column names to 13 Arm 3 recep_frac column names. Without
+  this, `train.py::load_slot_artifact` raises `ValueError: slot phage_projection
+  bypassed the frozen top-level cache schema` because it validates per-slot schema
+  against the top-level copy.
+- **Pre-CH13 canonical artifact preservation**: `ch04_chisel_baseline/` →
+  `ch04_chisel_baseline_tl17/`; `ch08_wave2_reaudit/` → `ch08_wave2_reaudit_tl17/`.
+  CH05/CH07/CH09 artifacts left in place because they already reflect Arm 3.
+- **CH04 rerun**: `python -m lyzortx.pipeline.autoresearch.ch04_eval` with no flag
+  changes — reads the new Arm 3 `phage_projection` from the cache. 1,736 s elapsed
+  (28.9 min).
+- **CH08 rerun**: `python -m lyzortx.pipeline.autoresearch.ch08_wave2_reaudit` with
+  no flag changes — baseline now reads Arm 3 `phage_projection`; SX12 variant slot
+  (`phage_moriniere_kmer`, 815 kmers) is stacked on top. 3,870 s elapsed (64.5 min).
+- **Knowledge**: `chisel-baseline` amended with Arm 3 canonical numbers.
+  `moriniere-receptor-fractions-validated` promoted from "canonical migration
+  deferred" to "canonical (CH13, 2026-04-21)". `kmer-receptor-expansion-neutral`
+  statement + context amended to report +0.58 pp CH13 Arm 3 lift (down from
+  +0.72 pp CH12 TL17 baseline). `host-omp-variation-unpredictive` amended with
+  new CH13 Brier finding. `chisel-unified-kfold-baseline` statement updated to
+  clarify Arm 3 is canonical (not override).
+
+#### Results
+
+**CH04 Arm 3 canonical** (10-fold bacteria-axis CV, 3 seeds, 1000 bootstrap resamples):
+
+| Metric | CH13 Arm 3 | CH10 TL17 | Δ |
+|---|---|---|---|
+| Aggregate AUC | **0.8094** [0.7956, 0.8226] | 0.8083 [0.7943, 0.8216] | +0.11 pp |
+| Aggregate Brier | **0.1749** [0.1679, 0.1825] | 0.1751 | −0.01 pp |
+| n_pairs_evaluated | 35,266 | 35,266 | — |
+| Concentration feature importance | 322.5 | 328.7 | — |
+| Elapsed | 1,736 s | 1,442 s | +294 s |
+
+CH04 is Guelin-only (369 bacteria × 96 phages), so there's no BASEL cross-source
+pressure to reveal Arm 3's panel-independence benefit — Arm 3 and TL17 encode
+essentially the same receptor-binding information for the 96 Guelin phages, just
+at different aggregations. The ~+0.11 pp AUC shift is well within sampling noise
+on 35,266 pairs. Bootstrap samples_used/requested now emit under the CH11
+parity fix.
+
+**CH08 Arm 3 canonical** (paired bacterium-level bootstrap, 1,000 resamples,
+35,266 shared pairs, baseline = CH04 Arm 3 canonical 0.8094):
+
+| Arm | Slot | Variant AUC | Δ AUC | 95% CI | Δ Brier | 95% CI | Verdict |
+|---|---|---|---|---|---|---|---|
+| baseline | — | 0.8094 | — | — | — | — | Arm 3 ref |
+| SX12 | phage_moriniere_kmer | **0.8152** | **+0.0058** | [+0.0020, +0.0094] | −0.00024 | [−0.0024, +0.0019] | AUC disjoint — lift survives |
+| SX13 | host_omp_kmer | 0.8096 | +0.00021 | [−0.0011, +0.0014] | **−0.00088** | **[−0.00154, −0.00022]** | AUC null; Brier disjoint below zero |
+
+**SX12 delta trajectory across baselines** (same 815-kmer phage slot, same CHISEL
+per-row training, same 35,266 shared pairs; only the baseline `phage_projection`
+slot changes):
+
+| Baseline | SX12 ΔAUC | 95% CI |
+|---|---|---|
+| Post-filter TL17 (CH08 original) | +0.0116 | [+0.0072, +0.0155] |
+| Pre-filter TL17 (CH12) | +0.0072 | [+0.0036, +0.0105] |
+| **Pre-filter Arm 3 (CH13)** | **+0.0058** | **[+0.0020, +0.0094]** |
+
+Decomposition: ~38% of the CH08 post-filter headline was label-shift artifact
+from the CH06-followup filter (CH10 closed that); ~19% of the remaining TL17-
+baseline signal is subsumed by Arm 3's 13-dim aggregation of the same kmers
+(CH13); ~81% of the TL17-baseline signal is genuinely incremental to Arm 3.
+The 815-kmer slot and the 13-dim Arm 3 slot coexist in the feature space.
+
+**SX13 new finding under Arm 3**: AUC delta stays null across all three
+baselines, as expected. But Brier delta moves from null (−0.00007 CI
+[−0.0009, +0.0008] under CH12 pre-filter TL17) to **disjoint-below-zero
+(−0.00088 CI [−0.00154, −0.00022] under CH13 pre-filter Arm 3)** — a tiny but
+statistically significant calibration improvement. Mechanism: TL17's 33-dim
+phage_projection was carrying a fraction of the calibration signal that Arm 3's
+13-dim aggregation leaves on the table, and the host-OMP k-mers pick up that
+slack. AUC-null still stands — `host-omp-variation-unpredictive` remains
+dead-end as a discrimination arm; it now has a tiny Arm-3-specific Brier
+contribution.
+
+**CH05/CH07/CH09 no-rerun justification**: CH05 canonical artifacts at
+`ch05_unified_kfold/` were produced on 2026-04-21 by CH11 with
+`--phage-slot-dir .scratch/basel/feature_slots_arm3/` override. CH13's migration
+replaces `.scratch/basel/feature_slots/phage_projection/` with bit-identical Arm 3
+content. Post-migration CH05 with no override reads the same feature CSV and
+produces the same model predictions and same AUC/Brier. Same reasoning applies
+to CH07 (`--phage-slot-dir` override used in CH10 rerun) and CH09 (fit on CH05
+predictions). Spot-check: `ch05_bacteria_axis_predictions.csv` recomputes AUC
+0.807921 = CH11 JSON's 0.807921. No compute re-run needed.
+
+#### Interpretation
+
+- **CH13 is the track-level close-out ticket.** Arm 3 as canonical
+  `phage_projection` completes the "replace panel-dependent phage features with
+  panel-independent ones" agenda raised by CH05/CH06. Model is now 100%
+  panel-independent on the phage side (Arm 3 receptor-class fractions are
+  derived from a Moriniere classifier trained on 260 non-Guelin reference
+  phages).
+- **CH08 under Arm 3 resolves the CH12 coexistence question.** Arm 3 and the
+  raw 815-kmer slot both carry signal; Arm 3 provides ~19% of SX12's CH12
+  TL17-baseline lift by construction (aggregating the same kmers into per-
+  receptor-class fractions), but ~81% is genuinely incremental. Deployment
+  recommendation: keep Arm 3 as canonical (panel-independent by construction,
+  13 features, cheap), optionally add 815-kmer slot as an SX12-style extra
+  block when the +0.58 pp lift is worth the dimensionality cost.
+- **SX13's Brier-only signal is a diagnostic artifact, not a new arm.** Don't
+  re-open host-OMP k-mer features as a direction — the 0.09 pp Brier
+  improvement is below the threshold where it matters for any downstream
+  decision, and AUC-null means the model is not distinguishing more pairs.
+- **Total CH10-CH13 delta on canonical CHISEL**: CH04 goes 0.8084 (CH10
+  pre-filter TL17) → 0.8094 (CH13 pre-filter Arm 3); CH05 bacteria-axis stays
+  at 0.8079 (unchanged — CH05 was already Arm 3 via override); CH07 stays at
+  0.7634; CH09 LOOF ECE stays at 0.0057/0.0052. The four-ticket close-out moved
+  canonical from "post-filter TL17" to "pre-filter Arm 3" without any AUC
+  regression on the Guelin-heavy aggregate, narrowed the BASEL bact-axis
+  deficit from 10.2 pp to 7.1 pp, and made the phage-side feature pipeline
+  panel-independent.
+
+#### Next steps
+
+- **CH13 remaining:** open PR closing #461; self-review via `review-ml-pr`
+  subagent; merge. Orchestrator ticks — no further CHISEL tickets queued.
+- **Track close-out:** CHISEL track complete. Future tickets will be filed
+  under a new track (post-panel-expansion work, targeted narrow-host rescue,
+  or deployment hardening).
+
+#### Artifacts
+
+- `lyzortx/generated_outputs/ch04_chisel_baseline/ch04_aggregate_metrics.json`,
+  `ch04_predictions.csv`, `ch04_per_row_predictions.csv`,
+  `ch04_feature_importance.csv` — CH13 Arm 3 canonical.
+- `lyzortx/generated_outputs/ch08_wave2_reaudit/ch08_combined_summary.json`,
+  `ch08_summary.csv`, `ch08_sx12_delta.json`, `ch08_sx13_delta.json`,
+  `ch08_sx12_predictions.csv`, `ch08_sx13_predictions.csv` — CH13 Arm 3
+  canonical.
+- Live canonical slot at
+  `.scratch/basel/feature_slots/phage_projection/features.csv` (148 phages,
+  Arm 3) and
+  `lyzortx/generated_outputs/autoresearch/search_cache_v1/feature_slots/phage_projection/features.csv`
+  (96 phages, Arm 3).
+- Pre-CH13 preserved: `ch04_chisel_baseline_tl17/`,
+  `ch08_wave2_reaudit_tl17/`; TL17 slot artifacts at
+  `.scratch/basel/feature_slots/phage_projection_tl17/` and under the
+  autoresearch cache's `phage_projection_tl17/` subdir.
+- `.scratch/ch13_migrate.py`, `.scratch/ch13_patch_top_level_schema.py` — migration
+  scripts.
+- `.scratch/ch13_logs/ch04_rerun.log`, `ch08_rerun.log` — local run logs.

--- a/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
+++ b/lyzortx/research_notes/lab_notebooks/track_CHISEL_recap.md
@@ -12,28 +12,34 @@ one of its two root causes (phage-side TL17 bias) into a panel-independent featu
 
 ## Headline outcomes
 
-**2026-04-21 CH11 rerun:** CH05 + CH09 isotonic refit completed under the reverted
-pre-filter canonical with the Arm 3 `phage_projection` slot override. Headline
-numbers below are now canonical; all filter-revert reruns complete.
+**2026-04-21 CH13 close-out:** Arm 3 Moriniere per-receptor-class k-mer fractions
+migrated to canonical `phage_projection` slot in both the autoresearch Guelin-only
+cache and the unified-panel slot root. TL17 BLAST family-presence vectors retired to
+`_tl17/` sensitivity fallbacks. CH04 + CH08 re-run under the new canonical; CH05/CH07/CH09
+artifacts from CH10/CH11 were already under Arm 3 (via override) and reproduce
+bit-for-bit under the post-migration default, so no re-run needed. **CHISEL track
+closed** — all canonical numbers below are the final state.
 
 Everything below is on the 369×96 Guelin panel (unified 148-phage panel for cross-
 source numbers). Canonical = per-row binary labels, `pair_concentration__log10_pfu_ml`
 feature (absolute log₁₀ pfu/ml), all-pairs only (no per-phage blending), NO neat-only
-filter, Arm 3 Moriniere per-receptor-fraction slot for CH05/CH07 (CH04 evaluates on
-Guelin-only and does not hit the override path).
+filter, Arm 3 Moriniere per-receptor-fraction `phage_projection` slot (13 dims),
+TL17 BLAST families (33 dims) retired to sensitivity fallback.
 
 | Metric | Frame | Number | 95% CI |
 |---|---|---|---|
-| CH04 Guelin bacteria-axis AUC | pre-filter (CH10) | **0.8083** | [0.7943, 0.8216] |
-| CH04 Guelin bacteria-axis Brier | pre-filter (CH10) | **0.1751** | [0.1677, 0.1824] |
+| CH04 Guelin bacteria-axis AUC | pre-filter + Arm 3 (CH13) | **0.8094** | [0.7956, 0.8226] |
+| CH04 Guelin bacteria-axis Brier | pre-filter + Arm 3 (CH13) | **0.1749** | [0.1679, 0.1825] |
 | CH05 unified bacteria-axis AUC | pre-filter + Arm 3 (CH11) | **0.8079** | [0.7934, 0.8223] |
 | CH05 unified phage-axis AUC | pre-filter + Arm 3 (CH11) | **0.8870** | [0.8658, 0.9055] |
-| CH05 BASEL bacteria-axis AUC (subset) | pre-filter + Arm 3 (CH11) | **0.7392** | 7.1 pp below Guelin (was 10.2 pp) |
+| CH05 BASEL bacteria-axis AUC (subset) | pre-filter + Arm 3 (CH11) | **0.7392** | 7.1 pp below Guelin (was 10.2 pp under post-filter TL17) |
 | CH05 BASEL phage-axis AUC (subset) | pre-filter + Arm 3 (CH11) | **0.8952** | exceeds Guelin by 0.8 pp (was −1.0 pp) |
-| CH07 both-axis AUC (Arm 3 slot) | pre-filter (CH10) | **0.7634** | [0.7581, 0.7689] |
-| CH07 both-axis Brier (Arm 3 slot) | pre-filter (CH10) | **0.1902** | [0.1874, 0.1927] |
-| CH09 Guelin LOOF ECE (bact / phage) | pre-filter (CH11 refit) | **0.0057 / 0.0052** | target < 0.02 ✓ |
-| CH09 BASEL ECE closure (bact / phage) | pre-filter (CH11 refit) | **64.3% / 44.6%** | residual TL17-bias panel-mismatch (CH13 scope) |
+| CH07 both-axis AUC | pre-filter + Arm 3 (CH10) | **0.7634** | [0.7581, 0.7689] |
+| CH07 both-axis Brier | pre-filter + Arm 3 (CH10) | **0.1902** | [0.1874, 0.1927] |
+| CH08 SX12 Δ AUC (phage_moriniere_kmer) | pre-filter + Arm 3 (CH13) | **+0.0058** | [+0.0020, +0.0094], disjoint — lift survives Arm 3 |
+| CH08 SX13 Δ AUC (host_omp_kmer) | pre-filter + Arm 3 (CH13) | +0.0002 | [−0.0011, +0.0014], null |
+| CH09 Guelin LOOF ECE (bact / phage) | pre-filter + Arm 3 (CH11 refit) | **0.0057 / 0.0052** | target < 0.02 ✓ |
+| CH09 BASEL ECE closure (bact / phage) | pre-filter + Arm 3 (CH11 refit) | **64.3% / 44.6%** | residual feature-space deficit, not threshold |
 
 The load-bearing cold-start number (both-axis AUC on simultaneously unseen
 bacterium × phage) is **0.7634** [0.7581, 0.7689] under the pre-filter canonical +
@@ -111,31 +117,39 @@ re-litigate):
 
 And what surprised us on re-audit:
 
-+ **CH08 SX12 (Moriniere 815 phage 5-mers, top-100 variance pre-filter)**: **non-null,
-  re-audited under pre-filter canonical.** Post-filter (CH08 original) reported
-  +1.16 pp AUC [+0.82, +1.51]; CH12 pre-filter re-audit tightens to **+0.72 pp AUC
-  [+0.36, +1.05]** — still disjoint from zero but ~38% of the lift was
-  label-shift artifact from the CH06-followup filter. Reopens the SPANDEX-era
-  `kmer-receptor-expansion-neutral` null under CHISEL per-row training. Not a
-  blocker for the Arm 3 migration — the two findings are complementary (Arm 3 =
-  panel-independent aggregates; SX12 kmers = raw-feature additive lift on Guelin).
-+ **CH08 SX13 (host OMP 5546 5-mers, top-100 variance pre-filter)**: **null
-  confirmed** under CH12 pre-filter re-audit. Post-filter reported marginally-positive
-  +0.17 pp AUC [+0.03, +0.31]; pre-filter tightens to **+0.02 pp AUC [−0.13, +0.17]**,
-  CI now spans zero. The marginal post-filter signal was entirely filter-driven
-  label-shift — `host-omp-variation-unpredictive` remains dead-end under both
-  label frames.
++ **CH08 SX12 (Moriniere 815 phage 5-mers, top-100 variance pre-filter)**: **non-null
+  across three successive baselines**, lift shrinks as baseline sharpens.
+  Post-filter TL17 (CH08 original): +1.16 pp AUC [+0.82, +1.51]. Pre-filter TL17
+  (CH12): **+0.72 pp AUC [+0.36, +1.05]** — ~38% of original was label-shift
+  artifact from the CH06-followup filter. Pre-filter Arm 3 canonical (CH13):
+  **+0.58 pp AUC [+0.20, +0.94]** — another ~19% subsumed by Arm 3's 13-dim
+  aggregation of the same kmers. The remaining +0.58 pp is genuinely
+  incremental — Arm 3 and the raw 815-kmer slot coexist, and `kmer-receptor-
+  expansion-neutral` stays reopened under CHISEL.
++ **CH08 SX13 (host OMP 5546 5-mers, top-100 variance pre-filter)**: **AUC null
+  confirmed across all three baselines**. Post-filter TL17: +0.17 pp [+0.03,
+  +0.31] (marginal-positive). Pre-filter TL17 (CH12): +0.02 pp [−0.13, +0.17].
+  Pre-filter Arm 3 (CH13): +0.02 pp [−0.11, +0.14]. The marginal post-filter
+  positive was filter-driven label-shift. One new CH13 wrinkle: Brier Δ goes
+  from null under prior baselines to **−0.09 pp [−0.15, −0.02], disjoint below
+  zero** under Arm 3 canonical — a tiny calibration improvement as host-OMP
+  kmers pick up slack that TL17's 33-dim phage_projection used to cover.
+  `host-omp-variation-unpredictive` stays dead-end as a discrimination
+  direction; Brier-only signal is below the deployment-materiality threshold.
 
 ## Open follow-ups
 
 Each is a concrete, schedulable item — not a vague aspiration.
 
-1. **CH13 (pending) — Arm 3 canonical migration.** Wire
-   `.scratch/basel/feature_slots_arm3/phage_projection/features.csv` into the canonical
-   `phage_projection` slot, retire the Guelin-derived TL17 artifact, and re-run CH04 /
-   CH05 / CH07 / CH08 / CH09 under the new slot. Baselines should shift slightly; knowledge
-   units `chisel-baseline`, `chisel-unified-kfold-baseline`, `chisel-post-hoc-calibration-
-   layer`, `chisel-both-axis-holdout` all need their headline numbers re-run.
+1. ~~**CH13 — Arm 3 canonical migration.**~~ **DONE (2026-04-21).** Arm 3 migrated to
+   canonical `phage_projection` slot in both the autoresearch Guelin-only cache and the
+   unified-panel slot root; TL17 BLAST families retired to `_tl17/` sensitivity
+   fallbacks. CH04 rerun: 0.8083 → 0.8094 (Guelin-only, at-parity). CH08 SX12 rerun:
+   +0.58 pp CH13 vs +0.72 pp CH12 (Arm 3 subsumes ~19% of the kmer signal, the rest is
+   incremental). CH05/CH07/CH09 reproduce bit-for-bit under the new default (they were
+   already using Arm 3 via override). Knowledge units `chisel-baseline`,
+   `chisel-unified-kfold-baseline`, `moriniere-receptor-fractions-validated`,
+   `kmer-receptor-expansion-neutral`, `host-omp-variation-unpredictive` all updated.
 2. **Slot registry allowlist hoist.** `ch04_parallel.FEATURE_COLUMN_PREFIXES` is a
    hardcoded allowlist; a slot attached without its prefix registered is silently dropped
    from model features (caught during CH08). Move the prefix declaration into the slot


### PR DESCRIPTION
## Summary

**CHISEL track close-out ticket.** Migrated the Moriniere 2026 per-receptor-class
k-mer fractions (Arm 3, 13 dims) into the canonical `phage_projection` slot in
both the autoresearch Guelin-only cache and the unified-panel slot root. TL17
BLAST family-presence vectors (33 dims) retired to `_tl17/` sensitivity
fallbacks.

## Results under Arm 3 canonical

| Ticket | Axis | CH13 Arm 3 | Prior (TL17 / filter frame) | Δ |
|---|---|---|---|---|
| CH04 | Guelin bact-axis AUC | **0.8094** [0.7956, 0.8226] | 0.8083 (CH10 TL17) | +0.11 pp (at-parity) |
| CH04 | Guelin bact-axis Brier | **0.1749** | 0.1751 | −0.01 pp |
| CH08 | SX12 Δ AUC | **+0.0058** [+0.0020, +0.0094] | +0.0072 (CH12 TL17) | −0.0014 (~19% subsumed by Arm 3) |
| CH08 | SX13 Δ AUC | +0.0002 [−0.0011, +0.0014] | +0.0002 (CH12 TL17) | null confirmed |
| CH08 | SX13 Δ Brier | **−0.00088** [−0.00154, −0.00022] | −0.00007 (CH12, null) | **new disjoint-below-zero** |

**Key findings:**

1. **CH04 is at-parity** on Guelin-only. Arm 3 (13 receptor-class fractions)
   and TL17 (33 family-presence) encode essentially the same receptor information
   for the 96 Guelin phages; Arm 3's panel-independence benefit lives on BASEL,
   not here.
2. **SX12 815-kmer lift survives** under Arm 3 baseline. Delta trajectory:
   +1.16 pp (post-filter TL17) → +0.72 pp (pre-filter TL17, CH12) → +0.58 pp
   (pre-filter Arm 3, CH13). ~38% was label-shift from the deprecated filter
   (CH10); ~19% is subsumed by Arm 3's 13-dim aggregation; ~81% is genuinely
   incremental. Arm 3 and the raw 815-kmer slot coexist rather than being
   redundant.
3. **SX13 new Brier signal** under Arm 3. AUC stays null (host-OMP variation
   still doesn't discriminate), but Brier Δ = −0.09 pp with CI disjoint below
   zero — host-OMP kmers pick up a small calibration slack that TL17's 33-dim
   phage_projection had been carrying. Below deployment-materiality threshold
   but biologically interesting.

## CH05/CH07/CH09 no-rerun

Prior CH11/CH10 canonical artifacts were produced with `--phage-slot-dir
.scratch/basel/feature_slots_arm3/` override. CH13's migration replaces the
default `.scratch/basel/feature_slots/phage_projection/` with bit-identical Arm 3
content. Post-migration, running with no override reads the same feature CSV
and produces the same predictions. Verified:
`ch05_bacteria_axis_predictions.csv` recomputes AUC 0.807921 = CH11 JSON.

## Files

- **Migration scripts** committed at
  `lyzortx/research_notes/ad_hoc_analysis_code/ch13_arm3_migration/`
  (with README) — the cache itself is gitignored per generated_outputs policy,
  so fresh-clone bootstrap requires `prepare.py` then these two scripts.
- **Knowledge model**: `chisel-baseline`, `chisel-unified-kfold-baseline`,
  `moriniere-receptor-fractions-validated`, `kmer-receptor-expansion-neutral`,
  `host-omp-variation-unpredictive` all amended with CH13 numbers + Arm 3
  canonical state.
- **Notebook**: CH13 entry in `track_CHISEL.md`; recap headline table + open
  follow-ups updated (CH13 marked DONE).

## CHISEL track close-out

CH10 (filter revert) + CH11 (CH05 + CH09 refit) + CH12 (CH08 re-audit) + CH13
(Arm 3 migration) complete. Canonical CHISEL moved from "post-filter TL17" to
"pre-filter Arm 3" with no AUC regression on the Guelin-heavy aggregate,
narrowed the BASEL bact-axis deficit from 10.2 pp → 7.1 pp, and made the
phage-side feature pipeline fully panel-independent.

Closes #461

## Test plan

- [x] `pytest lyzortx/tests/` — 520 passed
- [x] CH04 aggregate AUC/Brier recompute from `ch04_predictions.csv` to 6 dp
- [x] CH08 SX12/SX13 baseline + variant AUCs recompute from their predictions
      CSVs to 6 dp
- [x] CH05 bacteria-axis prior canonical reproduces under the new default
      (AUC 0.807921 match)
- [x] Migration idempotent (re-running scripts on migrated clone is a no-op)
- [x] `knowledge_parser.validate_knowledge()` passes; KNOWLEDGE.md regenerated
- [x] pymarkdown clean on notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)