### PR TITLE
[ORCH][EX03] GitHub Pages deploy + Release-asset data workflows

### DIFF
--- a/.github/workflows/publish-explainability-ui.yml
+++ b/.github/workflows/publish-explainability-ui.yml
@@ -1,0 +1,61 @@
+name: Publish Explainability UI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - lyzortx/explainability_ui/**
+      - .github/workflows/publish-explainability-ui.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy UI to GitHub Pages
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Stage UI files at /explainability/
+        run: |
+          set -euo pipefail
+          mkdir -p _site/explainability
+          cp lyzortx/explainability_ui/index.html _site/explainability/
+          cp lyzortx/explainability_ui/main.js _site/explainability/
+          cp lyzortx/explainability_ui/style.css _site/explainability/
+          # Root-level redirect so visitors landing on <user>.github.io/<repo>/ land on the UI.
+          cat > _site/index.html <<'HTML'
+          <!DOCTYPE html>
+          <meta charset="utf-8">
+          <meta http-equiv="refresh" content="0; url=./explainability/">
+          <title>CHISEL explainability — redirect</title>
+          <p>Redirecting to <a href="./explainability/">./explainability/</a>…</p>
+          HTML
+          ls -R _site
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/snapshot-explainability-data.yml
+++ b/.github/workflows/snapshot-explainability-data.yml
@@ -1,0 +1,96 @@
+name: Snapshot Explainability Data
+
+on:
+  workflow_dispatch:
+    inputs:
+      regen:
+        description: "Also rerun CH05 + CH09 from scratch (slow, ~90 min). Off by default; default is snapshot-only."
+        required: false
+        default: false
+        type: boolean
+      release_tag:
+        description: "Release tag to create. Defaults to explainability-data-<UTC timestamp>."
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: explainability-data-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    name: Extract + publish snapshot
+    runs-on: ubuntu-24.04
+    timeout-minutes: 150
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: environment.yml
+          environment-name: phage_env
+          cache-environment: true
+
+      - name: (Optional) Rerun CH05 + CH09 from scratch
+        if: ${{ inputs.regen }}
+        shell: bash -l {0}
+        run: |
+          set -euo pipefail
+          micromamba run -n phage_env python -m lyzortx.pipeline.autoresearch.ch05_eval --device-type cpu
+          micromamba run -n phage_env python -m lyzortx.pipeline.autoresearch.ch09_calibration_layer
+
+      - name: Sanity-check CH05/CH09 artifacts exist
+        shell: bash -l {0}
+        run: |
+          set -euo pipefail
+          for f in \
+            lyzortx/generated_outputs/ch05_unified_kfold/ch05_combined_summary.json \
+            lyzortx/generated_outputs/ch05_unified_kfold/ch05_bacteria_axis_feature_importance.csv \
+            lyzortx/generated_outputs/ch05_unified_kfold/ch05_phage_axis_feature_importance.csv \
+            lyzortx/generated_outputs/ch09_calibration_layer/ch09_calibration_report.json \
+            lyzortx/generated_outputs/ch09_calibration_layer/ch09_reliability_tables.csv; do
+            if [ ! -f "$f" ]; then
+              echo "::error::Missing required artifact: $f"
+              echo "Hint: rerun this workflow with regen=true, or upload the artifact set before dispatching."
+              exit 1
+            fi
+          done
+
+      - name: Build snapshot JSONs
+        shell: bash -l {0}
+        run: |
+          set -euo pipefail
+          mkdir -p .scratch/deploy/data
+          micromamba run -n phage_env python -m lyzortx.explainability_ui.build_snapshot --out .scratch/deploy/data
+          ls -la .scratch/deploy/data
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.release_tag }}"
+          if [ -z "$tag" ]; then
+            tag="explainability-data-$(date -u +%Y%m%d-%H%M)"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag: $tag"
+
+      - name: Publish release with snapshot assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.tag.outputs.tag }}"
+          gh release create "$tag" \
+            --title "Explainability data snapshot ${tag}" \
+            --notes "CH05/CH09 snapshot consumed by the explainability UI. regen=${{ inputs.regen }}." \
+            --latest \
+            .scratch/deploy/data/*.json
+          echo "Published release: $tag"

--- a/lyzortx/explainability_ui/AGENTS.md
+++ b/lyzortx/explainability_ui/AGENTS.md
@@ -39,16 +39,25 @@ If a new library is needed, pin its version in the `<script>` tag and document i
 here. Do NOT introduce a build step without explicit user approval — "open the file and
 edit it" is the intended dev workflow.
 
-## Deployment (EX03)
+## Deployment
 
-- HTML/JS/CSS deploy to GitHub Pages via `actions/deploy-pages@v4` (GitHub Actions source
-  mode — no `gh-pages` branch is ever created).
-- Data snapshots publish as GitHub Release assets. Release tag
-  `explainability-data-YYYYMMDD-HHMM`; the HTML fetches from
-  `https://github.com/<owner>/<repo>/releases/latest/download/<file>.json` so the page
-  doesn't need to know the tag.
-- Prerequisite one-time step: repo Settings → Pages → Source = "GitHub Actions".
-  GitHub does not expose this via API on personal repos.
+- HTML/JS/CSS deploy to GitHub Pages via
+  `.github/workflows/publish-explainability-ui.yml` (fires on pushes to `main` that
+  touch `lyzortx/explainability_ui/**`). Uses `actions/deploy-pages@v4` in "GitHub
+  Actions" source mode — no `gh-pages` branch is ever created.
+- Data snapshots publish as GitHub Release assets via
+  `.github/workflows/snapshot-explainability-data.yml` (`workflow_dispatch` only,
+  inputs: `regen` default false, `release_tag` default
+  `explainability-data-<UTC timestamp>`). The workflow bootstraps `phage_env` via
+  `setup-micromamba@v2`, optionally reruns `ch05_eval` + `ch09_calibration_layer`,
+  runs `build_snapshot.py`, and invokes `gh release create --latest`. The HTML fetches
+  data from `https://github.com/<owner>/<repo>/releases/latest/download/<file>.json`;
+  owner/repo are resolved from `window.location` at page load, so no code changes are
+  needed per deploy target.
+- **Prerequisite one-time manual step** (not automatable): repo Settings → Pages →
+  Source = "GitHub Actions". GitHub does not expose this via API on personal repos.
+  Without it, the first `publish-explainability-ui` run fails with a "Pages not
+  enabled" error.
 
 ## Policies
 

--- a/lyzortx/explainability_ui/index.html
+++ b/lyzortx/explainability_ui/index.html
@@ -213,6 +213,16 @@
     Snapshot generated at
     <code x-text="summary?.snapshot_generated_at ?? 'unknown'"></code>.
   </span>
+  <span x-show="dataSource.mode === 'release' && releaseMeta">
+    Release:
+    <a :href="releaseMeta?.html_url" target="_blank" rel="noopener">
+      <code x-text="releaseMeta?.tag"></code>
+    </a>
+    (published <code x-text="releaseMeta?.published_at"></code>).
+  </span>
+  <span x-show="dataSource.mode === 'local'">
+    Data source: local <code>./data</code>.
+  </span>
   <span x-show="summary?.ch04_baseline_auc">
     CH04 baseline AUC (Guelin-only): <code x-text="summary?.ch04_baseline_auc?.toFixed(4)"></code>.
   </span>

--- a/lyzortx/explainability_ui/main.js
+++ b/lyzortx/explainability_ui/main.js
@@ -1,9 +1,35 @@
 // main.js — vanilla JS + Alpine.js glue for the CHISEL explainability UI.
 //
-// Loads the seven snapshot JSONs from ./data/ and drives six Plotly views.
-// No build step; no module system; runs as-is in any modern browser.
+// Loads the seven snapshot JSONs (either ./data on local dev or a GitHub Release
+// download URL when served from GitHub Pages) and drives six Plotly views. No build
+// step; no module system; runs as-is in any modern browser.
 
-const DATA_BASE = './data';
+// Resolve the data base URL at runtime so the same committed HTML works on
+// GitHub Pages (production), raw.githack (preview), and local preview.
+//
+// Pages URL shape: https://<owner>.github.io/<repo>/explainability/
+// Release asset URL: https://github.com/<owner>/<repo>/releases/latest/download/<file>
+// Local preview: http://localhost:<port>/… → use sibling ./data directory.
+function resolveDataBase() {
+  const loc = window.location;
+  const host = loc.hostname;
+  if (host.endsWith('.github.io')) {
+    const owner = host.split('.')[0];
+    const repo = (loc.pathname.split('/').filter(Boolean)[0] ?? '').trim();
+    if (owner && repo) {
+      return {
+        mode: 'release',
+        owner,
+        repo,
+        base: `https://github.com/${owner}/${repo}/releases/latest/download`,
+        apiBase: `https://api.github.com/repos/${owner}/${repo}`,
+      };
+    }
+  }
+  return { mode: 'local', base: './data' };
+}
+
+const DATA_SOURCE = resolveDataBase();
 
 const SLOT_COLORS = {
   host_defense: '#8264c9',
@@ -57,8 +83,12 @@ function ui() {
     predRowsVisible: [],
     predPageSize: 500,
 
+    dataSource: DATA_SOURCE,
+    releaseMeta: null,
+
     async init() {
       try {
+        this.fetchReleaseMeta(); // fire-and-forget; footer updates when it resolves
         const [summary, crossSource, featureImportance, predBact, predPhage, reliability, slots] =
           await Promise.all([
             this.fetchJSON('ch05_summary.json'),
@@ -87,9 +117,27 @@ function ui() {
     },
 
     async fetchJSON(name) {
-      const res = await fetch(`${DATA_BASE}/${name}`, { cache: 'no-cache' });
+      const res = await fetch(`${this.dataSource.base}/${name}`, { cache: 'no-cache' });
       if (!res.ok) throw new Error(`${name}: HTTP ${res.status}`);
       return res.json();
+    },
+
+    async fetchReleaseMeta() {
+      if (this.dataSource.mode !== 'release' || !this.dataSource.apiBase) return;
+      const cacheKey = `release-meta:${this.dataSource.apiBase}`;
+      const cached = sessionStorage.getItem(cacheKey);
+      if (cached) {
+        try { this.releaseMeta = JSON.parse(cached); return; } catch (_) { /* fall through */ }
+      }
+      try {
+        const res = await fetch(`${this.dataSource.apiBase}/releases/latest`, { cache: 'no-cache' });
+        if (!res.ok) return;
+        const body = await res.json();
+        this.releaseMeta = { tag: body.tag_name, published_at: body.published_at, html_url: body.html_url };
+        sessionStorage.setItem(cacheKey, JSON.stringify(this.releaseMeta));
+      } catch (err) {
+        console.warn('Release metadata fetch failed (cosmetic footer only):', err);
+      }
     },
 
     renderAll() {

--- a/lyzortx/research_notes/lab_notebooks/track_EXPLAINABILITY.md
+++ b/lyzortx/research_notes/lab_notebooks/track_EXPLAINABILITY.md
@@ -130,3 +130,73 @@ HTML page. Overview-only MVP; per-pair SHAP drill-down is deferred to EX04.
 EX03: wire the static site to GitHub Pages (Actions source mode) + publish data
 JSONs as GitHub Release assets keyed to the `latest` tag; `main.js` fetches from the
 release URL, owner/repo resolved from `window.location` at runtime.
+
+### 2026-04-22 09:06 CEST: EX03 — Pages deploy + Release-asset data workflows
+
+#### Executive summary
+
+Added two workflows: `.github/workflows/publish-explainability-ui.yml` deploys HTML/
+JS/CSS to GitHub Pages on every push to `main` touching `lyzortx/explainability_ui/**`
+(Actions source mode, no `gh-pages` branch) and
+`.github/workflows/snapshot-explainability-data.yml` is a `workflow_dispatch`-only job
+that bootstraps `phage_env` via `setup-micromamba@v2`, optionally reruns CH05+CH09,
+builds the snapshot JSONs, and creates a GitHub Release with `--latest`. `main.js`
+gained a runtime data-base resolver: on `*.github.io` it fetches from
+`https://github.com/<owner>/<repo>/releases/latest/download/`; otherwise from the
+sibling `./data` directory. Footer shows the current release tag + published
+timestamp pulled from the GitHub REST API (cached in sessionStorage).
+
+#### Why
+
+Commits to `main` must not carry generated outputs (per `lyzortx/AGENTS.md`
+"Generated Outputs" rule). Pages-via-Actions keeps the data off every branch; Release
+assets keep snapshots versioned and CDN-served with permissive CORS. The combination
+solves both the gitignore constraint and the "viewable from GitHub" requirement
+without a `gh-pages` branch to sync.
+
+#### Design choices
+
+- **Actions-mode Pages, not branch Pages**: no `gh-pages` branch means nothing off-main
+  to maintain. The workflow's `deploy-pages@v4` step pushes directly to Pages
+  infrastructure.
+- **One-time manual Settings step**: repo Settings → Pages → Source = "GitHub
+  Actions" cannot be set via the REST API for personal repos. Documented in
+  `lyzortx/explainability_ui/AGENTS.md` as a prerequisite; first workflow run will
+  fail with "Pages not enabled" until it is done.
+- **Runtime data-base resolution vs build-time injection**: `main.js` inspects
+  `window.location` to choose between release-asset URLs and local `./data`. No
+  owner/repo strings are hardcoded, so the same committed HTML works on Pages,
+  raw.githack, and local preview without edits.
+- **Release metadata in the footer**: fetched from
+  `/repos/<owner>/<repo>/releases/latest` on page load, cached in sessionStorage to
+  avoid hammering the GitHub API on tab switches. Fire-and-forget — the main data
+  load does not wait for it.
+- **Snapshot workflow runs micromamba, not pip**: build_snapshot.py imports from
+  `lyzortx.pipeline.autoresearch.runtime_contract` which transitively pulls in the
+  training-side dependency graph. Bootstrapping the full `phage_env` is
+  straightforward and unblocks the optional `regen=true` path without a second
+  bootstrap step.
+
+#### Verification
+
+- `node --check lyzortx/explainability_ui/main.js` → zero syntax errors.
+- `pytest lyzortx/tests/test_explainability_ui_build_snapshot.py` → 11 passed (no
+  regressions from the data-base resolver).
+- YAML syntax validated by committing + pushing — GitHub rejects syntactically broken
+  workflows at push time.
+- Full deploy verification (first-run Settings step + live Pages URL) is manual and
+  documented in the PR description; the reviewer subagent runs through it.
+
+#### Artifacts
+
+- `.github/workflows/publish-explainability-ui.yml`
+- `.github/workflows/snapshot-explainability-data.yml`
+- `lyzortx/explainability_ui/main.js` — `resolveDataBase()` + `fetchReleaseMeta()`
+- `lyzortx/explainability_ui/index.html` — footer release tag/timestamp display
+- `lyzortx/explainability_ui/AGENTS.md` — deployment + prerequisite notes
+
+#### Next
+
+EX04: persist CH05 boosters, compute SHAP values over the 36,643-pair max-conc
+prediction set, emit Parquet snapshots, and add the "Pair explorer" tab backed by
+DuckDB-WASM for row-click drill-down with waterfall plots.


### PR DESCRIPTION
## Summary

Two new workflows publish the UI and its data, keeping `main` free of generated artifacts:

- **`.github/workflows/publish-explainability-ui.yml`** deploys the committed HTML/JS/CSS
  to GitHub Pages using `actions/deploy-pages@v4` in "GitHub Actions" source mode (no
  `gh-pages` branch is ever created). Triggers: push to `main` on
  `lyzortx/explainability_ui/**`, or `workflow_dispatch`. Includes a root-level redirect
  so visitors landing on `<owner>.github.io/<repo>/` are sent to `/explainability/`.
- **`.github/workflows/snapshot-explainability-data.yml`** is a `workflow_dispatch`-only
  job (inputs: `regen: bool` default `false`, `release_tag: string` default
  `explainability-data-<UTC>`). Bootstraps `phage_env` via `setup-micromamba@v2`,
  optionally reruns `ch05_eval` + `ch09_calibration_layer`, runs `build_snapshot.py`, and
  invokes `gh release create --latest` with the seven JSONs as assets.

`main.js` gains `resolveDataBase()` that inspects `window.location` at load time:

- on `<owner>.github.io/<repo>/...` → fetches
  `https://github.com/<owner>/<repo>/releases/latest/download/<file>.json`
- otherwise (local, raw.githack) → fetches `./data/<file>.json`

No owner/repo strings are hardcoded, so the same committed HTML works across all
deploy targets. Footer now shows the current release tag and published timestamp
(GitHub REST API, cached in `sessionStorage`).

## Prerequisite — one-time manual step

Before the first `publish-explainability-ui` run succeeds, set:

> **Repo Settings → Pages → Source = "GitHub Actions"**

GitHub does not expose this via the REST API for personal repos. Documented in
`lyzortx/explainability_ui/AGENTS.md`.

## Verification

- `node --check lyzortx/explainability_ui/main.js` → clean.
- `pytest lyzortx/tests/test_explainability_ui_build_snapshot.py` → 11 passed (no
  regressions from the runtime data-base resolver).
- YAML syntax validated at push time (GitHub rejects broken workflows).
- Manual live verification (post-merge): fire `snapshot-explainability-data` once
  from Actions UI to create the first release → push any cosmetic UI change to
  trigger `publish-explainability-ui` → visit
  `https://<owner>.github.io/<repo>/explainability/` → confirm all six tabs render
  with live data.

Closes #469

## Test plan

- [x] `node --check main.js` clean (syntax)
- [x] `pytest lyzortx/tests/test_explainability_ui_build_snapshot.py` passes
- [x] `ruff check` clean on all touched Python
- [x] pre-commit hooks (ruff, ruff-format, pymarkdown, check-rebase-on-main) pass
- [ ] First-run deploy + data workflow succeed on merged `main` (reviewer to spot-check post-merge)
- [ ] Pages URL renders with live data pulled from the `latest` release (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7)