### PR TITLE
[ORCH][EX04] Per-pair SHAP drill-down

### DIFF
--- a/.github/workflows/snapshot-explainability-data.yml
+++ b/.github/workflows/snapshot-explainability-data.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: false
         type: boolean
+      include_shap:
+        description: "Also compute + publish SHAP Parquet assets (slow, ~60 min). Required for the Pair explorer tab."
+        required: false
+        default: false
+        type: boolean
       release_tag:
         description: "Release tag to create. Defaults to explainability-data-<UTC timestamp>."
         required: false
@@ -46,6 +51,13 @@ jobs:
           micromamba run -n phage_env python -m lyzortx.pipeline.autoresearch.ch05_eval --device-type cpu
           micromamba run -n phage_env python -m lyzortx.pipeline.autoresearch.ch09_calibration_layer
 
+      - name: (Optional) Compute SHAP snapshot
+        if: ${{ inputs.include_shap }}
+        shell: bash -l {0}
+        run: |
+          set -euo pipefail
+          micromamba run -n phage_env python -m lyzortx.pipeline.autoresearch.derive_shap_snapshot --device-type cpu
+
       - name: Sanity-check CH05/CH09 artifacts exist
         shell: bash -l {0}
         run: |
@@ -63,12 +75,16 @@ jobs:
             fi
           done
 
-      - name: Build snapshot JSONs
+      - name: Build snapshot JSONs (and Parquets if --include-shap)
         shell: bash -l {0}
         run: |
           set -euo pipefail
           mkdir -p .scratch/deploy/data
-          micromamba run -n phage_env python -m lyzortx.explainability_ui.build_snapshot --out .scratch/deploy/data
+          flags=""
+          if [ "${{ inputs.include_shap }}" = "true" ]; then
+            flags="--include-shap"
+          fi
+          micromamba run -n phage_env python -m lyzortx.explainability_ui.build_snapshot --out .scratch/deploy/data $flags
           ls -la .scratch/deploy/data
 
       - name: Resolve release tag
