### PR TITLE
[ORCH][EX01] Emit per-axis feature importance from CH05

### DIFF
--- a/lyzortx/pipeline/autoresearch/ch05_eval.py
+++ b/lyzortx/pipeline/autoresearch/ch05_eval.py
@@ -370,6 +370,26 @@ def _ci_to_dict(ci: BootstrapMetricCI) -> dict[str, Optional[float]]:
     }
 
 
+def _aggregate_feature_importance(fi_frames: list[pd.DataFrame]) -> pd.DataFrame:
+    """Aggregate per-seed, per-fold LightGBM importance frames into a single CSV-ready frame.
+
+    Mirrors CH04's shape exactly: one row per (feature, is_concentration_feature) with
+    `mean_importance` (across all seeds × folds it appeared in) and `n_folds_selected`
+    (count of fits that retained the feature after RFE). Sorted descending by mean.
+    """
+    if not fi_frames:
+        raise ValueError(
+            "Feature importance frames list is empty; CH05 must collect at least one fit's importance to aggregate."
+        )
+    concat = pd.concat(fi_frames, ignore_index=True)
+    return (
+        concat.groupby(["feature", "is_concentration_feature"], as_index=False)
+        .agg(mean_importance=("importance", "mean"), n_folds_selected=("importance", "count"))
+        .sort_values("mean_importance", ascending=False)
+        .reset_index(drop=True)
+    )
+
+
 def run_bacteria_axis(
     *,
     candidate_module: ModuleType,
@@ -386,6 +406,7 @@ def run_bacteria_axis(
     mapping = bacteria_to_cv_group_map(clean_rows)
     fold_assignments = assign_bacteria_folds(mapping)
     all_rows: list[dict[str, object]] = []
+    all_feature_importance: list[pd.DataFrame] = []
     folds_to_run = N_FOLDS if max_folds is None else min(max_folds, N_FOLDS)
     for fold_id in range(folds_to_run):
         holdout_bac = {b for b, f in fold_assignments.items() if f == fold_id}
@@ -423,10 +444,14 @@ def run_bacteria_axis(
             num_workers=num_workers,
         )
         fold_seed_rows: list[dict[str, object]] = []
-        for _seed, rows, _fi in seed_results:
+        for seed, rows, fi in seed_results:
             for r in rows:
                 r["fold_id"] = fold_id
             fold_seed_rows.extend(rows)
+            fi = fi.copy()
+            fi["fold_id"] = fold_id
+            fi["seed"] = seed
+            all_feature_importance.append(fi)
         aggregated = _aggregate_fold_rows_to_pairs(fold_seed_rows)
         pair_pred = select_pair_max_concentration_rows(aggregated)
         fold_point = compute_aggregate_auc_brier(pair_pred.to_dict(orient="records"))
@@ -440,6 +465,13 @@ def run_bacteria_axis(
         all_rows.extend(aggregated.to_dict(orient="records"))
     per_row_df = pd.DataFrame(all_rows)
     per_row_df.to_csv(output_dir / "ch05_bacteria_axis_per_row_predictions.csv", index=False)
+    fi_agg = _aggregate_feature_importance(all_feature_importance)
+    fi_agg.to_csv(output_dir / "ch05_bacteria_axis_feature_importance.csv", index=False)
+    LOGGER.info(
+        "Bacteria-axis feature importance: %d features, top-3: %s",
+        len(fi_agg),
+        ", ".join(f"{row.feature}={row.mean_importance:.1f}" for row in fi_agg.head(3).itertuples()),
+    )
     return per_row_df
 
 
@@ -460,6 +492,7 @@ def run_phage_axis(
     phages = sorted(clean_rows["phage"].unique())
     fold_assignments = assign_phage_folds(phages, phage_family)
     all_rows: list[dict[str, object]] = []
+    all_feature_importance: list[pd.DataFrame] = []
     folds_to_run = N_FOLDS if max_folds is None else min(max_folds, N_FOLDS)
     for fold_id in range(folds_to_run):
         holdout_phages = {p for p, f in fold_assignments.items() if f == fold_id}
@@ -497,10 +530,14 @@ def run_phage_axis(
             num_workers=num_workers,
         )
         fold_seed_rows: list[dict[str, object]] = []
-        for _seed, rows, _fi in seed_results:
+        for seed, rows, fi in seed_results:
             for r in rows:
                 r["fold_id"] = fold_id
             fold_seed_rows.extend(rows)
+            fi = fi.copy()
+            fi["fold_id"] = fold_id
+            fi["seed"] = seed
+            all_feature_importance.append(fi)
         aggregated = _aggregate_fold_rows_to_pairs(fold_seed_rows)
         pair_pred = select_pair_max_concentration_rows(aggregated)
         fold_point = compute_aggregate_auc_brier(pair_pred.to_dict(orient="records"))
@@ -514,6 +551,13 @@ def run_phage_axis(
         all_rows.extend(aggregated.to_dict(orient="records"))
     per_row_df = pd.DataFrame(all_rows)
     per_row_df.to_csv(output_dir / "ch05_phage_axis_per_row_predictions.csv", index=False)
+    fi_agg = _aggregate_feature_importance(all_feature_importance)
+    fi_agg.to_csv(output_dir / "ch05_phage_axis_feature_importance.csv", index=False)
+    LOGGER.info(
+        "Phage-axis feature importance: %d features, top-3: %s",
+        len(fi_agg),
+        ", ".join(f"{row.feature}={row.mean_importance:.1f}" for row in fi_agg.head(3).itertuples()),
+    )
     return per_row_df
 
 

--- a/lyzortx/research_notes/lab_notebooks/track_EXPLAINABILITY.md
+++ b/lyzortx/research_notes/lab_notebooks/track_EXPLAINABILITY.md
@@ -1,0 +1,65 @@
+# Track EXPLAINABILITY
+
+## 2026-04-22 07:47 CEST: EX01 — per-axis feature importance emission
+
+### Executive summary
+
+Patched `ch05_eval.py` so both `run_bacteria_axis` and `run_phage_axis` persist
+`ch05_{bacteria,phage}_axis_feature_importance.csv` with the same schema as
+`ch04_feature_importance.csv` (`feature, is_concentration_feature, mean_importance,
+n_folds_selected`, sorted descending). Extracted the aggregation as
+`_aggregate_feature_importance` and added unit tests covering the schema contract,
+descending order, and the empty-input failure path. Full CH05 rerun (bacteria-axis +
+phage-axis) re-emitted all existing artifacts plus the two new CSVs. No model or
+evaluation logic changed; this is a pure artifact-emission patch.
+
+#### Why
+
+The explainability UI (EX02) needs per-axis feature importance to render the top-30 bar
+chart and per-slot breakdown tabs. CH05 was already training 30 boosters per axis
+(10 folds × 3 seeds) and calling the same `fit_seeds` machinery CH04 uses, but it was
+discarding each seed's `feature_importance_` frame (`_fi` underscore-prefix on the
+seed_results unpacking). Persisting it was a 5-line change inside each axis function
+plus a shared aggregation helper.
+
+#### Design choices
+
+- **Shared `_aggregate_feature_importance` helper, not axis-specific code**: both axes
+  produce the same per-seed frames from `fit_seeds`; one helper keeps the CSV shape
+  identical between axes and identical to CH04. The helper raises `ValueError` on empty
+  input (CH04 does not; CH05 should — an empty aggregate means zero fits ran, which is
+  a pipeline bug, not a recoverable state).
+- **No change to `fit_seeds` or `_fit_one_seed`**: the `feature_importance` frame is
+  already populated with `is_concentration_feature` in `ch04_parallel.py:230`, so CH05
+  just needs to stop discarding it.
+- **Drop the CH04 pattern of attaching `fold_id`/`seed` to the per-fit frame**: CH04
+  does `fi["fold_id"] = fold_id; fi["seed"] = seed` before appending, but its aggregate
+  groups only on `(feature, is_concentration_feature)` so the extra columns are
+  never used. Mirroring CH04 exactly preserves the option to emit long-form frames in a
+  future ticket, so I kept the fold/seed tagging even though it's unused at aggregate
+  time.
+
+#### Verification
+
+- Unit tests: `pytest lyzortx/tests/test_ch05_unified_kfold.py` → 10 passed
+  (2 new covering the aggregator).
+- Ruff: `ruff check lyzortx/pipeline/autoresearch/ch05_eval.py
+  lyzortx/tests/test_ch05_unified_kfold.py` → clean.
+- CH05 rerun: `python -m lyzortx.pipeline.autoresearch.ch05_eval --device-type cpu`.
+  Elapsed + headline numbers + CSV row counts recorded in the PR description once the
+  run completes.
+
+#### Artifacts
+
+- `lyzortx/pipeline/autoresearch/ch05_eval.py` — aggregation helper + axis functions
+  now emit the per-axis feature-importance CSV.
+- `lyzortx/tests/test_ch05_unified_kfold.py` — two new tests on the aggregator.
+- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_bacteria_axis_feature_importance.csv`
+  — new canonical artifact (gitignored, regenerated per run).
+- `lyzortx/generated_outputs/ch05_unified_kfold/ch05_phage_axis_feature_importance.csv`
+  — new canonical artifact (gitignored, regenerated per run).
+
+#### Next
+
+EX02: wire the two CSVs into the UI snapshot extractor and render them in a top-30
+feature-importance bar chart + per-slot breakdown small-multiples.

--- a/lyzortx/tests/test_ch05_unified_kfold.py
+++ b/lyzortx/tests/test_ch05_unified_kfold.py
@@ -14,6 +14,7 @@ from lyzortx.pipeline.autoresearch.ch05_eval import (
     BASEL_LOG_DILUTION_SENTINEL,
     BASEL_REPLICATE_ID,
     SOURCE_BASEL,
+    _aggregate_feature_importance,
     _bootstrap_by_unit,
     assign_phage_folds,
     load_basel_as_row_frame,
@@ -175,6 +176,61 @@ def test_bootstrap_by_unit_skips_degenerate_single_class_resamples() -> None:
     assert isinstance(cis["holdout_roc_auc"], BootstrapMetricCI)
     # Some resamples should have been skipped.
     assert cis["holdout_roc_auc"].bootstrap_samples_used < 200
+
+
+def test_aggregate_feature_importance_matches_ch04_schema_and_orders_desc() -> None:
+    """Two seeds × two folds → aggregated frame must match CH04's schema exactly.
+
+    Downstream (the explainability UI snapshot extractor) reads this CSV with the
+    same parser used for ch04_feature_importance.csv, so the (feature,
+    is_concentration_feature, mean_importance, n_folds_selected) schema and
+    descending-importance ordering are a hard contract.
+    """
+    fi_a_seed0 = pd.DataFrame(
+        {
+            "feature": ["host_typing__serotype", "phage_stats__gc", "pair_concentration__log10_pfu_ml"],
+            "importance": [2500.0, 600.0, 300.0],
+            "is_concentration_feature": [False, False, True],
+        }
+    )
+    fi_a_seed1 = pd.DataFrame(
+        {
+            "feature": ["host_typing__serotype", "phage_stats__gc", "pair_concentration__log10_pfu_ml"],
+            "importance": [2450.0, 580.0, 320.0],
+            "is_concentration_feature": [False, False, True],
+        }
+    )
+    # Second fold's RFE dropped phage_stats__gc entirely (simulates per-fold RFE variance).
+    fi_b_seed0 = pd.DataFrame(
+        {
+            "feature": ["host_typing__serotype", "pair_concentration__log10_pfu_ml"],
+            "importance": [2600.0, 310.0],
+            "is_concentration_feature": [False, True],
+        }
+    )
+
+    agg = _aggregate_feature_importance([fi_a_seed0, fi_a_seed1, fi_b_seed0])
+
+    assert list(agg.columns) == ["feature", "is_concentration_feature", "mean_importance", "n_folds_selected"]
+    assert agg["mean_importance"].is_monotonic_decreasing
+    # host_typing__serotype appears in all three fits; phage_stats__gc only in two.
+    serotype = agg[agg["feature"] == "host_typing__serotype"].iloc[0]
+    assert serotype["n_folds_selected"] == 3
+    assert serotype["mean_importance"] == pytest.approx((2500 + 2450 + 2600) / 3)
+    gc = agg[agg["feature"] == "phage_stats__gc"].iloc[0]
+    assert gc["n_folds_selected"] == 2
+    assert gc["mean_importance"] == pytest.approx(590.0)
+    # Concentration feature flagged correctly and averaged across all three fits.
+    concentration = agg[agg["feature"] == "pair_concentration__log10_pfu_ml"].iloc[0]
+    assert bool(concentration["is_concentration_feature"]) is True
+    assert concentration["n_folds_selected"] == 3
+    assert concentration["mean_importance"] == pytest.approx(310.0)
+
+
+def test_aggregate_feature_importance_rejects_empty_input() -> None:
+    """Callers must raise if zero fits contributed — empty aggregate is a pipeline bug."""
+    with pytest.raises(ValueError, match="empty"):
+        _aggregate_feature_importance([])
 
 
 def test_run_ch05_eval_rejects_phage_slot_dir_with_missing_slots(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Patch `ch05_eval.py` so `run_bacteria_axis` and `run_phage_axis` persist
  `ch05_bacteria_axis_feature_importance.csv` and `ch05_phage_axis_feature_importance.csv`
  alongside the existing per-axis metrics/predictions artifacts. Schema identical to
  `ch04_feature_importance.csv` (`feature, is_concentration_feature, mean_importance,
  n_folds_selected`, sorted descending) so the explainability UI snapshot extractor
  (EX02) can read the same columns off both sources.
- Extract the aggregation as a shared `_aggregate_feature_importance` helper and add
  two unit tests covering the schema contract + empty-input fail-fast path.
- No model or evaluation logic changes; both axis functions continue to use the same
  `fit_seeds` machinery CH04 uses.

Closes #465

## Rerun result

`python -m lyzortx.pipeline.autoresearch.ch05_eval --device-type cpu`

- Elapsed: **3224.4 s** (≈53.7 min) on MacBook, `--num-workers 3`
- Headline numbers reproduce CH11 canonical within ≤ 0.0001:
  - Bacteria-axis: AUC **0.807921** [0.793432, 0.822287], Brier **0.176269** [0.168760, 0.183997]
  - Phage-axis: AUC **0.887042** [0.865808, 0.905509], Brier **0.135156** [0.122669, 0.148942]
  - Cross-source (phage-axis): Guelin 0.887091, BASEL 0.895159; |ΔAUC| = 0.008068
- New artifacts:
  - `ch05_bacteria_axis_feature_importance.csv`: **325 features**, top-3 = `host_typing__host_serotype` (2492.8), `phage_stats__phage_gc_content` (557.2), `phage_stats__phage_genome_length_nt` (448.5)
  - `ch05_phage_axis_feature_importance.csv`: **329 features**, top-3 = `host_typing__host_serotype` (2556.7), `phage_stats__phage_gc_content` (544.2), `phage_stats__phage_genome_length_nt` (446.4)
  - Both files match CH04 schema exactly (header diff == 0)
  - All 30 fits (10 folds × 3 seeds) retained the top features: `n_folds_selected == 30` on all three top slots

## Test plan

- [x] `pytest lyzortx/tests/test_ch05_unified_kfold.py` → 10 passed (2 new covering aggregator)
- [x] `ruff check lyzortx/pipeline/autoresearch/ch05_eval.py lyzortx/tests/test_ch05_unified_kfold.py` → clean
- [x] pre-commit hooks (ruff, ruff-format, pymarkdown, check-rebase-on-main) → all passed on commit + push
- [x] CH05 rerun completes; both `ch05_{bacteria,phage}_axis_feature_importance.csv` materialize with >200 rows each; header matches `ch04_feature_importance.csv` exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7)