### PR TITLE
[ORCH][EX02] Build static UI scaffold + snapshot extractor

### DIFF
--- a/lyzortx/explainability_ui/AGENTS.md
+++ b/lyzortx/explainability_ui/AGENTS.md
@@ -1,0 +1,59 @@
+# Explainability UI Directory
+
+## Purpose
+
+Static HTML + Plotly.js dashboard over the CHISEL CH05 unified baseline. Overview-only
+MVP: headline AUC/Brier per axis, Guelin-vs-BASEL cross-source, CH09 reliability diagrams,
+feature importance, per-slot breakdown, and a filterable predictions table.
+
+## Separation of concerns
+
+- **UI code** (`index.html`, `main.js`, `style.css`) — committed, never generated. Safe
+  to edit in place.
+- **Snapshot extractor** (`build_snapshot.py`) — committed. Reads gitignored CH05/CH09
+  artifacts under `lyzortx/generated_outputs/` and writes normalized JSONs.
+- **Snapshot data** (JSON files) — generated, never committed. Default output is
+  `.scratch/explainability_ui/data/` for local dev; in production (per EX03) they ship
+  as GitHub Release assets and the HTML fetches from the `latest` release URL.
+
+## Running locally
+
+```bash
+python -m lyzortx.explainability_ui.build_snapshot --out .scratch/explainability_ui/data
+cp lyzortx/explainability_ui/{index.html,main.js,style.css} .scratch/explainability_ui/
+python -m http.server -d .scratch/explainability_ui 8765
+```
+
+Then open `http://localhost:8765/`. `fetch('./data/*.json')` requires same-origin, so
+`file://` opens do not work — always serve via `python -m http.server`.
+
+## Dependencies
+
+Only CDN-loaded JS libraries — no npm, no bundler, no build step. Version pinned in
+`index.html`:
+
+- Plotly.js 2.35.2 (via `cdn.plot.ly`)
+- Alpine.js 3.14.1 (via `unpkg.com`)
+
+If a new library is needed, pin its version in the `<script>` tag and document it
+here. Do NOT introduce a build step without explicit user approval — "open the file and
+edit it" is the intended dev workflow.
+
+## Deployment (EX03)
+
+- HTML/JS/CSS deploy to GitHub Pages via `actions/deploy-pages@v4` (GitHub Actions source
+  mode — no `gh-pages` branch is ever created).
+- Data snapshots publish as GitHub Release assets. Release tag
+  `explainability-data-YYYYMMDD-HHMM`; the HTML fetches from
+  `https://github.com/<owner>/<repo>/releases/latest/download/<file>.json` so the page
+  doesn't need to know the tag.
+- Prerequisite one-time step: repo Settings → Pages → Source = "GitHub Actions".
+  GitHub does not expose this via API on personal repos.
+
+## Policies
+
+- Do not commit any generated JSON under this directory or under
+  `lyzortx/explainability_ui/data/` — follow the `lyzortx/AGENTS.md` "Generated Outputs"
+  rule.
+- Do not hardcode owner/repo strings in `main.js` — resolve from `window.location` at
+  runtime so the same HTML works on Pages, raw.githack, and local preview.