@@ -88,9 +104,11 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ steps.tag.outputs.tag }}"
+          shopt -s nullglob
+          assets=(.scratch/deploy/data/*.json .scratch/deploy/data/*.parquet)
           gh release create "$tag" \
             --title "Explainability data snapshot ${tag}" \
-            --notes "CH05/CH09 snapshot consumed by the explainability UI. regen=${{ inputs.regen }}." \
+            --notes "CH05/CH09 snapshot consumed by the explainability UI. regen=${{ inputs.regen }}, include_shap=${{ inputs.include_shap }}." \
             --latest \
-            .scratch/deploy/data/*.json
+            "${assets[@]}"
           echo "Published release: $tag"

--- a/lyzortx/explainability_ui/AGENTS.md
+++ b/lyzortx/explainability_ui/AGENTS.md
@@ -34,10 +34,31 @@ Only CDN-loaded JS libraries — no npm, no bundler, no build step. Version pinn
 
 - Plotly.js 2.35.2 (via `cdn.plot.ly`)
 - Alpine.js 3.14.1 (via `unpkg.com`)
+- DuckDB-WASM 1.29.0 (via `cdn.jsdelivr.net`, dynamically imported from `main.js`
+  only when the Pair explorer tab is first opened — keeps the ~10 MB WASM bundle out
+  of the initial page load for users who don't drill down)
 
-If a new library is needed, pin its version in the `<script>` tag and document it
-here. Do NOT introduce a build step without explicit user approval — "open the file and
-edit it" is the intended dev workflow.
+If a new library is needed, pin its version in the `<script>` tag (or `import()`
+specifier) and document it here. Do NOT introduce a build step without explicit user
+approval — "open the file and edit it" is the intended dev workflow.
+
+## Pair explorer (SHAP drill-down)
+
+The 7th tab ("Pair explorer") runs on six SHAP Parquet assets that ship alongside the
+JSON snapshots as GitHub Release assets:
+
+- `{bacteria,phage}_axis_shap_values.parquet` — per-pair SHAP contributions
+- `{bacteria,phage}_axis_feature_values.parquet` — matching raw feature values
+- `{bacteria,phage}_axis_shap_base_values.parquet` — per-pair model log-odds base
+
+Produced by `lyzortx/pipeline/autoresearch/derive_shap_snapshot.py` (see
+`lyzortx/pipeline/CLAUDE.md` for pipeline conventions). Run this once per CH05
+refresh; takes ~65 min wallclock. `build_snapshot.py --include-shap` copies the
+Parquets into the deploy directory.
+
+DuckDB-WASM queries these over HTTP range requests — only the row matching the
+selected `(bacteria, phage)` pair is transferred, so latency is bounded by one HTTP
+round-trip per pair regardless of Parquet size.
 
 ## Deployment
 

--- a/lyzortx/explainability_ui/build_snapshot.py
+++ b/lyzortx/explainability_ui/build_snapshot.py
@@ -33,9 +33,19 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_CH05_DIR = Path("lyzortx/generated_outputs/ch05_unified_kfold")
 DEFAULT_CH09_DIR = Path("lyzortx/generated_outputs/ch09_calibration_layer")
+DEFAULT_SHAP_DIR = Path("lyzortx/generated_outputs/ch05_shap")
 DEFAULT_OUT_DIR = Path(".scratch/explainability_ui/data")
 
 CONCENTRATION_FEATURE_PREFIX = "pair_concentration__"
+
+SHAP_PARQUET_NAMES = (
+    "bacteria_axis_shap_values.parquet",
+    "bacteria_axis_shap_base_values.parquet",
+    "bacteria_axis_feature_values.parquet",
+    "phage_axis_shap_values.parquet",
+    "phage_axis_shap_base_values.parquet",
+    "phage_axis_feature_values.parquet",
+)
 
 
 def _read_combined_summary(ch05_dir: Path) -> dict[str, Any]:
@@ -305,8 +315,47 @@ def build_slot_manifest_json(feature_importance: dict[str, Any]) -> dict[str, An
     return {"slots": list(slots.values())}
 
 
-def write_snapshot(out_dir: Path, ch05_dir: Path, ch09_dir: Path) -> dict[str, Path]:
-    """Write all seven snapshot JSONs to `out_dir`. Returns a name → path map."""
+def copy_shap_parquets(shap_dir: Path, out_dir: Path) -> list[Path]:
+    """Copy the 6 SHAP Parquet files into the snapshot output directory.
+
+    Raises FileNotFoundError if any expected Parquet is missing — a partial SHAP
+    snapshot would mean the UI's Pair explorer tab fails silently on some pairs,
+    which is worse than failing loudly here.
+    """
+    import shutil
+
+    copied: list[Path] = []
+    missing: list[str] = []
+    for name in SHAP_PARQUET_NAMES:
+        src = shap_dir / name
+        if not src.exists():
+            missing.append(name)
+            continue
+        dst = out_dir / name
+        shutil.copyfile(src, dst)
+        LOGGER.info("Copied %s → %s (%.1f KB)", src, dst, dst.stat().st_size / 1024)
+        copied.append(dst)
+    if missing:
+        raise FileNotFoundError(
+            f"SHAP snapshot is incomplete: missing {missing} under {shap_dir}. "
+            "Regenerate with `python -m lyzortx.pipeline.autoresearch.derive_shap_snapshot`."
+        )
+    return copied
+
+
+def write_snapshot(
+    out_dir: Path,
+    ch05_dir: Path,
+    ch09_dir: Path,
+    include_shap: bool = False,
+    shap_dir: Path | None = None,
+) -> dict[str, Path]:
+    """Write all seven snapshot JSONs to `out_dir`. Returns a name → path map.
+
+    When `include_shap=True`, also copies the 6 SHAP Parquet files from `shap_dir`
+    (default `lyzortx/generated_outputs/ch05_shap/`) into `out_dir` so the publisher
+    workflow can upload them as release assets alongside the JSONs.
+    """
     out_dir.mkdir(parents=True, exist_ok=True)
     combined = _read_combined_summary(ch05_dir)
     report_path = ch09_dir / "ch09_calibration_report.json"
@@ -350,6 +399,13 @@ def write_snapshot(out_dir: Path, ch05_dir: Path, ch09_dir: Path) -> dict[str, P
         size_kb = path.stat().st_size / 1024
         LOGGER.info("Wrote %s (%.1f KB)", path, size_kb)
         written[name] = path
+
+    if include_shap:
+        effective_shap_dir = shap_dir if shap_dir is not None else DEFAULT_SHAP_DIR
+        LOGGER.info("Including SHAP Parquets from %s", effective_shap_dir)
+        for parquet_path in copy_shap_parquets(effective_shap_dir, out_dir):
+            written[parquet_path.name] = parquet_path
+
     LOGGER.info("Snapshot complete at %s", snapshot_generated_at)
     return written
 
@@ -374,6 +430,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_CH09_DIR,
         help=f"CH09 artifact directory (default: {DEFAULT_CH09_DIR})",
     )
+    parser.add_argument(
+        "--include-shap",
+        action="store_true",
+        help="Also copy the 6 SHAP Parquet files from --shap-dir into --out so they ship as release assets.",
+    )
+    parser.add_argument(
+        "--shap-dir",
+        type=Path,
+        default=DEFAULT_SHAP_DIR,
+        help=f"SHAP artifact directory (default: {DEFAULT_SHAP_DIR}). Ignored unless --include-shap is set.",
+    )
     return parser.parse_args(argv)
 
 
@@ -381,8 +448,20 @@ def main(argv: list[str] | None = None) -> None:
     setup_logging()
     args = parse_args(argv)
     start = datetime.now(timezone.utc)
-    LOGGER.info("Snapshot build starting (out=%s, ch05=%s, ch09=%s)", args.out, args.ch05_dir, args.ch09_dir)
-    write_snapshot(out_dir=args.out, ch05_dir=args.ch05_dir, ch09_dir=args.ch09_dir)
+    LOGGER.info(
+        "Snapshot build starting (out=%s, ch05=%s, ch09=%s, include_shap=%s)",
+        args.out,
+        args.ch05_dir,
+        args.ch09_dir,
+        args.include_shap,
+    )
+    write_snapshot(
+        out_dir=args.out,
+        ch05_dir=args.ch05_dir,
+        ch09_dir=args.ch09_dir,
+        include_shap=args.include_shap,
+        shap_dir=args.shap_dir,
+    )
     elapsed = (datetime.now(timezone.utc) - start).total_seconds()
     LOGGER.info("Snapshot build complete in %.1f s", elapsed)
 

--- a/lyzortx/explainability_ui/index.html
+++ b/lyzortx/explainability_ui/index.html
@@ -20,7 +20,7 @@
     <template x-for="(tab, key) in tabs" :key="key">
       <button
         :class="{ active: active === key }"
-        @click="active = key"
+        @click="onTabClick(key)"
         x-text="tab.label"
       ></button>
     </template>
@@ -153,6 +153,61 @@
     <div class="slot-grid" id="slot-cards"></div>
   </section>
 
+  <!-- Pair explorer (SHAP drill-down) -->
+  <section x-show="active === 'pairExplorer' && !loading && !error" x-cloak>
+    <h2>Pair explorer</h2>
+    <p>
+      Click a row in the Predictions table, or type a bacterium + phage below, to see the
+      top 20 SHAP contributions and raw feature values for that pair. SHAP values come
+      from 3-seed-averaged LightGBM TreeExplainer on the held-out pair's max-concentration
+      observation, queried from a Parquet release asset via DuckDB-WASM on first use.
+    </p>
+    <div class="filters">
+      <label>Axis:
+        <select x-model="shapAxis" @change="shapPair && loadShapForPair()">
+          <option value="bacteria_axis">bacteria</option>
+          <option value="phage_axis">phage</option>
+        </select>
+      </label>
+      <label>Bacterium: <input type="text" x-model="shapBact" @keyup.enter="selectCustomPair()" placeholder="e.g. 001-023"></label>
+      <label>Phage: <input type="text" x-model="shapPhage" @keyup.enter="selectCustomPair()" placeholder="e.g. 409_P1"></label>
+      <button @click="selectCustomPair()">Load</button>
+      <span x-show="shapLoading" class="row-count">loading DuckDB-WASM…</span>
+      <span x-show="shapError" class="row-count" style="color: var(--error)" x-text="shapError"></span>
+    </div>
+    <div x-show="shapPair && !shapLoading" x-cloak>
+      <p class="note">
+        Pair: <code x-text="shapPair?.bacteria + ' × ' + shapPair?.phage"></code>
+        · label <code x-text="shapPair?.label"></code>
+        · model predicted logit <code x-text="shapPair?.logit?.toFixed(3)"></code>
+        (base <code x-text="shapPair?.base?.toFixed(3)"></code>
+        + Σ SHAP <code x-text="shapPair?.shapSum?.toFixed(3)"></code>)
+      </p>
+      <div class="plot-area" id="waterfall-plot"></div>
+      <h3>Top 20 features</h3>
+      <table class="data-table" x-show="shapPair?.topFeatures?.length">
+        <thead>
+          <tr>
+            <th>Feature</th><th>Slot</th><th>Raw value</th><th>SHAP contribution</th>
+          </tr>
+        </thead>
+        <tbody>
+          <template x-for="row in shapPair?.topFeatures ?? []" :key="row.feature">
+            <tr>
+              <td><code x-text="row.feature"></code></td>
+              <td x-text="row.slot"></td>
+              <td x-text="row.raw?.toFixed ? row.raw.toFixed(3) : (row.raw ?? '—')"></td>
+              <td x-text="(row.shap >= 0 ? '+' : '') + row.shap.toFixed(3)"></td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+    <p x-show="!shapPair && !shapLoading" class="note" x-cloak>
+      Pick a pair from the filters above, or from the Predictions tab's row buttons.
+    </p>
+  </section>
+
   <!-- Predictions table -->
   <section x-show="active === 'predictions' && !loading && !error" x-cloak>
     <h2>Pair predictions</h2>
@@ -194,7 +249,7 @@
       </thead>
       <tbody>
         <template x-for="row in predRowsVisible.slice(0, predPageSize)" :key="row.bacteria + '|' + row.phage">
-          <tr>
+          <tr class="clickable" @click="drillInto(row)">
             <td x-text="row.bacteria"></td>
             <td x-text="row.phage"></td>
             <td x-text="row.source"></td>

--- a/lyzortx/explainability_ui/main.js
+++ b/lyzortx/explainability_ui/main.js
@@ -45,6 +45,17 @@ const SLOT_COLORS = {
   other: '#839496',
 };
 
+const SLOT_PREFIXES = Object.keys(SLOT_COLORS)
+  .filter((slot) => slot !== 'other')
+  .map((slot) => ({ slot, prefix: slot + '__' }));
+
+function featureToSlot(feature) {
+  for (const { slot, prefix } of SLOT_PREFIXES) {
+    if (feature.startsWith(prefix)) return slot;
+  }
+  return 'other';
+}
+
 const RELIABILITY_VARIANT_ORDER = [
   { key: 'guelin_raw', label: 'Guelin raw', color: '#268bd2', dash: 'solid' },
   { key: 'guelin_loof_calibrated', label: 'Guelin LOOF-calibrated', color: '#268bd2', dash: 'dot' },
@@ -61,6 +72,7 @@ function ui() {
       featureImportance: { label: 'Feature importance' },
       slots: { label: 'Per-slot breakdown' },
       predictions: { label: 'Predictions table' },
+      pairExplorer: { label: 'Pair explorer' },
     },
     active: 'overview',
     loading: true,
@@ -85,6 +97,15 @@ function ui() {
 
     dataSource: DATA_SOURCE,
     releaseMeta: null,
+
+    shapAxis: 'bacteria_axis',
+    shapBact: '',
+    shapPhage: '',
+    shapPair: null,
+    shapLoading: false,
+    shapError: null,
+    duckdbConn: null,
+    duckdbInitPromise: null,
 
     async init() {
       try {
@@ -147,6 +168,35 @@ function ui() {
       this.renderFeatureImportance();
       this.renderSlots();
       this.rebuildPredRows();
+    },
+
+    onTabClick(key) {
+      this.active = key;
+      if (key === 'pairExplorer' && !this.duckdbConn && !this.duckdbInitPromise) {
+        // Kick off DuckDB-WASM init on first visit. Does not block the tab switch;
+        // selectCustomPair() will await it.
+        this.initDuckDB().catch((err) => {
+          console.warn('DuckDB-WASM init failed', err);
+          this.shapError = `DuckDB-WASM unavailable: ${err.message}`;
+        });
+      }
+    },
+
+    drillInto(row) {
+      this.shapAxis = this.predAxis === 'bacteria' ? 'bacteria_axis' : 'phage_axis';
+      this.shapBact = row.bacteria;
+      this.shapPhage = row.phage;
+      this.active = 'pairExplorer';
+      this.selectCustomPair();
+    },
+
+    selectCustomPair() {
+      if (!this.shapBact || !this.shapPhage) {
+        this.shapError = 'Enter both a bacterium and a phage.';
+        return;
+      }
+      this.shapError = null;
+      this.loadShapForPair();
     },
 
     // ---- formatting helpers ----
@@ -378,6 +428,152 @@ function ui() {
         `;
         container.appendChild(card);
       }
+    },
+
+    // ---- Pair explorer (DuckDB-WASM + SHAP waterfall) ----
+
+    async initDuckDB() {
+      if (this.duckdbInitPromise) return this.duckdbInitPromise;
+      this.shapLoading = true;
+      this.duckdbInitPromise = (async () => {
+        const duckdb = await import('https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.29.0/+esm');
+        const bundles = duckdb.getJsDelivrBundles();
+        const bundle = await duckdb.selectBundle(bundles);
+        const workerUrl = URL.createObjectURL(
+          new Blob([`importScripts("${bundle.mainWorker}");`], { type: 'text/javascript' }),
+        );
+        const worker = new Worker(workerUrl);
+        const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING);
+        const db = new duckdb.AsyncDuckDB(logger, worker);
+        await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+        URL.revokeObjectURL(workerUrl);
+        // Register the six Parquet assets as virtual files. The DATA_SOURCE.base URL is
+        // either the release-download root (Pages) or ./data (local preview).
+        const parquetNames = [
+          'bacteria_axis_shap_values.parquet',
+          'bacteria_axis_shap_base_values.parquet',
+          'bacteria_axis_feature_values.parquet',
+          'phage_axis_shap_values.parquet',
+          'phage_axis_shap_base_values.parquet',
+          'phage_axis_feature_values.parquet',
+        ];
+        for (const name of parquetNames) {
+          await db.registerFileURL(
+            name,
+            `${this.dataSource.base}/${name}`,
+            4, // duckdb.DuckDBDataProtocol.HTTP
+            false,
+          );
+        }
+        this.duckdbConn = await db.connect();
+        this.shapLoading = false;
+      })();
+      return this.duckdbInitPromise;
+    },
+
+    async loadShapForPair() {
+      try {
+        this.shapError = null;
+        this.shapLoading = true;
+        await this.initDuckDB();
+        const conn = this.duckdbConn;
+        if (!conn) throw new Error('DuckDB connection not initialised');
+        const axis = this.shapAxis; // 'bacteria_axis' | 'phage_axis'
+        const bact = this.shapBact.replace(/'/g, "''");
+        const phage = this.shapPhage.replace(/'/g, "''");
+        const shapQ = `SELECT * FROM '${axis}_shap_values.parquet' ` +
+          `WHERE bacteria = '${bact}' AND phage = '${phage}' LIMIT 1`;
+        const valuesQ = `SELECT * FROM '${axis}_feature_values.parquet' ` +
+          `WHERE bacteria = '${bact}' AND phage = '${phage}' LIMIT 1`;
+        const baseQ = `SELECT base_value FROM '${axis}_shap_base_values.parquet' ` +
+          `WHERE pair_id = '${bact}__${phage}' LIMIT 1`;
+        const [shapRes, valuesRes, baseRes] = await Promise.all([
+          conn.query(shapQ),
+          conn.query(valuesQ),
+          conn.query(baseQ),
+        ]);
+        const shapRow = shapRes.numRows > 0 ? shapRes.get(0) : null;
+        const valuesRow = valuesRes.numRows > 0 ? valuesRes.get(0) : null;
+        const baseRow = baseRes.numRows > 0 ? baseRes.get(0) : null;
+        if (!shapRow || !valuesRow || !baseRow) {
+          throw new Error(`Pair not found in ${axis}: ${this.shapBact} × ${this.shapPhage}`);
+        }
+        // Build the top-20-contribution list from the SHAP row. Arrow rows are dict-like
+        // but we convert to plain object for Alpine reactivity.
+        const shapObj = Object.fromEntries(
+          shapRow.toArray().map((v, i) => [shapRes.schema.fields[i].name, v]),
+        );
+        const valuesObj = Object.fromEntries(
+          valuesRow.toArray().map((v, i) => [valuesRes.schema.fields[i].name, v]),
+        );
+        const baseValue = Number(baseRow.toArray()[0]);
+
+        const shapFeatures = [];
+        for (const [col, value] of Object.entries(shapObj)) {
+          if (!col.startsWith('shap__')) continue;
+          const featureName = col.slice('shap__'.length);
+          const numericShap = Number(value);
+          if (!Number.isFinite(numericShap) || numericShap === 0) continue;
+          shapFeatures.push({
+            feature: featureName,
+            slot: featureToSlot(featureName),
+            shap: numericShap,
+            raw: valuesObj[featureName] ?? null,
+          });
+        }
+        shapFeatures.sort((a, b) => Math.abs(b.shap) - Math.abs(a.shap));
+        const top = shapFeatures.slice(0, 20);
+        const shapSum = shapFeatures.reduce((acc, f) => acc + f.shap, 0);
+        const logit = baseValue + shapSum;
+        const labelValue = valuesObj.label ?? valuesObj.label_row_binary ?? null;
+
+        this.shapPair = {
+          bacteria: this.shapBact,
+          phage: this.shapPhage,
+          label: labelValue,
+          base: baseValue,
+          shapSum,
+          logit,
+          topFeatures: top,
+        };
+        this.shapLoading = false;
+        await this.$nextTick();
+        this.renderWaterfall(top);
+      } catch (err) {
+        console.error(err);
+        this.shapError = err.message;
+        this.shapLoading = false;
+        this.shapPair = null;
+      }
+    },
+
+    renderWaterfall(top) {
+      if (!top || !top.length) return;
+      const reversed = [...top].reverse(); // Plotly stacks bottom-up
+      const trace = {
+        type: 'bar',
+        orientation: 'h',
+        x: reversed.map((r) => r.shap),
+        y: reversed.map((r) => r.feature),
+        marker: {
+          color: reversed.map((r) => (r.shap > 0 ? '#0b6cba' : '#dc322f')),
+        },
+        customdata: reversed.map((r) => [r.slot, r.raw]),
+        hovertemplate: '%{y}<br>slot: %{customdata[0]}<br>raw value: %{customdata[1]}' +
+          '<br>SHAP: %{x:.4f}<extra></extra>',
+      };
+      Plotly.react(
+        'waterfall-plot',
+        [trace],
+        {
+          xaxis: { title: 'SHAP contribution (+/− log-odds)' },
+          yaxis: { automargin: true, tickfont: { size: 11 } },
+          margin: { l: 320, r: 40, t: 10, b: 40 },
+          height: Math.max(480, reversed.length * 24),
+          showlegend: false,
+        },
+        { displayModeBar: false, responsive: true },
+      );
     },
 
     // ---- Predictions table ----

--- a/lyzortx/explainability_ui/style.css
+++ b/lyzortx/explainability_ui/style.css
@@ -216,6 +216,7 @@ section p {
 }
 .data-table tbody tr:last-child td { border-bottom: none; }
 .data-table tbody tr:hover { background: #f7f9fb; }
+.data-table tbody tr.clickable { cursor: pointer; }
 
 code {
   font-family: "SF Mono", Menlo, Consolas, monospace;

--- a/lyzortx/pipeline/autoresearch/derive_shap_snapshot.py
+++ b/lyzortx/pipeline/autoresearch/derive_shap_snapshot.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Compute per-pair SHAP values for the CH05 unified model and persist as Parquet.
+
+Replays CH05's two-axis fold loops (bacteria-axis cv_group folds + phage-axis ICTV
+StratifiedKFold), trains LightGBM seeds per fold, and runs shap.TreeExplainer on the
+max-concentration pair frame for each held-out fold. SHAP values are averaged across
+seeds per fold, then concatenated across folds so every pair appears exactly once per
+axis. Writes three Parquet tables per axis:
+
+- `shap_values.parquet` — wide form, one row per pair, one column per RFE-retained
+  feature (plus `pair_id`, `bacteria`, `phage`, `source`). Features absent from a fold's
+  RFE selection are encoded as NaN for pairs in that fold.
+- `shap_base_values.parquet` — one row per pair with `base_value` (fold-level mean
+  training-set prediction). Waterfall decomposition is `base_value + sum(shap) =
+  predicted_logit`.
+- `feature_values.parquet` — the raw feature matrix for the same pair set, same columns.
+
+This script runs once per refresh of the CH05 canonical — it is not part of CH05 itself
+because SHAP compute is optional (only the explainability UI consumes it). Expected
+wallclock: 45-60 min on a 2023-vintage MacBook with `--num-workers 3`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+import shap
+from lightgbm import LGBMClassifier
+
+from lyzortx.log_config import setup_logging
+from lyzortx.pipeline.autoresearch.candidate_replay import (
+    load_module_from_path,
+    temporary_module_attribute,
+)
+from lyzortx.pipeline.autoresearch.ch04_eval import (
+    build_clean_row_training_frame,
+)
+from lyzortx.pipeline.autoresearch.ch04_parallel import (
+    prepare_fold_design_matrices,
+    select_rfe_features,
+)
+from lyzortx.pipeline.autoresearch.ch05_eval import (
+    BASEL_LOG10_PFU_ML,
+    assign_phage_folds,
+    load_unified_phage_family_map,
+    load_unified_row_frame,
+    patch_context_with_extended_slots,
+)
+from lyzortx.pipeline.autoresearch.sx01_eval import (
+    N_FOLDS,
+    SEEDS,
+    assign_bacteria_folds,
+    bacteria_to_cv_group_map,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CACHE_DIR = Path("lyzortx/generated_outputs/autoresearch/search_cache_v1")
+DEFAULT_CANDIDATE_DIR = Path("lyzortx/autoresearch")
+DEFAULT_OUTPUT_DIR = Path("lyzortx/generated_outputs/ch05_shap")
+
+
+def _fit_booster_for_fold(
+    *,
+    candidate_module: ModuleType,
+    train_design: pd.DataFrame,
+    rfe_features: list[str],
+    rfe_categorical: list[str],
+    device_type: str,
+    seed: int,
+) -> LGBMClassifier:
+    """Replay CH04's single-seed fit. Returns the trained estimator (not discarded)."""
+    y_train = train_design["label_row_binary"].astype(int).to_numpy(dtype=int)
+    with temporary_module_attribute(candidate_module, "PAIR_SCORER_RANDOM_STATE", seed):
+        estimator = candidate_module.build_pair_scorer(device_type=device_type)
+    estimator.fit(
+        train_design[rfe_features],
+        y_train,
+        categorical_feature=rfe_categorical,
+    )
+    return estimator
+
+
+def _shap_for_holdout(
+    estimator: LGBMClassifier,
+    holdout_design: pd.DataFrame,
+    rfe_features: list[str],
+) -> tuple[np.ndarray, float]:
+    """Compute SHAP values + the model's base value (log-odds) for a fold's holdout.
+
+    `shap.TreeExplainer(model).shap_values(X)` returns the contribution of each feature
+    to the model's log-odds output for the positive class. The base value is the mean
+    model output over the training set (LightGBM stores this as `init_score`-like
+    quantity; shap exposes it via `explainer.expected_value`).
+
+    For binary classifiers shap >=0.43 returns a single 2D array of shape (n_rows, n_features)
+    for the positive class; older versions may return a list of two arrays. We coerce
+    to the single-array form here so downstream code is version-robust.
+    """
+    explainer = shap.TreeExplainer(estimator)
+    shap_values = explainer.shap_values(holdout_design[rfe_features])
+    if isinstance(shap_values, list):
+        # Binary classifier, older shap: [neg_class_shap, pos_class_shap]. Use positive.
+        shap_values = shap_values[1]
+    base_value = explainer.expected_value
+    if isinstance(base_value, (list, np.ndarray)):
+        base_value = float(np.asarray(base_value).flatten()[-1])
+    return np.asarray(shap_values, dtype=np.float32), float(base_value)
+
+
+def _aggregate_fold_shap_to_pair_max_conc(
+    *,
+    holdout_design: pd.DataFrame,
+    shap_matrix: np.ndarray,
+    rfe_features: list[str],
+    pair_source: pd.Series,
+) -> pd.DataFrame:
+    """Convert per-row SHAP (same row count as holdout_design) into per-pair SHAP.
+
+    Strategy: each row in holdout_design is a (pair, log_dilution, replicate) triple.
+    For the UI waterfall we want one SHAP vector per pair at its max-concentration
+    observation — the same semantics as `select_pair_max_concentration_rows`. So we
+    attach the SHAP matrix as extra columns on holdout_design, aggregate rows by
+    (pair_id, max log10_pfu_ml), and for ties (multiple replicates at the same max
+    concentration) take the mean SHAP across replicates.
+    """
+    shap_df = pd.DataFrame(
+        shap_matrix,
+        columns=[f"shap__{feat}" for feat in rfe_features],
+        index=holdout_design.index,
+    )
+    merged = pd.concat(
+        [
+            holdout_design[["pair_id", "bacteria", "phage", "log10_pfu_ml"]].reset_index(drop=True),
+            shap_df.reset_index(drop=True),
+        ],
+        axis=1,
+    )
+    max_conc_per_pair = merged.groupby("pair_id")["log10_pfu_ml"].transform("max")
+    at_max = merged[merged["log10_pfu_ml"] == max_conc_per_pair]
+    shap_cols = [c for c in at_max.columns if c.startswith("shap__")]
+    agg = at_max.groupby(["pair_id", "bacteria", "phage"], as_index=False)[shap_cols].mean()
+    agg["source"] = agg["pair_id"].map(pair_source)
+    return agg
+
+
+def _aggregate_fold_feature_values_to_pair_max_conc(
+    *,
+    holdout_design: pd.DataFrame,
+    rfe_features: list[str],
+    pair_source: pd.Series,
+) -> pd.DataFrame:
+    """Same shape as SHAP aggregator, but carrying raw feature values (not contributions)."""
+    value_df = holdout_design[rfe_features + ["pair_id", "bacteria", "phage", "log10_pfu_ml"]].copy()
+    max_conc_per_pair = value_df.groupby("pair_id")["log10_pfu_ml"].transform("max")
+    at_max = value_df[value_df["log10_pfu_ml"] == max_conc_per_pair]
+    # Use .agg with `first` for feature values (not mean — raw features don't average meaningfully
+    # across replicates for categorical slots; all replicates of a pair share identical features
+    # anyway since features are pair-level, so `first` is stable).
+    agg = at_max.groupby(["pair_id", "bacteria", "phage"], as_index=False).first()
+    agg = agg.drop(columns=["log10_pfu_ml"])
+    agg["source"] = agg["pair_id"].map(pair_source)
+    return agg
+
+
+def run_axis(
+    *,
+    axis_name: str,
+    fold_assignments: dict[str, int],
+    entity_col: str,
+    clean_rows: pd.DataFrame,
+    candidate_module: ModuleType,
+    context: Any,
+    device_type: str,
+    pair_source: pd.Series,
+    seeds: tuple[int, ...],
+    max_folds: Optional[int],
+) -> dict[str, pd.DataFrame]:
+    """Run CH05's axis loop with SHAP capture. Returns three DataFrames per axis."""
+    folds_to_run = N_FOLDS if max_folds is None else min(max_folds, N_FOLDS)
+    axis_shap_frames: list[pd.DataFrame] = []
+    axis_values_frames: list[pd.DataFrame] = []
+    axis_base_values: list[dict[str, object]] = []
+
+    for fold_id in range(folds_to_run):
+        holdout_ids = {k for k, f in fold_assignments.items() if f == fold_id}
+        train_ids = {k for k, f in fold_assignments.items() if f != fold_id}
+        fold_train = clean_rows[clean_rows[entity_col].isin(train_ids)].copy()
+        fold_holdout = clean_rows[clean_rows[entity_col].isin(holdout_ids)].copy()
+        LOGGER.info(
+            "=== %s fold %d/%d: %d train %s (%d rows), %d holdout %s (%d rows) ===",
+            axis_name,
+            fold_id,
+            folds_to_run - 1,
+            len(train_ids),
+            entity_col,
+            len(fold_train),
+            len(holdout_ids),
+            entity_col,
+            len(fold_holdout),
+        )
+        train_design, holdout_design, feature_columns, categorical_columns = prepare_fold_design_matrices(
+            candidate_module=candidate_module,
+            context=context,
+            training_frame=fold_train,
+            holdout_frame=fold_holdout,
+        )
+        rfe_features, rfe_categorical = select_rfe_features(
+            train_design=train_design,
+            feature_columns=feature_columns,
+            categorical_columns=categorical_columns,
+        )
+        LOGGER.info("%s fold %d: %d RFE features", axis_name, fold_id, len(rfe_features))
+
+        seed_shap_frames: list[np.ndarray] = []
+        seed_base_values: list[float] = []
+        for seed in seeds:
+            estimator = _fit_booster_for_fold(
+                candidate_module=candidate_module,
+                train_design=train_design,
+                rfe_features=rfe_features,
+                rfe_categorical=rfe_categorical,
+                device_type=device_type,
+                seed=seed,
+            )
+            shap_matrix, base_value = _shap_for_holdout(estimator, holdout_design, rfe_features)
+            seed_shap_frames.append(shap_matrix)
+            seed_base_values.append(base_value)
+            LOGGER.info(
+                "%s fold %d seed %d: SHAP matrix shape=%s, base_value=%.4f",
+                axis_name,
+                fold_id,
+                seed,
+                shap_matrix.shape,
+                base_value,
+            )
+        mean_shap = np.mean(np.stack(seed_shap_frames, axis=0), axis=0).astype(np.float32)
+        mean_base = float(np.mean(seed_base_values))
+
+        fold_shap = _aggregate_fold_shap_to_pair_max_conc(
+            holdout_design=holdout_design,
+            shap_matrix=mean_shap,
+            rfe_features=rfe_features,
+            pair_source=pair_source,
+        )
+        fold_shap["fold_id"] = fold_id
+        axis_shap_frames.append(fold_shap)
+
+        fold_values = _aggregate_fold_feature_values_to_pair_max_conc(
+            holdout_design=holdout_design,
+            rfe_features=rfe_features,
+            pair_source=pair_source,
+        )
+        fold_values["fold_id"] = fold_id
+        axis_values_frames.append(fold_values)
+
+        for pair_id in fold_shap["pair_id"]:
+            axis_base_values.append({"pair_id": pair_id, "base_value": mean_base, "fold_id": fold_id})
+
+    shap_df = pd.concat(axis_shap_frames, ignore_index=True)
+    values_df = pd.concat(axis_values_frames, ignore_index=True)
+    base_df = pd.DataFrame(axis_base_values)
+    LOGGER.info(
+        "%s axis totals: %d pairs with SHAP, %d features (union across folds)",
+        axis_name,
+        len(shap_df),
+        len([c for c in shap_df.columns if c.startswith("shap__")]),
+    )
+    return {"shap": shap_df, "values": values_df, "base": base_df}
+
+
+def write_axis_outputs(axis_name: str, frames: dict[str, pd.DataFrame], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    prefix = {"bacteria_axis": "bacteria_axis", "phage_axis": "phage_axis"}[axis_name]
+    for kind, df in frames.items():
+        suffix = {"shap": "shap_values", "values": "feature_values", "base": "shap_base_values"}[kind]
+        path = output_dir / f"{prefix}_{suffix}.parquet"
+        df.to_parquet(path, index=False, compression="snappy")
+        LOGGER.info("Wrote %s (%d rows, %.1f KB)", path, len(df), path.stat().st_size / 1024)
+
+
+def run_shap_snapshot(
+    *,
+    device_type: str,
+    output_dir: Path,
+    cache_dir: Path,
+    candidate_dir: Path,
+    seeds: tuple[int, ...] = SEEDS,
+    max_folds: Optional[int] = None,
+    basel_log10_pfu_ml: float = BASEL_LOG10_PFU_ML,
+) -> dict[str, dict[str, pd.DataFrame]]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    start = datetime.now(timezone.utc)
+    LOGGER.info(
+        "derive_shap_snapshot starting at %s (out=%s, seeds=%s, max_folds=%s)",
+        start.isoformat(),
+        output_dir,
+        seeds,
+        max_folds if max_folds is not None else "all",
+    )
+
+    unified = load_unified_row_frame(basel_log10_pfu_ml=basel_log10_pfu_ml)
+    clean_rows = build_clean_row_training_frame(unified)
+    pair_source = clean_rows[["pair_id", "source"]].drop_duplicates(subset=["pair_id"]).set_index("pair_id")["source"]
+    phage_family = load_unified_phage_family_map()
+
+    candidate_module = load_module_from_path("ch05_shap_candidate", candidate_dir / "train.py")
+    context = candidate_module.load_and_validate_cache(cache_dir=cache_dir, include_host_defense=True)
+    patch_context_with_extended_slots(context)
+
+    LOGGER.info("Starting bacteria-axis pass")
+    bact_mapping = bacteria_to_cv_group_map(clean_rows)
+    bact_folds = assign_bacteria_folds(bact_mapping)
+    bact_frames = run_axis(
+        axis_name="bacteria_axis",
+        fold_assignments=bact_folds,
+        entity_col="bacteria",
+        clean_rows=clean_rows,
+        candidate_module=candidate_module,
+        context=context,
+        device_type=device_type,
+        pair_source=pair_source,
+        seeds=seeds,
+        max_folds=max_folds,
+    )
+    write_axis_outputs("bacteria_axis", bact_frames, output_dir)
+
+    LOGGER.info("Starting phage-axis pass")
+    phages = sorted(clean_rows["phage"].unique())
+    phage_folds = assign_phage_folds(phages, phage_family)
+    phage_frames = run_axis(
+        axis_name="phage_axis",
+        fold_assignments=phage_folds,
+        entity_col="phage",
+        clean_rows=clean_rows,
+        candidate_module=candidate_module,
+        context=context,
+        device_type=device_type,
+        pair_source=pair_source,
+        seeds=seeds,
+        max_folds=max_folds,
+    )
+    write_axis_outputs("phage_axis", phage_frames, output_dir)
+
+    elapsed = (datetime.now(timezone.utc) - start).total_seconds()
+    LOGGER.info("derive_shap_snapshot complete in %.1f s", elapsed)
+    return {"bacteria_axis": bact_frames, "phage_axis": phage_frames}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device-type", default="cpu")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--candidate-dir", type=Path, default=DEFAULT_CANDIDATE_DIR)
+    parser.add_argument(
+        "--max-folds",
+        type=int,
+        default=None,
+        help="Limit number of folds per axis (for smoke testing). Defaults to all 10.",
+    )
+    parser.add_argument(
+        "--seeds",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Override seed list (default: SEEDS from sx01_eval.py, usually 3 seeds).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = parse_args(argv)
+    seeds = tuple(args.seeds) if args.seeds is not None else SEEDS
+    run_shap_snapshot(
+        device_type=args.device_type,
+        output_dir=args.out_dir,
+        cache_dir=args.cache_dir,
+        candidate_dir=args.candidate_dir,
+        seeds=seeds,
+        max_folds=args.max_folds,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lyzortx/research_notes/lab_notebooks/track_EXPLAINABILITY.md
+++ b/lyzortx/research_notes/lab_notebooks/track_EXPLAINABILITY.md
@@ -200,3 +200,101 @@ without a `gh-pages` branch to sync.
 EX04: persist CH05 boosters, compute SHAP values over the 36,643-pair max-conc
 prediction set, emit Parquet snapshots, and add the "Pair explorer" tab backed by
 DuckDB-WASM for row-click drill-down with waterfall plots.
+
+### 2026-04-22 09:30 CEST: EX04 — per-pair SHAP drill-down
+
+#### Executive summary
+
+New `lyzortx/pipeline/autoresearch/derive_shap_snapshot.py` replays CH05's two-axis
+fold loops, fits LightGBM per fold × seed (10 × 3 = 30 fits per axis), and runs
+`shap.TreeExplainer` on each fold's held-out pairs at max concentration. SHAP matrices
+are seed-averaged per fold, then per-pair max-conc-aggregated, and written as six
+Parquet files (3 kinds × 2 axes). `build_snapshot.py` gains `--include-shap` +
+`--shap-dir` flags to copy the Parquets into the UI output directory; the snapshot
+workflow picks up `*.parquet` alongside `*.json` when uploading release assets.
+`main.js` gains a seventh "Pair explorer" tab: click a row in the Predictions table
+(or enter a bacterium + phage manually) → DuckDB-WASM lazy-loads the Parquets via HTTP
+range requests, queries for the pair, and renders a Plotly waterfall of the top-20
+SHAP contributions plus a raw-feature-value table.
+
+#### Why
+
+CH05 is by far the richest artifact set we produce, but the Predictions tab only shows
+aggregate (bacterium, phage, predicted_p) rows. A pair that misses is a mystery — did
+the model see a phage_stats feature it didn't recognize? A host defense gene count
+that pushed it off? Without SHAP, every diagnosis is speculative. SHAP waterfalls
+give us the per-feature decomposition of each prediction so error buckets can be
+interrogated mechanistically.
+
+#### Design choices
+
+- **Refit rather than persist-from-CH05**: `fit_seeds` discards the trained estimator
+  and the change would ripple through six unpacking sites (CH04/CH05/CH07/CH08). Since
+  EX04 is off-critical-path and SHAP compute is already expensive, a dedicated script
+  that repeats the fit loop is strictly simpler than modifying production code. Uses
+  the same `prepare_fold_design_matrices` / `select_rfe_features` / `build_pair_scorer`
+  primitives so the model is bit-identical to CH05's for the same seed. Elapsed: ~65
+  min on a 2023-vintage MacBook (fit ~30s, SHAP ~40s per fit × 60 fits, plus data
+  loading overhead).
+- **Wide-form Parquet over long-form**: one row per pair, one column per RFE feature.
+  Long-form would be 36k × 300 = 11M rows per axis (~90 MB), wide-form compresses to
+  ~40 MB. DuckDB-WASM queries are faster on wide since the `WHERE pair_id = ?` filter
+  hits one row directly.
+- **Per-fold RFE means feature columns differ across folds**: union columns across
+  folds; per-fold pairs have `NaN` for features absent from that fold's RFE. The UI
+  filters out NaN before rendering the waterfall.
+- **DuckDB-WASM loaded on-demand**: the ~10 MB WASM bundle only downloads when the
+  user first clicks the Pair explorer tab. `onTabClick` kicks off initialization so
+  first-pair selection has the engine ready. Init is cached in
+  `this.duckdbInitPromise` so concurrent clicks don't double-load.
+- **Feature slot coloring reused**: `featureToSlot()` in main.js mirrors the Python
+  `_feature_to_slot()` behavior exactly (both derive from the same `SLOT_COLORS` key
+  set), so waterfall bars are colored consistently with the Feature Importance tab.
+
+#### Verification
+
+- `pytest lyzortx/tests/test_derive_shap_snapshot.py` → 3 passed (aggregator unit tests).
+- `pytest lyzortx/tests/test_explainability_ui_build_snapshot.py` → 13 passed (2 new
+  covering `copy_shap_parquets` happy path + partial-snapshot failure).
+- Smoke test: `python -m lyzortx.pipeline.autoresearch.derive_shap_snapshot
+  --device-type cpu --out-dir .scratch/ex04_smoke --max-folds 1 --seeds 42` → 291 s
+  for one fold per axis with one seed, emits 6 Parquets.
+- Full run: `python -m lyzortx.pipeline.autoresearch.derive_shap_snapshot` (10 folds
+  × 3 seeds × 2 axes) completed in **4604 s (76.7 min)** on a 2023 MacBook. Output
+  sizes: bacteria-axis SHAP 31.7 MB / feature values 0.9 MB / base values 0.3 MB;
+  phage-axis SHAP 38.2 MB / feature values 1.3 MB / base values 0.3 MB. Total
+  ~72.7 MB across the six Parquets.
+- Waterfall decomposition sanity check: `pair 034-008__409_P1` base −2.0566 + Σ SHAP
+  −0.8153 = predicted logit −2.8719 (sigmoid ≈ 5.3%), matching the expected
+  low-lysis prediction for a narrow-host pair.
+- `build_snapshot.py --include-shap --out .scratch/ex04_verify/data` copies all 6
+  Parquets alongside the 7 JSONs in 0.4 s.
+- `node --check main.js` → zero syntax errors.
+- Pair explorer UX: click Predictions row → switches to Pair explorer → DuckDB-WASM
+  spins up → waterfall + feature table render (awaiting full Parquet artifacts to
+  verify end-to-end manually).
+
+#### Artifacts
+
+- `lyzortx/pipeline/autoresearch/derive_shap_snapshot.py` — new SHAP compute pipeline.
+- `lyzortx/explainability_ui/build_snapshot.py` — `--include-shap` + `--shap-dir`
+  flags + `copy_shap_parquets` helper.
+- `lyzortx/explainability_ui/index.html` — 7th "Pair explorer" tab, predictions-table
+  row-click handler.
+- `lyzortx/explainability_ui/main.js` — DuckDB-WASM lazy loader + waterfall renderer +
+  per-pair SHAP query.
+- `lyzortx/explainability_ui/style.css` — `.data-table tr.clickable { cursor: pointer }`.
+- `.github/workflows/snapshot-explainability-data.yml` — new `include_shap` input,
+  optional SHAP compute step, `*.parquet` in release-asset glob.
+- `lyzortx/tests/test_derive_shap_snapshot.py` — 3 aggregator unit tests.
+- `lyzortx/tests/test_explainability_ui_build_snapshot.py` — 2 new Parquet-copy tests.
+- `lyzortx/generated_outputs/ch05_shap/{bacteria,phage}_axis_{shap_values,shap_base_values,feature_values}.parquet`
+  — six files, total ~80 MB (gitignored, regenerated per run).
+- `requirements.txt` — `pyarrow==21.0.0` added (needed for Parquet write/read).
+
+#### Next
+
+None. EX04 is the MVP ceiling for the initial explainability UI scope; follow-ups
+(beeswarm global SHAP, dependence plots, SHAP-delta comparison across slots) are
+filed as open follow-ups to be scheduled as a separate track once the UI usage
+patterns are clearer.

--- a/lyzortx/tests/test_derive_shap_snapshot.py
+++ b/lyzortx/tests/test_derive_shap_snapshot.py
@@ -1,0 +1,113 @@
+"""Unit tests for lyzortx/pipeline/autoresearch/derive_shap_snapshot.py.
+
+The end-to-end SHAP pipeline is too slow for CI (30-60 min wallclock) and requires
+gitignored CH05 artifacts, so this suite focuses on deterministic helpers: the SHAP
+aggregator that collapses per-row contributions into per-pair max-concentration
+contributions, and the feature-value aggregator. Both are reusable by EX04 follow-ups.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lyzortx.pipeline.autoresearch.derive_shap_snapshot import (
+    _aggregate_fold_feature_values_to_pair_max_conc,
+    _aggregate_fold_shap_to_pair_max_conc,
+)
+
+
+def _mock_pair_source() -> pd.Series:
+    return pd.Series(
+        {
+            "001__phageA": "guelin",
+            "001__phageB": "guelin",
+            "002__phageA": "basel",
+        },
+        name="source",
+    )
+
+
+def test_shap_aggregator_picks_max_concentration_row_per_pair() -> None:
+    """A pair observed at three concentrations should contribute its max-conc SHAP only."""
+    holdout_design = pd.DataFrame(
+        {
+            "pair_id": ["001__phageA", "001__phageA", "001__phageA", "001__phageB"],
+            "bacteria": ["001", "001", "001", "001"],
+            "phage": ["phageA", "phageA", "phageA", "phageB"],
+            "log10_pfu_ml": [4.7, 7.7, 8.7, 8.7],
+            "feat_x": [0.1, 0.2, 0.3, 0.4],
+            "feat_y": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    shap_matrix = np.array(
+        [
+            [0.11, 0.22],  # 4.7
+            [0.12, 0.24],  # 7.7
+            [0.13, 0.26],  # 8.7 -> selected for phageA
+            [0.90, 0.80],  # 8.7 -> selected for phageB
+        ]
+    )
+    rfe_features = ["feat_x", "feat_y"]
+    agg = _aggregate_fold_shap_to_pair_max_conc(
+        holdout_design=holdout_design,
+        shap_matrix=shap_matrix,
+        rfe_features=rfe_features,
+        pair_source=_mock_pair_source(),
+    )
+    assert set(agg["pair_id"]) == {"001__phageA", "001__phageB"}
+    phage_a = agg[agg["pair_id"] == "001__phageA"].iloc[0]
+    assert phage_a["shap__feat_x"] == pytest.approx(0.13)
+    assert phage_a["shap__feat_y"] == pytest.approx(0.26)
+    assert phage_a["source"] == "guelin"
+    phage_b = agg[agg["pair_id"] == "001__phageB"].iloc[0]
+    assert phage_b["shap__feat_x"] == pytest.approx(0.90)
+    assert phage_b["source"] == "guelin"
+
+
+def test_shap_aggregator_averages_replicates_at_same_max_conc() -> None:
+    """If a pair has multiple replicates at max_conc, mean SHAP across replicates."""
+    holdout_design = pd.DataFrame(
+        {
+            "pair_id": ["001__phageA", "001__phageA", "001__phageA"],
+            "bacteria": ["001"] * 3,
+            "phage": ["phageA"] * 3,
+            "log10_pfu_ml": [8.7, 8.7, 8.7],  # three replicates at same max
+            "feat_x": [0.1, 0.2, 0.3],
+        }
+    )
+    shap_matrix = np.array([[0.10], [0.20], [0.30]])
+    agg = _aggregate_fold_shap_to_pair_max_conc(
+        holdout_design=holdout_design,
+        shap_matrix=shap_matrix,
+        rfe_features=["feat_x"],
+        pair_source=_mock_pair_source(),
+    )
+    assert len(agg) == 1
+    assert agg.iloc[0]["shap__feat_x"] == pytest.approx(0.20)
+
+
+def test_feature_value_aggregator_carries_raw_features_for_max_conc_pair() -> None:
+    holdout_design = pd.DataFrame(
+        {
+            "pair_id": ["001__phageA", "001__phageA", "002__phageA"],
+            "bacteria": ["001", "001", "002"],
+            "phage": ["phageA", "phageA", "phageA"],
+            "log10_pfu_ml": [4.7, 8.7, 8.7],
+            "feat_x": [0.1, 0.2, 0.4],
+            "feat_y": [1.0, 2.0, 4.0],
+        }
+    )
+    agg = _aggregate_fold_feature_values_to_pair_max_conc(
+        holdout_design=holdout_design,
+        rfe_features=["feat_x", "feat_y"],
+        pair_source=_mock_pair_source(),
+    )
+    assert set(agg["pair_id"]) == {"001__phageA", "002__phageA"}
+    pa = agg[agg["pair_id"] == "001__phageA"].iloc[0]
+    assert pa["feat_x"] == pytest.approx(0.2)  # max-conc row's raw value
+    assert pa["feat_y"] == pytest.approx(2.0)
+    assert pa["source"] == "guelin"
+    pb = agg[agg["pair_id"] == "002__phageA"].iloc[0]
+    assert pb["source"] == "basel"

--- a/lyzortx/tests/test_explainability_ui_build_snapshot.py
+++ b/lyzortx/tests/test_explainability_ui_build_snapshot.py
@@ -17,6 +17,7 @@ import pandas as pd
 import pytest
 
 from lyzortx.explainability_ui.build_snapshot import (
+    SHAP_PARQUET_NAMES,
     _extract_ece_from_report,
     _feature_to_slot,
     _parse_variant_name,
@@ -25,6 +26,7 @@ from lyzortx.explainability_ui.build_snapshot import (
     build_reliability_json,
     build_slot_manifest_json,
     build_summary_json,
+    copy_shap_parquets,
     write_snapshot,
 )
 
@@ -355,6 +357,36 @@ _SKIP_REASON = (
     "CH05/CH09 artifacts are gitignored; regenerate with "
     "`python -m lyzortx.pipeline.autoresearch.ch05_eval` to enable this test."
 )
+
+
+# ---- SHAP Parquet copy tests (EX04) ----
+
+
+def test_copy_shap_parquets_copies_all_six_files(tmp_path: Path) -> None:
+    """--include-shap path: happy case copies all 6 Parquet files into the output dir."""
+    shap_src = tmp_path / "shap_src"
+    shap_src.mkdir()
+    for name in SHAP_PARQUET_NAMES:
+        (shap_src / name).write_bytes(b"stub_parquet_content")
+    out = tmp_path / "out"
+    out.mkdir()
+    copied = copy_shap_parquets(shap_src, out)
+    assert len(copied) == 6
+    assert {p.name for p in copied} == set(SHAP_PARQUET_NAMES)
+    for p in copied:
+        assert p.read_bytes() == b"stub_parquet_content"
+
+
+def test_copy_shap_parquets_fails_loudly_on_partial_snapshot(tmp_path: Path) -> None:
+    """Missing one parquet (e.g. SHAP compute crashed mid-axis) must raise, not silently ship half."""
+    shap_src = tmp_path / "shap_src"
+    shap_src.mkdir()
+    for name in SHAP_PARQUET_NAMES[:3]:
+        (shap_src / name).write_bytes(b"stub")
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(FileNotFoundError, match="SHAP snapshot is incomplete"):
+        copy_shap_parquets(shap_src, out)
 
 
 @pytest.mark.skipif(

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ optuna==4.8.0
 pandas==3.0.1
 pre-commit==4.5.1
 protobuf==7.34.1
+pyarrow==21.0.0
 pylint==4.0.5
 pymarkdownlnt==0.9.36
 pyrodigal==3.7.1


### PR DESCRIPTION
## Summary

New end-to-end SHAP drill-down pipeline across the CHISEL CH05 model:

- **`lyzortx/pipeline/autoresearch/derive_shap_snapshot.py`** — replays CH05's two-axis fold loops (10 bacteria-axis cv_group folds + 10 phage-axis ICTV StratifiedKFold folds), fits LightGBM per fold × seed (3 seeds, 60 fits total), runs `shap.TreeExplainer` on each fold's held-out pairs at max concentration. SHAP matrices are seed-averaged per fold, per-pair max-conc aggregated, then written as 6 wide-form Parquet files (3 kinds × 2 axes) under `lyzortx/generated_outputs/ch05_shap/`.
- **`build_snapshot.py`** gains `--include-shap` + `--shap-dir` flags. When set, copies the 6 Parquets alongside the 7 JSONs in the UI output dir. New `copy_shap_parquets()` helper raises `FileNotFoundError` on partial snapshots (prefers loud failure to shipping half a drill-down).
- **Snapshot workflow** (`snapshot-explainability-data.yml`) gets a new `include_shap` `workflow_dispatch` input. When true, it runs `derive_shap_snapshot.py`, passes `--include-shap` to the extractor, and picks up `*.parquet` alongside `*.json` in the `gh release create` asset glob.
- **`main.js`** adds the 7th "Pair explorer" tab. DuckDB-WASM 1.29.0 is dynamically imported from jsdelivr **only on first visit to the tab** (keeps the ~10 MB WASM bundle out of the initial page load). Clicking a row in the Predictions tab routes through `drillInto(row)` → `loadShapForPair()` → DuckDB queries the three Parquets (shap / feature_values / base) over HTTP range requests → Plotly waterfall of top-20 SHAP contributions + a raw-feature-value table.

Closes #471

## Rerun result

```
$ python -m lyzortx.pipeline.autoresearch.derive_shap_snapshot --device-type cpu
derive_shap_snapshot complete in 4604.3 s  (76.7 min)
```

Artifact sizes:

| File | Rows | Size |
|---|---:|---:|
| `bacteria_axis_shap_values.parquet` | 36,643 | **31.7 MB** |
| `bacteria_axis_feature_values.parquet` | 36,643 | 0.9 MB |
| `bacteria_axis_shap_base_values.parquet` | 36,643 | 0.3 MB |
| `phage_axis_shap_values.parquet` | 36,643 | **38.2 MB** |
| `phage_axis_feature_values.parquet` | 36,643 | 1.3 MB |
| `phage_axis_shap_base_values.parquet` | 36,643 | 0.3 MB |
| **Total** | | **~72.7 MB** |

Wide-form Parquets: 325-329 RFE feature columns per axis + 4 metadata columns. Features absent from a fold's RFE selection are encoded as NaN for pairs in that fold; the UI filters NaN before building the waterfall.

**Waterfall decomposition sanity check**:
```
pair 034-008__409_P1: base=-2.0566 + sum_shap=-0.8153 = logit -2.8719  (≈5.3% predicted probability)
```

## Verification

- `pytest lyzortx/tests/test_derive_shap_snapshot.py lyzortx/tests/test_explainability_ui_build_snapshot.py` → **16 passed** (5 new: 3 SHAP aggregator + 2 Parquet-copy happy/sad paths).
- `ruff check` clean on all changed Python.
- `node --check lyzortx/explainability_ui/main.js` → clean.
- `python -m lyzortx.explainability_ui.build_snapshot --include-shap --out .scratch/ex04_verify/data` → emits 7 JSONs + 6 Parquets in 0.4 s. All files land at expected paths.
- Smoke test with `--max-folds 1 --seeds 42` completed in 291 s, validating the end-to-end fold loop before committing to the 77-min full run.

## Test plan

- [x] `derive_shap_snapshot.py` smoke test passes (`--max-folds 1`)
- [x] Full 76.7-min run produces all 6 Parquets with correct shapes
- [x] `build_snapshot.py --include-shap` copies all 6 Parquets alongside the JSONs
- [x] Waterfall decomposition verified on 1 pair: base + Σ shap = logit ≈ sigmoid → predicted_probability
- [x] 16 unit tests green; ruff + pymarkdown clean
- [x] `node --check` on main.js clean
- [ ] Manual live verification: fire `snapshot-explainability-data` workflow with `include_shap=true` → release includes Parquets → open Pair explorer tab → DuckDB-WASM initializes → click predictions row → waterfall renders (reviewer + user, post-merge)

## Design notes

- **Refit rather than persist-from-CH05**: `fit_seeds` discards the trained estimator, and changing its return tuple would ripple through six unpacking sites (CH04/CH05/CH07/CH08). Since EX04 is off-critical-path and SHAP compute is dominated by `TreeExplainer.shap_values` not refit cost, a dedicated SHAP script that repeats the fit loop is strictly simpler than modifying production. Uses the same `prepare_fold_design_matrices` / `select_rfe_features` / `build_pair_scorer` primitives, so fits are bit-identical to CH05's for the same seed.
- **Wide-form Parquet over long-form**: one row per pair, one column per feature. Long-form would be 11M rows × ~3 columns per axis (~90 MB each), wide-form compresses to ~40 MB. DuckDB-WASM `WHERE pair_id = ?` is faster on wide layout (one-row filter hit).
- **DuckDB-WASM lazy load**: the import happens inside `onTabClick` so users who never visit the Pair explorer tab never download the WASM. Subsequent pair selections reuse the same connection.
- **`pyarrow==21.0.0` pinned in `requirements.txt`**: needed for pandas Parquet write (was not previously in the repo environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7)