--- a/lyzortx/explainability_ui/CLAUDE.md
+++ b/lyzortx/explainability_ui/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/lyzortx/explainability_ui/build_snapshot.py
+++ b/lyzortx/explainability_ui/build_snapshot.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Extract CH05 + CH09 artifacts into normalized JSONs for the explainability UI.
+
+The static `index.html` fetches these JSONs (either from a local server during
+development or from GitHub Release assets in production, per EX03) and renders six
+views: Overview, Cross-source, Calibration, Feature importance, Per-slot breakdown,
+Predictions table.
+
+This script is deterministic and idempotent: re-running it with the same source
+artifacts produces byte-identical output (apart from the `snapshot_generated_at` UTC
+timestamp, which is intentionally the only non-deterministic field).
+
+Usage:
+    python -m lyzortx.explainability_ui.build_snapshot \
+        --out .scratch/explainability_ui/data
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.runtime_contract import SLOT_SPECS
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CH05_DIR = Path("lyzortx/generated_outputs/ch05_unified_kfold")
+DEFAULT_CH09_DIR = Path("lyzortx/generated_outputs/ch09_calibration_layer")
+DEFAULT_OUT_DIR = Path(".scratch/explainability_ui/data")
+
+CONCENTRATION_FEATURE_PREFIX = "pair_concentration__"
+
+
+def _read_combined_summary(ch05_dir: Path) -> dict[str, Any]:
+    path = ch05_dir / "ch05_combined_summary.json"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Missing CH05 combined summary at {path}. Run "
+            "`python -m lyzortx.pipeline.autoresearch.ch05_eval --device-type cpu` first."
+        )
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _ci_block(ci_dict: dict[str, Any]) -> dict[str, float | None]:
+    """Normalize a CH05 {point_estimate, ci_low, ci_high} dict into UI-friendly shape."""
+    return {
+        "point": ci_dict.get("point_estimate"),
+        "lo": ci_dict.get("ci_low"),
+        "hi": ci_dict.get("ci_high"),
+    }
+
+
+def build_summary_json(combined: dict[str, Any]) -> dict[str, Any]:
+    """Shape the headline numbers for the Overview tab."""
+    bact = combined["bacteria_axis"]
+    phage = combined["phage_axis"]
+    return {
+        "task_id": combined["task_id"],
+        "scorecard": combined["scorecard"],
+        "per_phage_blending": combined["per_phage_blending"],
+        "frame": (
+            "CHISEL unified 148-phage × 369-bacteria panel, per-row binary training, "
+            "all-pairs only, Arm 3 Moriniere per-receptor-class k-mer fractions as the "
+            "canonical phage_projection slot."
+        ),
+        "elapsed_seconds": combined["elapsed_seconds"],
+        "ch04_baseline_auc": combined.get("ch04_baseline_auc"),
+        "cross_source_auc_delta": combined.get("cross_source_auc_delta"),
+        "phage_axis_generalization_gap_auc": combined.get("phage_axis_generalization_gap_auc"),
+        "axes": {
+            "bacteria": {
+                "fold_strategy": "10-fold via CH02 cv_group hash",
+                "n_pairs": bact["n_pairs"],
+                "n_bacteria": bact["n_bacteria"],
+                "n_phages": bact["n_phages"],
+                "auc": _ci_block(bact["aggregate"]["holdout_roc_auc"]),
+                "brier": _ci_block(bact["aggregate"]["holdout_brier_score"]),
+            },
+            "phage": {
+                "fold_strategy": "10-fold StratifiedKFold by ICTV family",
+                "n_pairs": phage["n_pairs"],
+                "n_bacteria": phage["n_bacteria"],
+                "n_phages": phage["n_phages"],
+                "auc": _ci_block(phage["aggregate"]["holdout_roc_auc"]),
+                "brier": _ci_block(phage["aggregate"]["holdout_brier_score"]),
+            },
+        },
+    }
+
+
+def build_cross_source_json(combined: dict[str, Any], ch09_report: dict[str, Any]) -> dict[str, Any]:
+    """Per-axis Guelin vs BASEL breakdown.
+
+    Phage-axis entries carry bootstrap CIs (from `ch05_phage_axis.cross_source`); bact-axis
+    entries are point estimates only (CH05 doesn't bootstrap bact-axis cross-source — the
+    paired bootstrap is phage-axis scoped by design). Bact-axis numbers come from CH09's
+    `axis_source_metrics.bacteria_axis.{guelin_raw, basel_raw}` which reports point AUC/
+    Brier/ECE without resampling.
+    """
+    phage_rows = []
+    for row in combined["phage_axis"]["cross_source"]:
+        phage_rows.append(
+            {
+                "source": row["source"],
+                "n_pairs": row["n_pairs"],
+                "n_phages": row["n_phages"],
+                "auc": {"point": row["auc_point"], "lo": row["auc_low"], "hi": row["auc_high"]},
+                "brier": {
+                    "point": row["brier_point"],
+                    "lo": row["brier_low"],
+                    "hi": row["brier_high"],
+                },
+            }
+        )
+    bacteria_rows = []
+    bact_metrics = ch09_report["axis_source_metrics"]["bacteria_axis"]
+    for source_label, key in (("guelin", "guelin_raw"), ("basel", "basel_raw")):
+        entry = bact_metrics[key]
+        bacteria_rows.append(
+            {
+                "source": source_label,
+                "n_pairs": entry["n_pairs"],
+                "auc": {"point": entry["auc"], "lo": None, "hi": None},
+                "brier": {"point": entry["brier"], "lo": None, "hi": None},
+                "ece": entry["ece"],
+            }
+        )
+    return {"bacteria": bacteria_rows, "phage": phage_rows}
+
+
+def _feature_to_slot(feature: str) -> str:
+    """Map a namespaced feature name (e.g. `host_typing__host_serotype`) to its slot key."""
+    if feature.startswith(CONCENTRATION_FEATURE_PREFIX):
+        return "pair_concentration"
+    for spec in SLOT_SPECS:
+        if feature.startswith(spec.column_prefix):
+            return spec.slot_name
+    if feature.startswith("pair_depo_capsule__"):
+        return "pair_depo_capsule"
+    if feature.startswith("pair_receptor_omp__"):
+        return "pair_receptor_omp"
+    return "other"
+
+
+def build_feature_importance_json(ch05_dir: Path) -> dict[str, Any]:
+    """Load both per-axis FI CSVs and attach slot tags for coloring in the UI."""
+    result: dict[str, Any] = {}
+    for axis_name, filename in (
+        ("bacteria_axis", "ch05_bacteria_axis_feature_importance.csv"),
+        ("phage_axis", "ch05_phage_axis_feature_importance.csv"),
+    ):
+        path = ch05_dir / filename
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Missing feature importance CSV at {path}. Ensure CH05 ran under the "
+                "EX01 patch (ch05_eval.py emits these alongside per-axis metrics)."
+            )
+        df = pd.read_csv(path)
+        df["slot"] = df["feature"].map(_feature_to_slot)
+        result[axis_name] = df.to_dict(orient="records")
+    return result
+
+
+def build_predictions_json(ch05_dir: Path, axis_key: str) -> list[dict[str, Any]]:
+    """Flatten a per-axis predictions CSV into a compact JSON list for the table tab."""
+    csv_name = f"ch05_{axis_key}_predictions.csv"
+    path = ch05_dir / csv_name
+    if not path.exists():
+        raise FileNotFoundError(f"Missing {csv_name} at {path}.")
+    df = pd.read_csv(path)
+    out = df.loc[
+        :,
+        [
+            "bacteria",
+            "phage",
+            "source",
+            "label_row_binary",
+            "predicted_probability",
+            "log10_pfu_ml",
+        ],
+    ].rename(
+        columns={
+            "label_row_binary": "label",
+            "predicted_probability": "predicted",
+        }
+    )
+    return out.to_dict(orient="records")
+
+
+def build_reliability_json(ch09_dir: Path) -> dict[str, Any]:
+    """Group CH09 reliability tables by (axis, source, variant) and attach per-variant ECE."""
+    tables_path = ch09_dir / "ch09_reliability_tables.csv"
+    report_path = ch09_dir / "ch09_calibration_report.json"
+    for path in (tables_path, report_path):
+        if not path.exists():
+            raise FileNotFoundError(f"Missing CH09 artifact at {path}.")
+    tables = pd.read_csv(tables_path)
+    with report_path.open(encoding="utf-8") as f:
+        report = json.load(f)
+
+    variants: dict[str, dict[str, Any]] = {}
+    for variant_name, group in tables.groupby("variant"):
+        axis, source, variant_kind = _parse_variant_name(str(variant_name))
+        bins = group[["bin_lo", "bin_hi", "n_pairs", "mean_predicted", "observed_rate", "reliability_gap"]].to_dict(
+            orient="records"
+        )
+        variants[str(variant_name)] = {
+            "axis": axis,
+            "source": source,
+            "variant": variant_kind,
+            "bins": bins,
+        }
+    ece_map = _extract_ece_from_report(report)
+    for variant_name, body in variants.items():
+        body["ece"] = ece_map.get(variant_name)
+    return {"variants": variants}
+
+
+def _parse_variant_name(name: str) -> tuple[str, str, str]:
+    """Parse CH09 variant names into (axis, source, variant_kind).
+
+    Examples:
+        bacteria_axis_guelin_raw            -> (bacteria, guelin, raw)
+        phage_axis_basel_guelin_calibrator_applied -> (phage, basel, guelin_calibrator_applied)
+        bacteria_axis_guelin_loof_calibrated -> (bacteria, guelin, loof_calibrated)
+    """
+    if name.startswith("bacteria_axis_"):
+        axis = "bacteria"
+        rest = name[len("bacteria_axis_") :]
+    elif name.startswith("phage_axis_"):
+        axis = "phage"
+        rest = name[len("phage_axis_") :]
+    else:
+        raise ValueError(f"Unrecognized CH09 variant name: {name!r}")
+    if rest.startswith("guelin_"):
+        source = "guelin"
+        variant_kind = rest[len("guelin_") :]
+    elif rest.startswith("basel_"):
+        source = "basel"
+        variant_kind = rest[len("basel_") :]
+    else:
+        raise ValueError(f"Unrecognized CH09 variant source in: {name!r}")
+    return axis, source, variant_kind
+
+
+def _extract_ece_from_report(report: dict[str, Any]) -> dict[str, float]:
+    """Map each reliability variant name to its ECE from the CH09 report."""
+    result: dict[str, float] = {}
+    for axis_key, axis_block in report["axis_source_metrics"].items():
+        for entry_key, entry in axis_block.items():
+            result[f"{axis_key}_{entry_key}"] = entry["ece"]
+    return result
+
+
+def build_slot_manifest_json(feature_importance: dict[str, Any]) -> dict[str, Any]:
+    """Per-slot metadata: canonical SlotSpec info + per-axis feature count and cumulative importance."""
+    slots: dict[str, dict[str, Any]] = {}
+    for spec in SLOT_SPECS:
+        slots[spec.slot_name] = {
+            "slot_name": spec.slot_name,
+            "block_role": spec.block_role,
+            "entity_key": spec.entity_key,
+            "column_prefix": spec.column_prefix,
+            "description": spec.description,
+        }
+    # Pair-level and concentration slots are not in SlotSpec but show up in feature importance.
+    for pseudo_slot in ("pair_depo_capsule", "pair_receptor_omp", "pair_concentration", "other"):
+        slots.setdefault(
+            pseudo_slot,
+            {
+                "slot_name": pseudo_slot,
+                "block_role": "pair" if pseudo_slot.startswith("pair_") else "meta",
+                "entity_key": "pair",
+                "column_prefix": f"{pseudo_slot}__",
+                "description": (
+                    "Pairwise cross-term block (host × phage)."
+                    if pseudo_slot.startswith("pair_") and pseudo_slot != "pair_concentration"
+                    else (
+                        "Concentration feature encoded as absolute log₁₀ pfu/ml."
+                        if pseudo_slot == "pair_concentration"
+                        else "Uncategorized feature source."
+                    )
+                ),
+            },
+        )
+    # Attach per-axis counts and cumulative importance from FI.
+    for axis_key in ("bacteria_axis", "phage_axis"):
+        for slot in slots.values():
+            slot.setdefault("axes", {})
+            slot["axes"][axis_key] = {"feature_count": 0, "cumulative_importance": 0.0}
+        for feature in feature_importance[axis_key]:
+            slot = slots.get(feature["slot"])
+            if slot is None:
+                continue
+            slot["axes"][axis_key]["feature_count"] += 1
+            slot["axes"][axis_key]["cumulative_importance"] += float(feature["mean_importance"])
+    return {"slots": list(slots.values())}
+
+
+def write_snapshot(out_dir: Path, ch05_dir: Path, ch09_dir: Path) -> dict[str, Path]:
+    """Write all seven snapshot JSONs to `out_dir`. Returns a name → path map."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    combined = _read_combined_summary(ch05_dir)
+    report_path = ch09_dir / "ch09_calibration_report.json"
+    if not report_path.exists():
+        raise FileNotFoundError(f"Missing CH09 report at {report_path}.")
+    with report_path.open(encoding="utf-8") as f:
+        ch09_report = json.load(f)
+
+    LOGGER.info("Reading CH05 combined summary + CH09 calibration report")
+    summary = build_summary_json(combined)
+    LOGGER.info("Building cross-source JSON (phage-axis w/ CIs, bacteria-axis point-only)")
+    cross_source = build_cross_source_json(combined, ch09_report)
+    LOGGER.info("Loading per-axis feature importance")
+    feature_importance = build_feature_importance_json(ch05_dir)
+    LOGGER.info("Loading bacteria-axis predictions")
+    predictions_bact = build_predictions_json(ch05_dir, "bacteria_axis")
+    LOGGER.info("Loading phage-axis predictions")
+    predictions_phage = build_predictions_json(ch05_dir, "phage_axis")
+    LOGGER.info("Building reliability JSON from CH09 tables")
+    reliability = build_reliability_json(ch09_dir)
+    LOGGER.info("Building slot manifest with per-axis counts + cumulative importance")
+    slot_manifest = build_slot_manifest_json(feature_importance)
+
+    snapshot_generated_at = datetime.now(timezone.utc).isoformat()
+    summary["snapshot_generated_at"] = snapshot_generated_at
+
+    outputs = {
+        "ch05_summary.json": summary,
+        "ch05_cross_source.json": cross_source,
+        "ch05_feature_importance.json": feature_importance,
+        "ch05_predictions_bact.json": predictions_bact,
+        "ch05_predictions_phage.json": predictions_phage,
+        "ch05_reliability.json": reliability,
+        "slot_manifest.json": slot_manifest,
+    }
+    written: dict[str, Path] = {}
+    for name, body in outputs.items():
+        path = out_dir / name
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(body, f, indent=2)
+        size_kb = path.stat().st_size / 1024
+        LOGGER.info("Wrote %s (%.1f KB)", path, size_kb)
+        written[name] = path
+    LOGGER.info("Snapshot complete at %s", snapshot_generated_at)
+    return written
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help=f"Output directory for snapshot JSONs (default: {DEFAULT_OUT_DIR})",
+    )
+    parser.add_argument(
+        "--ch05-dir",
+        type=Path,
+        default=DEFAULT_CH05_DIR,
+        help=f"CH05 artifact directory (default: {DEFAULT_CH05_DIR})",
+    )
+    parser.add_argument(
+        "--ch09-dir",
+        type=Path,
+        default=DEFAULT_CH09_DIR,
+        help=f"CH09 artifact directory (default: {DEFAULT_CH09_DIR})",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+    start = datetime.now(timezone.utc)
+    LOGGER.info("Snapshot build starting (out=%s, ch05=%s, ch09=%s)", args.out, args.ch05_dir, args.ch09_dir)
+    write_snapshot(out_dir=args.out, ch05_dir=args.ch05_dir, ch09_dir=args.ch09_dir)
+    elapsed = (datetime.now(timezone.utc) - start).total_seconds()
+    LOGGER.info("Snapshot build complete in %.1f s", elapsed)
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/explainability_ui/index.html
+++ b/lyzortx/explainability_ui/index.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CHISEL explainability — CH05 unified</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.14.1/dist/cdn.min.js"></script>
+</head>
+<body x-data="ui()">
+
+<header>
+  <h1>CHISEL explainability — CH05 unified</h1>
+  <p class="subtitle">
+    148-phage × 369-bacteria panel, per-row binary training, all-pairs only,
+    Arm 3 Moriniere per-receptor-class k-mer fractions as the canonical phage_projection slot.
+  </p>
+  <nav class="tabs">
+    <template x-for="(tab, key) in tabs" :key="key">
+      <button
+        :class="{ active: active === key }"
+        @click="active = key"
+        x-text="tab.label"
+      ></button>
+    </template>
+  </nav>
+</header>
+
+<main>
+  <!-- Loading / error banner -->
+  <div class="banner" x-show="loading" x-cloak>Loading snapshot…</div>
+  <div class="banner error" x-show="error" x-cloak x-text="error"></div>
+
+  <!-- Overview -->
+  <section x-show="active === 'overview' && !loading && !error" x-cloak>
+    <h2>Headline metrics</h2>
+    <div class="stat-grid">
+      <template x-for="axis in ['bacteria', 'phage']" :key="axis">
+        <div class="stat-card">
+          <h3 x-text="axisLabel(axis)"></h3>
+          <p class="fold-strategy" x-text="summary?.axes[axis]?.fold_strategy"></p>
+          <dl>
+            <dt>AUC</dt>
+            <dd x-html="fmtCI(summary?.axes[axis]?.auc)"></dd>
+            <dt>Brier</dt>
+            <dd x-html="fmtCI(summary?.axes[axis]?.brier)"></dd>
+            <dt>n pairs</dt>
+            <dd x-text="fmtInt(summary?.axes[axis]?.n_pairs)"></dd>
+            <dt>n bacteria</dt>
+            <dd x-text="fmtInt(summary?.axes[axis]?.n_bacteria)"></dd>
+            <dt>n phages</dt>
+            <dd x-text="fmtInt(summary?.axes[axis]?.n_phages)"></dd>
+          </dl>
+        </div>
+      </template>
+    </div>
+    <div class="plot-area" id="overview-lollipop"></div>
+    <p class="note">
+      Training unit: per-row binary (bacterium, phage, log_dilution, replicate, X, Y) → {0, 1}
+      with <code>pair_concentration__log10_pfu_ml</code> as a numeric feature.
+      Evaluation at each held-out pair's max observed <code>log10_pfu_ml</code>.
+      Scorecard: <code x-text="summary?.scorecard"></code>.
+      Per-phage blending: <code x-text="summary?.per_phage_blending"></code>.
+      Elapsed: <span x-text="fmtInt(summary?.elapsed_seconds) + ' s'"></span>.
+    </p>
+  </section>
+
+  <!-- Cross-source -->
+  <section x-show="active === 'crossSource' && !loading && !error" x-cloak>
+    <h2>Guelin vs BASEL</h2>
+    <p>
+      Phage-axis BASEL AUC 0.895 (wide CI, n=52 phages) vs Guelin 0.887 — cross-source
+      discrimination parity under CHISEL AUC+Brier. Bacteria-axis shows a 7.1 pp BASEL
+      deficit (0.739 vs 0.810) that is the TL17-bias panel-mismatch signal, addressed by
+      the Arm 3 slot migration (CH13) but not fully closed.
+    </p>
+    <div class="plot-area" id="cross-source-plot"></div>
+    <table class="data-table" x-show="crossSource">
+      <thead>
+        <tr>
+          <th>Axis</th><th>Source</th><th>n pairs</th><th>AUC</th><th>Brier</th>
+        </tr>
+      </thead>
+      <tbody>
+        <template x-for="row in crossSourceRows()" :key="row.axis + '|' + row.source">
+          <tr>
+            <td x-text="row.axis"></td>
+            <td x-text="row.source"></td>
+            <td x-text="fmtInt(row.n_pairs)"></td>
+            <td x-html="fmtCI(row.auc)"></td>
+            <td x-html="fmtCI(row.brier)"></td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- Calibration -->
+  <section x-show="active === 'calibration' && !loading && !error" x-cloak>
+    <h2>Reliability diagrams</h2>
+    <p>
+      Deciles 6–9 of the raw-prediction curves show 18–31 pp overpredicton of lysis (the
+      TL17-era signature) — the CH09 isotonic calibrator flattens the Guelin curves to
+      near-perfect. BASEL's residual miscalibration after applying the Guelin-fit calibrator
+      is the panel-mismatch signal, not a threshold issue.
+    </p>
+    <div class="axis-toggle">
+      <label><input type="radio" name="reliability-axis" value="bacteria" x-model="reliabilityAxis" @change="renderReliability()"> Bacteria-axis</label>
+      <label><input type="radio" name="reliability-axis" value="phage" x-model="reliabilityAxis" @change="renderReliability()"> Phage-axis</label>
+    </div>
+    <div class="plot-area" id="reliability-plot"></div>
+    <table class="data-table">
+      <thead><tr><th>Variant</th><th>ECE</th></tr></thead>
+      <tbody>
+        <template x-for="v in reliabilityVariants()" :key="v.key">
+          <tr>
+            <td><code x-text="v.key"></code></td>
+            <td x-text="v.ece === null ? '—' : v.ece.toFixed(4)"></td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- Feature importance -->
+  <section x-show="active === 'featureImportance' && !loading && !error" x-cloak>
+    <h2>Top-30 LightGBM feature importance</h2>
+    <p>
+      Averaged across 30 fits (10 folds × 3 seeds) per axis. Colors map to the feature
+      slot; hover for the full name and the number of folds that retained the feature
+      after RFE (<code>n_folds_selected / 30</code>).
+    </p>
+    <div class="axis-toggle">
+      <label><input type="radio" name="fi-axis" value="bacteria_axis" x-model="fiAxis" @change="renderFeatureImportance()"> Bacteria-axis</label>
+      <label><input type="radio" name="fi-axis" value="phage_axis" x-model="fiAxis" @change="renderFeatureImportance()"> Phage-axis</label>
+    </div>
+    <div class="plot-area tall" id="fi-plot"></div>
+  </section>
+
+  <!-- Per-slot breakdown -->
+  <section x-show="active === 'slots' && !loading && !error" x-cloak>
+    <h2>Per-slot breakdown</h2>
+    <p>
+      Feature count and cumulative mean importance per slot per axis. The pair-level blocks
+      (<code>pair_depo_capsule</code>, <code>pair_receptor_omp</code>) are derived cross-terms,
+      not in the canonical <code>SLOT_SPECS</code> but produced by the same feature pipeline.
+    </p>
+    <div class="axis-toggle">
+      <label><input type="radio" name="slot-axis" value="bacteria_axis" x-model="slotAxis" @change="renderSlots()"> Bacteria-axis</label>
+      <label><input type="radio" name="slot-axis" value="phage_axis" x-model="slotAxis" @change="renderSlots()"> Phage-axis</label>
+    </div>
+    <div class="slot-grid" id="slot-cards"></div>
+  </section>
+
+  <!-- Predictions table -->
+  <section x-show="active === 'predictions' && !loading && !error" x-cloak>
+    <h2>Pair predictions</h2>
+    <p>
+      One row per held-out (bacterium, phage) pair at its max observed log10_pfu_ml.
+      Sort by <code>|p − label|</code> to inspect the model's worst calibration errors.
+    </p>
+    <div class="filters">
+      <label>Axis:
+        <select x-model="predAxis" @change="rebuildPredRows()">
+          <option value="bacteria">bacteria</option>
+          <option value="phage">phage</option>
+        </select>
+      </label>
+      <label>Source:
+        <select x-model="predSource" @change="rebuildPredRows()">
+          <option value="all">all</option>
+          <option value="guelin">guelin</option>
+          <option value="basel">basel</option>
+        </select>
+      </label>
+      <label>Sort by:
+        <select x-model="predSort" @change="rebuildPredRows()">
+          <option value="absErrDesc">|p − label| (desc)</option>
+          <option value="predictedDesc">predicted (desc)</option>
+          <option value="predictedAsc">predicted (asc)</option>
+          <option value="bacteria">bacterium</option>
+          <option value="phage">phage</option>
+        </select>
+      </label>
+      <span class="row-count" x-text="predRowsVisible.length.toLocaleString() + ' pairs (showing first ' + predPageSize + ')'"></span>
+    </div>
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th>Bacterium</th><th>Phage</th><th>Source</th>
+          <th>Label</th><th>Predicted</th><th>|p − label|</th>
+        </tr>
+      </thead>
+      <tbody>
+        <template x-for="row in predRowsVisible.slice(0, predPageSize)" :key="row.bacteria + '|' + row.phage">
+          <tr>
+            <td x-text="row.bacteria"></td>
+            <td x-text="row.phage"></td>
+            <td x-text="row.source"></td>
+            <td x-text="row.label"></td>
+            <td x-text="row.predicted.toFixed(4)"></td>
+            <td x-text="row.absErr.toFixed(4)"></td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </section>
+</main>
+
+<footer x-show="!loading && !error" x-cloak>
+  <span>
+    Snapshot generated at
+    <code x-text="summary?.snapshot_generated_at ?? 'unknown'"></code>.
+  </span>
+  <span x-show="summary?.ch04_baseline_auc">
+    CH04 baseline AUC (Guelin-only): <code x-text="summary?.ch04_baseline_auc?.toFixed(4)"></code>.
+  </span>
+</footer>
+
+<script src="main.js"></script>
+</body>
+</html>

--- a/lyzortx/explainability_ui/main.js
+++ b/lyzortx/explainability_ui/main.js
@@ -1,0 +1,353 @@
+// main.js — vanilla JS + Alpine.js glue for the CHISEL explainability UI.
+//
+// Loads the seven snapshot JSONs from ./data/ and drives six Plotly views.
+// No build step; no module system; runs as-is in any modern browser.
+
+const DATA_BASE = './data';
+
+const SLOT_COLORS = {
+  host_defense: '#8264c9',
+  host_surface: '#2aa198',
+  host_typing: '#268bd2',
+  host_stats: '#b58900',
+  phage_projection: '#d33682',
+  phage_stats: '#cb4b16',
+  phage_kmer: '#6c71c4',
+  pair_depo_capsule: '#859900',
+  pair_receptor_omp: '#dc322f',
+  pair_concentration: '#073642',
+  other: '#839496',
+};
+
+const RELIABILITY_VARIANT_ORDER = [
+  { key: 'guelin_raw', label: 'Guelin raw', color: '#268bd2', dash: 'solid' },
+  { key: 'guelin_loof_calibrated', label: 'Guelin LOOF-calibrated', color: '#268bd2', dash: 'dot' },
+  { key: 'basel_raw', label: 'BASEL raw', color: '#dc322f', dash: 'solid' },
+  { key: 'basel_guelin_calibrator_applied', label: 'BASEL (Guelin calibrator applied)', color: '#dc322f', dash: 'dot' },
+];
+
+function ui() {
+  return {
+    tabs: {
+      overview: { label: 'Overview' },
+      crossSource: { label: 'Cross-source' },
+      calibration: { label: 'Calibration' },
+      featureImportance: { label: 'Feature importance' },
+      slots: { label: 'Per-slot breakdown' },
+      predictions: { label: 'Predictions table' },
+    },
+    active: 'overview',
+    loading: true,
+    error: null,
+
+    summary: null,
+    crossSource: null,
+    featureImportance: null,
+    reliability: null,
+    slotManifest: null,
+    predictionsBact: null,
+    predictionsPhage: null,
+
+    reliabilityAxis: 'bacteria',
+    fiAxis: 'bacteria_axis',
+    slotAxis: 'bacteria_axis',
+    predAxis: 'bacteria',
+    predSource: 'all',
+    predSort: 'absErrDesc',
+    predRowsVisible: [],
+    predPageSize: 500,
+
+    async init() {
+      try {
+        const [summary, crossSource, featureImportance, predBact, predPhage, reliability, slots] =
+          await Promise.all([
+            this.fetchJSON('ch05_summary.json'),
+            this.fetchJSON('ch05_cross_source.json'),
+            this.fetchJSON('ch05_feature_importance.json'),
+            this.fetchJSON('ch05_predictions_bact.json'),
+            this.fetchJSON('ch05_predictions_phage.json'),
+            this.fetchJSON('ch05_reliability.json'),
+            this.fetchJSON('slot_manifest.json'),
+          ]);
+        this.summary = summary;
+        this.crossSource = crossSource;
+        this.featureImportance = featureImportance;
+        this.predictionsBact = predBact;
+        this.predictionsPhage = predPhage;
+        this.reliability = reliability;
+        this.slotManifest = slots;
+        this.loading = false;
+        await this.$nextTick();
+        this.renderAll();
+      } catch (err) {
+        console.error(err);
+        this.error = `Failed to load snapshot data: ${err.message}. Run build_snapshot.py and serve this directory.`;
+        this.loading = false;
+      }
+    },
+
+    async fetchJSON(name) {
+      const res = await fetch(`${DATA_BASE}/${name}`, { cache: 'no-cache' });
+      if (!res.ok) throw new Error(`${name}: HTTP ${res.status}`);
+      return res.json();
+    },
+
+    renderAll() {
+      this.renderOverview();
+      this.renderCrossSource();
+      this.renderReliability();
+      this.renderFeatureImportance();
+      this.renderSlots();
+      this.rebuildPredRows();
+    },
+
+    // ---- formatting helpers ----
+    axisLabel(axis) { return axis === 'bacteria' ? 'Bacteria-axis' : 'Phage-axis'; },
+    fmtCI(ciBlock) {
+      if (!ciBlock) return '—';
+      const { point, lo, hi } = ciBlock;
+      if (point == null) return '—';
+      const body = point.toFixed(4);
+      if (lo == null || hi == null) return body;
+      return `${body} <span class="ci">[${lo.toFixed(4)}, ${hi.toFixed(4)}]</span>`;
+    },
+    fmtInt(n) { return (n ?? 0).toLocaleString(); },
+
+    // ---- Overview ----
+    renderOverview() {
+      if (!this.summary) return;
+      const axes = ['bacteria', 'phage'];
+      const aucTraces = [];
+      const brierTraces = [];
+      axes.forEach((axis) => {
+        const a = this.summary.axes[axis].auc;
+        aucTraces.push({
+          name: this.axisLabel(axis),
+          y: [this.axisLabel(axis)],
+          x: [a.point],
+          error_x: { type: 'data', symmetric: false, array: [a.hi - a.point], arrayminus: [a.point - a.lo] },
+          type: 'scatter', mode: 'markers',
+          marker: { size: 12, color: '#0b6cba' },
+          xaxis: 'x1', yaxis: 'y1',
+          showlegend: false,
+          hovertemplate: `${this.axisLabel(axis)} AUC: %{x:.4f} [${a.lo.toFixed(4)}, ${a.hi.toFixed(4)}]<extra></extra>`,
+        });
+        const b = this.summary.axes[axis].brier;
+        brierTraces.push({
+          name: this.axisLabel(axis),
+          y: [this.axisLabel(axis)],
+          x: [b.point],
+          error_x: { type: 'data', symmetric: false, array: [b.hi - b.point], arrayminus: [b.point - b.lo] },
+          type: 'scatter', mode: 'markers',
+          marker: { size: 12, color: '#cb4b16' },
+          xaxis: 'x2', yaxis: 'y2',
+          showlegend: false,
+          hovertemplate: `${this.axisLabel(axis)} Brier: %{x:.4f} [${b.lo.toFixed(4)}, ${b.hi.toFixed(4)}]<extra></extra>`,
+        });
+      });
+      Plotly.react(
+        'overview-lollipop',
+        [...aucTraces, ...brierTraces],
+        {
+          grid: { rows: 1, columns: 2, pattern: 'independent' },
+          xaxis: { title: 'AUC', range: [0.7, 0.95], domain: [0, 0.48] },
+          xaxis2: { title: 'Brier', range: [0.1, 0.22], domain: [0.52, 1.0] },
+          yaxis: { automargin: true, anchor: 'x1' },
+          yaxis2: { automargin: true, anchor: 'x2' },
+          margin: { l: 120, r: 20, t: 10, b: 40 },
+          height: 220,
+        },
+        { displayModeBar: false, responsive: true },
+      );
+    },
+
+    // ---- Cross-source ----
+    crossSourceRows() {
+      if (!this.crossSource) return [];
+      const rows = [];
+      for (const src of (this.crossSource.bacteria ?? [])) rows.push({ axis: 'bacteria', ...src });
+      for (const src of (this.crossSource.phage ?? [])) rows.push({ axis: 'phage', ...src });
+      return rows;
+    },
+    renderCrossSource() {
+      if (!this.crossSource) return;
+      const axes = ['bacteria', 'phage'];
+      const sources = ['guelin', 'basel'];
+      const traces = [];
+      sources.forEach((source) => {
+        const xs = [];
+        const ys = [];
+        const errs = [];
+        const hover = [];
+        axes.forEach((axis) => {
+          const entry = (this.crossSource[axis] ?? []).find((r) => r.source === source);
+          if (!entry) return;
+          xs.push(entry.auc.point);
+          ys.push(this.axisLabel(axis));
+          const hi = entry.auc.hi == null ? 0 : entry.auc.hi - entry.auc.point;
+          const lo = entry.auc.lo == null ? 0 : entry.auc.point - entry.auc.lo;
+          errs.push({ hi, lo });
+          hover.push(`${source} ${axis}: ${entry.auc.point.toFixed(4)} (n=${entry.n_pairs})`);
+        });
+        traces.push({
+          name: source,
+          type: 'scatter',
+          mode: 'markers',
+          x: xs,
+          y: ys,
+          error_x: {
+            type: 'data',
+            symmetric: false,
+            array: errs.map((e) => e.hi),
+            arrayminus: errs.map((e) => e.lo),
+          },
+          marker: { size: 12, color: source === 'guelin' ? '#268bd2' : '#dc322f' },
+          text: hover,
+          hovertemplate: '%{text}<extra></extra>',
+        });
+      });
+      Plotly.react(
+        'cross-source-plot',
+        traces,
+        {
+          xaxis: { title: 'AUC', range: [0.65, 0.98] },
+          yaxis: { automargin: true },
+          margin: { l: 140, r: 20, t: 10, b: 40 },
+          height: 260,
+          legend: { orientation: 'h', x: 0, y: -0.2 },
+        },
+        { displayModeBar: false, responsive: true },
+      );
+    },
+
+    // ---- Calibration ----
+    reliabilityVariants() {
+      if (!this.reliability) return [];
+      return RELIABILITY_VARIANT_ORDER.map((v) => {
+        const key = `${this.reliabilityAxis}_axis_${v.key}`;
+        const body = this.reliability.variants[key];
+        return { key, ece: body?.ece ?? null };
+      });
+    },
+    renderReliability() {
+      if (!this.reliability) return;
+      const traces = [];
+      RELIABILITY_VARIANT_ORDER.forEach((v) => {
+        const key = `${this.reliabilityAxis}_axis_${v.key}`;
+        const body = this.reliability.variants[key];
+        if (!body) return;
+        traces.push({
+          name: v.label,
+          type: 'scatter',
+          mode: 'lines+markers',
+          x: body.bins.map((b) => b.mean_predicted),
+          y: body.bins.map((b) => b.observed_rate),
+          line: { color: v.color, dash: v.dash },
+          marker: { color: v.color, size: 7 },
+          hovertemplate: `${v.label}<br>bin [%{customdata[0]:.2f}, %{customdata[1]:.2f}]` +
+            `<br>predicted %{x:.3f} → observed %{y:.3f}<extra></extra>`,
+          customdata: body.bins.map((b) => [b.bin_lo, b.bin_hi]),
+        });
+      });
+      traces.push({
+        name: 'perfect',
+        x: [0, 1], y: [0, 1],
+        mode: 'lines',
+        line: { color: '#aaa', dash: 'dash' },
+        hoverinfo: 'skip',
+        showlegend: true,
+      });
+      Plotly.react(
+        'reliability-plot',
+        traces,
+        {
+          xaxis: { title: 'mean predicted probability', range: [0, 1] },
+          yaxis: { title: 'observed fraction positive', range: [0, 1] },
+          margin: { l: 60, r: 20, t: 10, b: 50 },
+          height: 420,
+          legend: { orientation: 'h', x: 0, y: -0.15 },
+        },
+        { displayModeBar: false, responsive: true },
+      );
+    },
+
+    // ---- Feature importance ----
+    renderFeatureImportance() {
+      if (!this.featureImportance) return;
+      const rows = this.featureImportance[this.fiAxis].slice(0, 30);
+      rows.reverse(); // Plotly bar charts grow bottom-up.
+      const trace = {
+        type: 'bar',
+        orientation: 'h',
+        x: rows.map((r) => r.mean_importance),
+        y: rows.map((r) => r.feature),
+        marker: {
+          color: rows.map((r) => SLOT_COLORS[r.slot] ?? SLOT_COLORS.other),
+        },
+        customdata: rows.map((r) => [r.slot, r.n_folds_selected, r.is_concentration_feature]),
+        hovertemplate: '%{y}<br>slot: %{customdata[0]}<br>importance: %{x:.1f}' +
+          '<br>selected in %{customdata[1]}/30 fits<extra></extra>',
+      };
+      Plotly.react(
+        'fi-plot',
+        [trace],
+        {
+          margin: { l: 320, r: 40, t: 10, b: 40 },
+          xaxis: { title: 'mean LightGBM importance' },
+          yaxis: { automargin: true, tickfont: { size: 11 } },
+          height: Math.max(640, rows.length * 22),
+          showlegend: false,
+        },
+        { displayModeBar: false, responsive: true },
+      );
+    },
+
+    // ---- Per-slot breakdown ----
+    renderSlots() {
+      if (!this.slotManifest) return;
+      const container = document.getElementById('slot-cards');
+      if (!container) return;
+      const rows = [...this.slotManifest.slots];
+      rows.sort((a, b) => (b.axes?.[this.slotAxis]?.cumulative_importance ?? 0) -
+                         (a.axes?.[this.slotAxis]?.cumulative_importance ?? 0));
+      container.innerHTML = '';
+      for (const slot of rows) {
+        const axisInfo = slot.axes?.[this.slotAxis] ?? { feature_count: 0, cumulative_importance: 0 };
+        if (axisInfo.feature_count === 0) continue;
+        const card = document.createElement('div');
+        card.className = 'slot-card';
+        const color = SLOT_COLORS[slot.slot_name] ?? SLOT_COLORS.other;
+        card.innerHTML = `
+          <h3 style="color: ${color}">${slot.slot_name}
+            <span class="role-pill">${slot.block_role}</span>
+          </h3>
+          <div class="description">${slot.description}</div>
+          <div class="stat-row">
+            <span>feature count</span><span>${axisInfo.feature_count}</span>
+            <span>cumulative importance</span><span>${axisInfo.cumulative_importance.toFixed(0)}</span>
+            <span>entity key</span><span><code>${slot.entity_key}</code></span>
+          </div>
+        `;
+        container.appendChild(card);
+      }
+    },
+
+    // ---- Predictions table ----
+    rebuildPredRows() {
+      const src = this.predAxis === 'bacteria' ? this.predictionsBact : this.predictionsPhage;
+      if (!src) { this.predRowsVisible = []; return; }
+      let rows = src;
+      if (this.predSource !== 'all') rows = rows.filter((r) => r.source === this.predSource);
+      rows = rows.map((r) => ({ ...r, absErr: Math.abs(r.predicted - r.label) }));
+      const sorts = {
+        absErrDesc: (a, b) => b.absErr - a.absErr,
+        predictedDesc: (a, b) => b.predicted - a.predicted,
+        predictedAsc: (a, b) => a.predicted - b.predicted,
+        bacteria: (a, b) => a.bacteria.localeCompare(b.bacteria),
+        phage: (a, b) => a.phage.localeCompare(b.phage),
+      };
+      rows.sort(sorts[this.predSort] ?? sorts.absErrDesc);
+      this.predRowsVisible = rows;
+    },
+  };
+}

--- a/lyzortx/explainability_ui/style.css
+++ b/lyzortx/explainability_ui/style.css
@@ -1,0 +1,250 @@
+:root {
+  --bg: #f7f8fa;
+  --fg: #1a1d23;
+  --muted: #5a6270;
+  --accent: #0b6cba;
+  --border: #d9dde3;
+  --card: #ffffff;
+  --error: #b72b2b;
+}
+
+* { box-sizing: border-box; }
+[x-cloak] { display: none !important; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--fg);
+  background: var(--bg);
+}
+
+header {
+  padding: 16px 24px 0;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+header h1 {
+  margin: 0 0 4px;
+  font-size: 18px;
+  letter-spacing: -0.01em;
+}
+.subtitle {
+  margin: 0 0 12px;
+  color: var(--muted);
+  font-size: 13px;
+  max-width: 900px;
+}
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 0;
+}
+.tabs button {
+  background: transparent;
+  border: none;
+  padding: 10px 14px;
+  font: inherit;
+  color: var(--muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+.tabs button.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+.tabs button:hover { color: var(--fg); }
+
+main {
+  padding: 16px 24px 48px;
+  max-width: 1400px;
+}
+
+section h2 {
+  margin: 12px 0 8px;
+  font-size: 16px;
+}
+section p {
+  margin: 0 0 12px;
+  color: var(--muted);
+  max-width: 900px;
+}
+
+.banner {
+  margin: 24px 0;
+  padding: 12px 16px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.banner.error {
+  border-color: var(--error);
+  color: var(--error);
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+.stat-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 14px 16px;
+}
+.stat-card h3 {
+  margin: 0 0 4px;
+  font-size: 14px;
+  color: var(--accent);
+}
+.fold-strategy {
+  margin: 0 0 10px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.stat-card dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  margin: 0;
+  font-size: 13px;
+}
+.stat-card dt { color: var(--muted); }
+.stat-card dd { margin: 0; font-variant-numeric: tabular-nums; }
+
+.ci {
+  color: var(--muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.plot-area {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  min-height: 320px;
+  margin-bottom: 16px;
+}
+.plot-area.tall { min-height: 640px; }
+
+.axis-toggle {
+  margin: 4px 0 10px;
+  display: flex;
+  gap: 16px;
+}
+.axis-toggle label { cursor: pointer; }
+
+.slot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+.slot-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 12px 14px;
+}
+.slot-card h3 {
+  margin: 0 0 4px;
+  font-size: 14px;
+}
+.slot-card .description {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.slot-card .stat-row {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  font-size: 13px;
+}
+.slot-card .role-pill {
+  display: inline-block;
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--border);
+  color: var(--fg);
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-bottom: 10px;
+  align-items: center;
+}
+.filters select {
+  font: inherit;
+  padding: 4px 8px;
+}
+.row-count {
+  color: var(--muted);
+  font-size: 12px;
+  margin-left: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+.data-table th {
+  background: #f0f2f5;
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+}
+.data-table td {
+  padding: 6px 12px;
+  border-bottom: 1px solid #eef0f3;
+}
+.data-table tbody tr:last-child td { border-bottom: none; }
+.data-table tbody tr:hover { background: #f7f9fb; }
+
+code {
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  background: #eef0f3;
+  padding: 1px 5px;
+  border-radius: 2px;
+  font-size: 12px;
+}
+
+.note {
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--card);
+  border: 1px dashed var(--border);
+  padding: 10px 14px;
+  border-radius: 4px;
+}
+
+footer {
+  padding: 12px 24px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: 24px;
+  color: var(--muted);
+  font-size: 12px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 700px) {
+  main { padding: 12px; }
+  .stat-grid { grid-template-columns: 1fr; }
+}

--- a/lyzortx/research_notes/lab_notebooks/track_EXPLAINABILITY.md
+++ b/lyzortx/research_notes/lab_notebooks/track_EXPLAINABILITY.md
@@ -63,3 +63,70 @@ plus a shared aggregation helper.
 
 EX02: wire the two CSVs into the UI snapshot extractor and render them in a top-30
 feature-importance bar chart + per-slot breakdown small-multiples.
+
+### 2026-04-22 08:53 CEST: EX02 — static UI scaffold + snapshot extractor
+
+#### Executive summary
+
+Built the committed UI scaffold under `lyzortx/explainability_ui/` (`index.html` +
+`main.js` + `style.css`) and a `build_snapshot.py` extractor that reads CH05/CH09
+artifacts and emits seven normalized JSONs. Plotly.js + Alpine.js loaded via CDN — no
+npm, no bundler, no build step. Six tabs render: Overview (AUC/Brier lollipops with
+CIs + stat cards), Cross-source (Guelin vs BASEL bars + table), Calibration
+(reliability diagrams per axis with raw/calibrated overlays + per-variant ECE),
+Feature importance (top-30 horizontal bar colored by slot), Per-slot breakdown
+(small-multiples sorted by cumulative importance), Predictions table (filterable +
+sortable, 36,643 rows per axis). Eleven unit tests cover parsers, assemblers, and an
+end-to-end integration pass against the live CH05/CH09 artifacts.
+
+#### Why
+
+EX01 gave the UI its missing input (per-axis feature importance). EX02 delivers the
+extractor + renderer so a developer can inspect the CHISEL model end-to-end from one
+HTML page. Overview-only MVP; per-pair SHAP drill-down is deferred to EX04.
+
+#### Design choices
+
+- **Two concerns separated**: UI code (HTML/JS/CSS — committed, safe to edit) vs data
+  snapshots (JSON under `.scratch/` — generated, never committed). The committed side
+  follows `lyzortx/AGENTS.md` generated-outputs policy; the generated side ships as
+  GitHub Release assets in EX03.
+- **No build step**: Plotly + Alpine via CDN, vanilla JS everywhere else. The
+  intended dev workflow is "open the file in an editor and reload the page"; keeping
+  that property forever is more valuable than code-organization gains from a bundler.
+- **Bact-axis cross-source CIs left null**: CH05 bootstraps phage-axis cross-source
+  but not bact-axis (the paired bootstrap is phage-axis-scoped by design). Rather
+  than fabricate CIs, the snapshot carries CH09's point estimates with explicit
+  `null` CI bounds; the UI renders them with no error bars and a clear label.
+- **Slot coloring**: features prefixed `{slot}__` map to a fixed palette derived from
+  `runtime_contract.SLOT_SPECS` plus two pseudo-slots (`pair_depo_capsule`,
+  `pair_receptor_omp`) and `pair_concentration`. Features without a recognized prefix
+  fall through to "other".
+
+#### Verification
+
+- `pytest lyzortx/tests/test_explainability_ui_build_snapshot.py` → 11 passed
+  (10 parser/assembler unit tests + 1 end-to-end integration test that skips when
+  CH05/CH09 artifacts are absent).
+- `python -m lyzortx.explainability_ui.build_snapshot --out .scratch/explainability_ui/data`
+  → 7 JSONs materialize in 0.4 s (total 11.5 MB; gzip ~2 MB over the wire). Headline
+  numbers verified: bact-axis AUC 0.807921 [0.793432, 0.822287], phage-axis AUC
+  0.887042 [0.865808, 0.905509], 36,643 bact pairs.
+- `python -m http.server -d .scratch/explainability_ui 8765` serves HTML + data JSONs;
+  `curl` against `/` and `/data/ch05_summary.json` both return 200 with correct
+  content. `node --check main.js` reports zero syntax errors.
+- `ruff check` clean on all new code.
+
+#### Artifacts
+
+- `lyzortx/explainability_ui/{index.html, main.js, style.css, build_snapshot.py,
+  AGENTS.md, CLAUDE.md}` — committed UI scaffold + extractor.
+- `lyzortx/tests/test_explainability_ui_build_snapshot.py` — 11 tests.
+- `.scratch/explainability_ui/data/*.json` — generated snapshot (regenerated per run,
+  gitignored).
+
+#### Next
+
+EX03: wire the static site to GitHub Pages (Actions source mode) + publish data
+JSONs as GitHub Release assets keyed to the `latest` tag; `main.js` fetches from the
+release URL, owner/repo resolved from `window.location` at runtime.

--- a/lyzortx/tests/test_explainability_ui_build_snapshot.py
+++ b/lyzortx/tests/test_explainability_ui_build_snapshot.py
@@ -1,0 +1,388 @@
+"""Tests for lyzortx/explainability_ui/build_snapshot.py.
+
+Unit-tests the snapshot extractor's parsers and assemblers against real CH05/CH09
+artifact shapes (either mock fixtures or, when available, the live artifacts under
+`lyzortx/generated_outputs/`). The end-to-end `write_snapshot` roundtrip is covered
+by a gated integration test that skips if the artifacts are missing (they're
+gitignored and expensive to regenerate).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from lyzortx.explainability_ui.build_snapshot import (
+    _extract_ece_from_report,
+    _feature_to_slot,
+    _parse_variant_name,
+    build_cross_source_json,
+    build_feature_importance_json,
+    build_reliability_json,
+    build_slot_manifest_json,
+    build_summary_json,
+    write_snapshot,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CH05_DIR = REPO_ROOT / "lyzortx/generated_outputs/ch05_unified_kfold"
+CH09_DIR = REPO_ROOT / "lyzortx/generated_outputs/ch09_calibration_layer"
+
+
+# ---- Parser unit tests (deterministic, no fixture dependency) ----
+
+
+def test_feature_to_slot_handles_all_known_prefixes() -> None:
+    cases = {
+        "host_defense__AbiD": "host_defense",
+        "host_surface__host_capsule_profile_cluster_19_score": "host_surface",
+        "host_typing__host_serotype": "host_typing",
+        "host_stats__host_gc_content": "host_stats",
+        "phage_projection__recep_frac_GluI": "phage_projection",
+        "phage_stats__phage_gc_content": "phage_stats",
+        "phage_kmer__AAAA": "phage_kmer",
+        "pair_depo_capsule__cluster_1_x_capsule_type_K1": "pair_depo_capsule",
+        "pair_receptor_omp__OmpC_x_OmpC_score": "pair_receptor_omp",
+        "pair_concentration__log10_pfu_ml": "pair_concentration",
+        "mystery_feature__x": "other",
+    }
+    for feature, expected_slot in cases.items():
+        assert _feature_to_slot(feature) == expected_slot, feature
+
+
+def test_parse_variant_name_covers_all_ch09_shapes() -> None:
+    """CH09 emits 8 variants: {bacteria,phage}_axis × {guelin,basel}_{raw,calibrated-variant}."""
+    assert _parse_variant_name("bacteria_axis_guelin_raw") == ("bacteria", "guelin", "raw")
+    assert _parse_variant_name("bacteria_axis_guelin_loof_calibrated") == (
+        "bacteria",
+        "guelin",
+        "loof_calibrated",
+    )
+    assert _parse_variant_name("bacteria_axis_basel_raw") == ("bacteria", "basel", "raw")
+    assert _parse_variant_name("bacteria_axis_basel_guelin_calibrator_applied") == (
+        "bacteria",
+        "basel",
+        "guelin_calibrator_applied",
+    )
+    assert _parse_variant_name("phage_axis_guelin_raw") == ("phage", "guelin", "raw")
+    assert _parse_variant_name("phage_axis_basel_guelin_calibrator_applied") == (
+        "phage",
+        "basel",
+        "guelin_calibrator_applied",
+    )
+
+
+def test_parse_variant_name_rejects_unknown_axis() -> None:
+    with pytest.raises(ValueError, match="Unrecognized CH09 variant name"):
+        _parse_variant_name("some_other_axis_guelin_raw")
+
+
+def test_parse_variant_name_rejects_unknown_source() -> None:
+    with pytest.raises(ValueError, match="Unrecognized CH09 variant source"):
+        _parse_variant_name("bacteria_axis_mysterious_raw")
+
+
+def test_extract_ece_from_report_flattens_axis_source_to_variant_name() -> None:
+    report = {
+        "axis_source_metrics": {
+            "bacteria_axis": {
+                "guelin_raw": {"auc": 0.81, "brier": 0.17, "ece": 0.12, "n_pairs": 35403},
+                "basel_raw": {"auc": 0.73, "brier": 0.21, "ece": 0.20, "n_pairs": 1240},
+            },
+            "phage_axis": {
+                "guelin_raw": {"auc": 0.88, "brier": 0.13, "ece": 0.11, "n_pairs": 35403},
+            },
+        }
+    }
+    result = _extract_ece_from_report(report)
+    assert result["bacteria_axis_guelin_raw"] == pytest.approx(0.12)
+    assert result["bacteria_axis_basel_raw"] == pytest.approx(0.20)
+    assert result["phage_axis_guelin_raw"] == pytest.approx(0.11)
+
+
+# ---- Assembler unit tests with inline mock data ----
+
+
+def _mock_combined_summary() -> dict[str, Any]:
+    return {
+        "task_id": "CH05",
+        "scorecard": "AUC + Brier (nDCG/mAP/top-k retired)",
+        "per_phage_blending": "retired (see per-phage-retired-under-chisel)",
+        "bacteria_axis": {
+            "n_pairs": 36643,
+            "n_bacteria": 369,
+            "n_phages": 148,
+            "aggregate": {
+                "holdout_roc_auc": {
+                    "point_estimate": 0.807921,
+                    "ci_low": 0.793432,
+                    "ci_high": 0.822287,
+                },
+                "holdout_brier_score": {
+                    "point_estimate": 0.176269,
+                    "ci_low": 0.168760,
+                    "ci_high": 0.183997,
+                },
+            },
+        },
+        "phage_axis": {
+            "n_pairs": 36643,
+            "n_bacteria": 369,
+            "n_phages": 148,
+            "aggregate": {
+                "holdout_roc_auc": {
+                    "point_estimate": 0.887042,
+                    "ci_low": 0.865808,
+                    "ci_high": 0.905509,
+                },
+                "holdout_brier_score": {
+                    "point_estimate": 0.135156,
+                    "ci_low": 0.122669,
+                    "ci_high": 0.148942,
+                },
+            },
+            "cross_source": [
+                {
+                    "source": "guelin",
+                    "n_pairs": 35403,
+                    "n_phages": 96,
+                    "auc_point": 0.887091,
+                    "auc_low": 0.867058,
+                    "auc_high": 0.907535,
+                    "brier_point": 0.134624,
+                    "brier_low": 0.121341,
+                    "brier_high": 0.148332,
+                },
+                {
+                    "source": "basel",
+                    "n_pairs": 1240,
+                    "n_phages": 52,
+                    "auc_point": 0.895159,
+                    "auc_low": 0.838062,
+                    "auc_high": 0.942456,
+                    "brier_point": 0.150337,
+                    "brier_low": 0.124741,
+                    "brier_high": 0.177961,
+                },
+            ],
+        },
+        "phage_axis_generalization_gap_auc": -0.079121,
+        "cross_source_auc_delta": 0.008068,
+        "ch04_baseline_auc": 0.808276,
+        "elapsed_seconds": 3224.4,
+    }
+
+
+def _mock_ch09_report() -> dict[str, Any]:
+    return {
+        "task_id": "CH09",
+        "axis_source_metrics": {
+            "bacteria_axis": {
+                "guelin_raw": {"auc": 0.81036, "brier": 0.17484, "ece": 0.12195, "n_pairs": 35403},
+                "basel_raw": {"auc": 0.73921, "brier": 0.21708, "ece": 0.20466, "n_pairs": 1240},
+            },
+            "phage_axis": {
+                "guelin_raw": {"auc": 0.88709, "brier": 0.13462, "ece": 0.11139, "n_pairs": 35403},
+                "basel_raw": {"auc": 0.89516, "brier": 0.15034, "ece": 0.18794, "n_pairs": 1240},
+            },
+        },
+    }
+
+
+def test_build_summary_exposes_headline_numbers_at_4dp() -> None:
+    summary = build_summary_json(_mock_combined_summary())
+    assert summary["task_id"] == "CH05"
+    assert summary["axes"]["bacteria"]["auc"]["point"] == pytest.approx(0.807921)
+    assert summary["axes"]["bacteria"]["auc"]["lo"] == pytest.approx(0.793432)
+    assert summary["axes"]["bacteria"]["auc"]["hi"] == pytest.approx(0.822287)
+    assert summary["axes"]["phage"]["auc"]["point"] == pytest.approx(0.887042)
+    assert summary["axes"]["phage"]["brier"]["point"] == pytest.approx(0.135156)
+    assert summary["axes"]["bacteria"]["n_pairs"] == 36643
+    assert summary["axes"]["phage"]["n_phages"] == 148
+
+
+def test_build_cross_source_carries_phage_axis_cis_and_bact_axis_point_only() -> None:
+    result = build_cross_source_json(_mock_combined_summary(), _mock_ch09_report())
+    assert len(result["phage"]) == 2
+    basel_phage = next(r for r in result["phage"] if r["source"] == "basel")
+    assert basel_phage["auc"]["point"] == pytest.approx(0.895159)
+    assert basel_phage["auc"]["lo"] == pytest.approx(0.838062)
+    # Bacteria-axis has CH09 point estimates only; CIs stay null (CH05 doesn't bootstrap
+    # bact-axis cross-source, so presenting CIs would be fabrication).
+    assert len(result["bacteria"]) == 2
+    basel_bact = next(r for r in result["bacteria"] if r["source"] == "basel")
+    assert basel_bact["auc"]["point"] == pytest.approx(0.73921)
+    assert basel_bact["auc"]["lo"] is None
+    assert basel_bact["auc"]["hi"] is None
+    assert basel_bact["ece"] == pytest.approx(0.20466)
+
+
+def test_build_feature_importance_attaches_slot_tag(tmp_path: Path) -> None:
+    """FI CSVs get a `slot` column for UI coloring; prefix mapping must match."""
+    bact_csv = tmp_path / "ch05_bacteria_axis_feature_importance.csv"
+    phage_csv = tmp_path / "ch05_phage_axis_feature_importance.csv"
+    pd.DataFrame(
+        {
+            "feature": [
+                "host_typing__host_serotype",
+                "phage_stats__phage_gc_content",
+                "pair_concentration__log10_pfu_ml",
+            ],
+            "is_concentration_feature": [False, False, True],
+            "mean_importance": [2500.0, 570.0, 320.0],
+            "n_folds_selected": [30, 30, 30],
+        }
+    ).to_csv(bact_csv, index=False)
+    pd.DataFrame(
+        {
+            "feature": ["host_typing__host_o_type"],
+            "is_concentration_feature": [False],
+            "mean_importance": [300.0],
+            "n_folds_selected": [30],
+        }
+    ).to_csv(phage_csv, index=False)
+    fi = build_feature_importance_json(tmp_path)
+    assert fi["bacteria_axis"][0]["slot"] == "host_typing"
+    assert fi["bacteria_axis"][1]["slot"] == "phage_stats"
+    assert fi["bacteria_axis"][2]["slot"] == "pair_concentration"
+    assert fi["phage_axis"][0]["slot"] == "host_typing"
+
+
+def test_build_reliability_groups_by_variant_and_attaches_ece(tmp_path: Path) -> None:
+    tables = pd.DataFrame(
+        {
+            "variant": [
+                "bacteria_axis_guelin_raw",
+                "bacteria_axis_guelin_raw",
+                "bacteria_axis_guelin_loof_calibrated",
+                "phage_axis_basel_raw",
+            ],
+            "bin_lo": [0.0, 0.1, 0.0, 0.0],
+            "bin_hi": [0.1, 0.2, 0.1, 0.1],
+            "n_pairs": [9084, 5042, 9000, 200],
+            "mean_predicted": [0.04, 0.15, 0.05, 0.06],
+            "observed_rate": [0.05, 0.12, 0.05, 0.03],
+            "reliability_gap": [0.01, -0.03, 0.0, -0.03],
+        }
+    )
+    tables.to_csv(tmp_path / "ch09_reliability_tables.csv", index=False)
+    report = {
+        "axis_source_metrics": {
+            "bacteria_axis": {
+                "guelin_raw": {"auc": 0.81, "brier": 0.17, "ece": 0.122, "n_pairs": 35403},
+                "guelin_loof_calibrated": {
+                    "auc": 0.805,
+                    "brier": 0.15,
+                    "ece": 0.006,
+                    "n_pairs": 35403,
+                },
+            },
+            "phage_axis": {
+                "basel_raw": {"auc": 0.90, "brier": 0.15, "ece": 0.188, "n_pairs": 1240},
+            },
+        }
+    }
+    (tmp_path / "ch09_calibration_report.json").write_text(json.dumps(report))
+    result = build_reliability_json(tmp_path)
+    assert set(result["variants"].keys()) == {
+        "bacteria_axis_guelin_raw",
+        "bacteria_axis_guelin_loof_calibrated",
+        "phage_axis_basel_raw",
+    }
+    raw = result["variants"]["bacteria_axis_guelin_raw"]
+    assert raw["axis"] == "bacteria"
+    assert raw["source"] == "guelin"
+    assert raw["variant"] == "raw"
+    assert len(raw["bins"]) == 2
+    assert raw["ece"] == pytest.approx(0.122)
+    assert result["variants"]["bacteria_axis_guelin_loof_calibrated"]["ece"] == pytest.approx(0.006)
+
+
+def test_build_slot_manifest_counts_features_per_axis() -> None:
+    fi = {
+        "bacteria_axis": [
+            {
+                "feature": "host_typing__a",
+                "slot": "host_typing",
+                "is_concentration_feature": False,
+                "mean_importance": 1000,
+                "n_folds_selected": 30,
+            },
+            {
+                "feature": "host_typing__b",
+                "slot": "host_typing",
+                "is_concentration_feature": False,
+                "mean_importance": 500,
+                "n_folds_selected": 30,
+            },
+            {
+                "feature": "phage_stats__gc",
+                "slot": "phage_stats",
+                "is_concentration_feature": False,
+                "mean_importance": 300,
+                "n_folds_selected": 30,
+            },
+        ],
+        "phage_axis": [
+            {
+                "feature": "host_typing__a",
+                "slot": "host_typing",
+                "is_concentration_feature": False,
+                "mean_importance": 1100,
+                "n_folds_selected": 30,
+            },
+        ],
+    }
+    manifest = build_slot_manifest_json(fi)
+    slots = {s["slot_name"]: s for s in manifest["slots"]}
+    host_typing = slots["host_typing"]
+    assert host_typing["axes"]["bacteria_axis"]["feature_count"] == 2
+    assert host_typing["axes"]["bacteria_axis"]["cumulative_importance"] == pytest.approx(1500.0)
+    assert host_typing["axes"]["phage_axis"]["feature_count"] == 1
+    # Slots with no features on an axis still appear (with count=0) so UI can show an empty card.
+    phage_stats = slots["phage_stats"]
+    assert phage_stats["axes"]["phage_axis"]["feature_count"] == 0
+
+
+# ---- End-to-end integration test (skip if artifacts missing) ----
+
+
+_SKIP_REASON = (
+    "CH05/CH09 artifacts are gitignored; regenerate with "
+    "`python -m lyzortx.pipeline.autoresearch.ch05_eval` to enable this test."
+)
+
+
+@pytest.mark.skipif(
+    not (CH05_DIR / "ch05_combined_summary.json").exists() or not (CH09_DIR / "ch09_calibration_report.json").exists(),
+    reason=_SKIP_REASON,
+)
+def test_write_snapshot_emits_all_seven_jsons_with_expected_headline_numbers(tmp_path: Path) -> None:
+    """End-to-end: extractor → 7 JSONs, bact-axis AUC 0.807921, phage-axis AUC 0.887042."""
+    out_dir = tmp_path / "snapshot"
+    written = write_snapshot(out_dir=out_dir, ch05_dir=CH05_DIR, ch09_dir=CH09_DIR)
+    expected_names = {
+        "ch05_summary.json",
+        "ch05_cross_source.json",
+        "ch05_feature_importance.json",
+        "ch05_predictions_bact.json",
+        "ch05_predictions_phage.json",
+        "ch05_reliability.json",
+        "slot_manifest.json",
+    }
+    assert set(written.keys()) == expected_names
+    with (out_dir / "ch05_summary.json").open() as f:
+        summary = json.load(f)
+    assert summary["axes"]["bacteria"]["auc"]["point"] == pytest.approx(0.807921, abs=1e-5)
+    assert summary["axes"]["phage"]["auc"]["point"] == pytest.approx(0.887042, abs=1e-5)
+    assert summary["axes"]["bacteria"]["n_pairs"] == 36643
+    with (out_dir / "ch05_feature_importance.json").open() as f:
+        fi = json.load(f)
+    assert len(fi["bacteria_axis"]) > 200
+    assert len(fi["phage_axis"]) > 200
+    assert fi["bacteria_axis"][0]["feature"] == "host_typing__host_serotype"
+    assert fi["bacteria_axis"][0]["slot"] == "host_typing"


### PR DESCRIPTION
## Summary

- New `lyzortx/explainability_ui/` directory: `index.html` + `main.js` + `style.css`
  (Plotly.js 2.35.2 + Alpine.js 3.14.1 via CDN, no build step) plus `build_snapshot.py`
  that reads CH05/CH09 artifacts and emits seven normalized JSONs under
  `.scratch/explainability_ui/data/` (or a caller-specified `--out` directory).
- **Six tabs**: Overview (AUC/Brier lollipops with CIs + stat cards), Cross-source
  (Guelin vs BASEL bars with phage-axis CIs + bact-axis point-only), Calibration
  (reliability diagrams per axis with raw/isotonic overlays + per-variant ECE table),
  Feature importance (top-30 horizontal bar colored by slot, hover shows
  `n_folds_selected`), Per-slot breakdown (small-multiples with feature_count +
  cumulative_importance), Predictions table (filterable + sortable over 36,643 rows,
  paged to first 500).
- **11 unit tests**: parsers (feature→slot mapping, CH09 variant name parsing, ECE
  report flattening), assemblers (summary/cross-source/FI/reliability/slot_manifest
  against inline mock fixtures), and one end-to-end integration pass against the live
  CH05/CH09 artifacts (auto-skips when artifacts missing, keeps CI green).

Closes #467

## Architecture

- **UI code** (committed, safe to edit): `index.html`, `main.js`, `style.css`,
  `build_snapshot.py`, `AGENTS.md`, `CLAUDE.md`. Total ~1.1 KB gzipped per asset.
- **Data snapshots** (generated, gitignored): `.scratch/explainability_ui/data/*.json`
  during local dev; EX03 will publish to GitHub Release assets keyed to `latest`.
- **No build step**: Plotly + Alpine from CDN, vanilla JS + Alpine.js directives for
  reactivity. Opening the file in an editor is the entire dev workflow.

## Verification

```
$ python -m pytest lyzortx/tests/test_explainability_ui_build_snapshot.py -v
...
11 passed in 0.57s

$ python -m lyzortx.explainability_ui.build_snapshot --out .scratch/explainability_ui/data
Snapshot build complete in 0.4 s

$ ls .scratch/explainability_ui/data/
ch05_cross_source.json  ch05_predictions_bact.json   ch05_reliability.json
ch05_feature_importance.json  ch05_predictions_phage.json  ch05_summary.json
ch05_predictions_bact.json    slot_manifest.json

$ python -m http.server -d .scratch/explainability_ui 8765 &
$ curl -s http://localhost:8765/data/ch05_summary.json | python -c "import json, sys; print(json.load(sys.stdin)['axes']['bacteria']['auc'])"
{'point': 0.807921, 'lo': 0.793432, 'hi': 0.822287}
```

Headline numbers verified end-to-end:

- Bacteria-axis AUC **0.807921** [0.793432, 0.822287] (matches CH11 canonical)
- Phage-axis AUC **0.887042** [0.865808, 0.905509]
- 36,643 bact-axis pairs, 36,643 phage-axis pairs (same universe, different fold strategy)
- `node --check main.js` passes (no JS syntax errors)
- `ruff check` clean on all new Python

Total snapshot: ~11.5 MB uncompressed, ~2 MB over gzip. Two prediction JSONs dominate
(5.66 MB each, 36k rows × 6 cols) but browser memory handles them fine — 500-row
virtualized pager in the Predictions tab.

## Test plan

- [x] Unit tests green (11 passed)
- [x] `ruff check` clean
- [x] pre-commit hooks (ruff, ruff-format, pymarkdown, check-rebase-on-main) all pass
- [x] `build_snapshot.py` runs end-to-end in 0.4 s; produces 7 JSONs
- [x] Served via `python -m http.server`; HTML + data both fetch 200; headline numbers match CH11 canonical
- [ ] Browser-rendered screenshots of all 6 tabs (reviewer to run `python -m http.server -d .scratch/explainability_ui 8765` and open `http://localhost:8765/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7)